### PR TITLE
freebsd: improve service handling in playbook

### DIFF
--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -65,9 +65,9 @@
       tags: jenkins
 
     - name: Jenkins | Enable init script at startup
-      command: echo "jenkins_enable=YES" >> /etc/rc.conf
+      lineinfile: dest=/etc/rc.conf line="jenkins_enable=YES"
       tags: jenkins
 
     - name: Jenkins | Start service
-      command: service jenkins enable
+      command: service jenkins start
       tags: jenkins


### PR DESCRIPTION
Use lineinfile instead of echo and use the standard "start" directive instead of "enable" which isn't available everywhere.