### PR TITLE
dist: add ccache and systemd support to centos7

### DIFF
--- a/setup/centos7/ansible-playbook.yaml
+++ b/setup/centos7/ansible-playbook.yaml
@@ -29,6 +29,10 @@
       service: name=ntpd state=started enabled=yes
       tags: ntp
 
+    - name: ccache | Install ccache
+      include: ../ansible-tasks/ccache.yaml version=3.2.2
+      tags: ccache
+
     - name: General | Increase file descriptor limits
       lineinfile: dest=/etc/security/limits.conf line="{{ item }}"
       with_items:
@@ -62,15 +66,22 @@
       command: curl -sL https://jenkins-iojs.nodesource.com/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins
 
-    - name: Jenkins | Copy start.sh script
-      copy: src=./resources/start.sh dest=/home/{{ server_user }}/start.sh owner={{ server_user }} group={{ server_user }} mode=0755
+    - name: Jenkins | Copy jenkins.service systemd config
+      copy: src=./resources/jenkins.service dest=/usr/lib/systemd/system/jenkins.service mode=0644
       tags: jenkins
 
-    - name: Jenkins | Copy secrets to start.sh script
-      replace: dest=/home/{{ server_user }}/start.sh regexp="\{\{secret\}\}" replace="{{ server_secret }}"
+    - name: Jenkins | Copy server user to jenkins.service
+      replace: dest=/usr/lib/systemd/system/jenkins.service regexp="\{\{user\}\}" replace="{{ server_user }}"
       tags: jenkins
 
-    - name: Jenkins | Copy server ids to start.sh script
-      replace: dest=/home/{{ server_user }}/start.sh regexp="\{\{id\}\}" replace="{{ server_id }}"
+    - name: Jenkins | Copy secrets to jenkins.service
+      replace: dest=/usr/lib/systemd/system/jenkins.service regexp="\{\{secret\}\}" replace="{{ server_secret }}"
       tags: jenkins
 
+    - name: Jenkins | Copy server ids to jenkins.service
+      replace: dest=/usr/lib/systemd/system/jenkins.service regexp="\{\{id\}\}" replace="{{ server_id }}"
+      tags: jenkins
+      
+    - name: Jenkins | Start service
+      service: name=jenkins state=started
+      tags: jenkins

--- a/setup/centos7/ansible-vars.yaml
+++ b/setup/centos7/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - ryanstevens
+  - jbergstroem
 packages:
   - java-1.7.0-openjdk
   - git

--- a/setup/centos7/resources/jenkins.service
+++ b/setup/centos7/resources/jenkins.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Jenkins Slave
+Wants=network.target
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+User={{user}}
+Environment="USER={{user}}" \
+            "SHELL=/bin/bash" \
+            "HOME=/home/{{user}}" \
+            "PATH=/usr/local/bin:/usr/bin" \
+            "NODE_COMMON_PIPE=/home/{{user}}/test.pipe" \
+            "OSTYPE=linux-gnu"
+ExecStart=/usr/bin/java \
+          -jar /home/{{user}}/slave.jar \
+          -jnlpUrl https://jenkins-iojs.nodesource.com/computer/iojs-digitalocean-centos7-64-{{id}}/slave-agent.jnlp \
+          -secret {{secret}}
+Restart=always
+RestartSec=30
+StartLimitInterval=0


### PR DESCRIPTION
This also introduces a minor change to the init script so that it starts on boot (the [Install] section).