### PR TITLE
win: download Git from git-for-windows releases

### DIFF
--- a/setup/windows/README.md
+++ b/setup/windows/README.md
@@ -23,7 +23,7 @@ For io.js & libuv Jenkins setup, on a fresh server:
   - Find `Path` under "System variables" -> "Edit"
   - Append `;C:\Python27\;C:\Program Files (x86)\Java\jre1.8.0_25\bin` (adjust Java location appropriately) to the end of the "Variable value"
   - OK, OK, OK
-1. Install **Git** from http://git-scm.com/download/win
+1. Install **Git** from https://github.com/git-for-windows/git/releases
   - Default options except _"Use Git and optional Unix tools from the Windows Command Prompt"_ (they are used in tests)
 1. Clone **GYP**
   - Start -> "cmd"


### PR DESCRIPTION
As described in detail in #142, old versions of Git for windows crash when running `git rebase`. The `git-for-windows/git` repository contains pre-releases of newer versions that work correctly.

The three Windows 2012r2 machines have already been updated.
