### PR TITLE
ubuntu: add git-core PPA to 12.04

### DIFF
--- a/setup/ubuntu12.04/ansible-playbook.yaml
+++ b/setup/ubuntu12.04/ansible-playbook.yaml
@@ -8,6 +8,10 @@
     - include_vars: ansible-vars.yaml
       tags: vars
 
+    - name: General | Install updated git PPA
+      apt_repository: repo='ppa:git-core/ppa'
+      tags: general
+
     - name: General | APT Update
       apt: update_cache=yes
       tags: general


### PR DESCRIPTION
The version of git shipped with Ubuntu 12.04 is old, it cannot fetch from GitHub refs that were updated. This is an issue with Jenkins, since the test-commit job uses a reference that was updated by the push-merge-commit job.

/cc @nodejs/build 