### PR TITLE
fedora22: Add `which`

### DIFF
--- a/setup/fedora22/ansible-vars.yaml
+++ b/setup/fedora22/ansible-vars.yaml
@@ -14,3 +14,4 @@ packages:
   - libtool
   - ntp
   - ccache
+  - which


### PR DESCRIPTION
Our build scripts uses `which` that is missing from the default fedora22 distribution.

Fixes/refs: https://github.com/nodejs/build/issues/145

/cc @targos