### PR TITLE
Add joaocgreis to the ssh_users list in Jenkins slaves

### DIFF
--- a/setup/centos5/ansible-vars.yaml
+++ b/setup/centos5/ansible-vars.yaml
@@ -5,6 +5,7 @@ ssh_users:
   - wblankenship
   - ryanstevens
   - jbergstroem
+  - joaocgreis
 packages:
   - git
   - java-1.7.0-openjdk

--- a/setup/centos6/ansible-vars.yaml
+++ b/setup/centos6/ansible-vars.yaml
@@ -5,6 +5,7 @@ ssh_users:
   - wblankenship
   - ryanstevens
   - jbergstroem
+  - joaocgreis
 packages:
   - git
   - java-1.8.0-openjdk

--- a/setup/centos7/ansible-vars.yaml
+++ b/setup/centos7/ansible-vars.yaml
@@ -5,6 +5,7 @@ ssh_users:
   - wblankenship
   - ryanstevens
   - jbergstroem
+  - joaocgreis
 packages:
   - java-1.7.0-openjdk
   - git

--- a/setup/containers/ansible-vars.yaml
+++ b/setup/containers/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - ghostbar
+  - joaocgreis
 packages:
   - nodejs
   - openjdk-7-jre

--- a/setup/debian8/ansible-vars.yaml
+++ b/setup/debian8/ansible-vars.yaml
@@ -5,6 +5,7 @@ ssh_users:
   - wblankenship
   - jbergstroem
   - kenperkins
+  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/fedora21/ansible-vars.yaml
+++ b/setup/fedora21/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - jbergstroem
+  - joaocgreis
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/fedora22/ansible-vars.yaml
+++ b/setup/fedora22/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - jbergstroem
+  - joaocgreis
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/linter/ansible-vars.yaml
+++ b/setup/linter/ansible-vars.yaml
@@ -4,6 +4,7 @@ init_script_path: /usr/local/etc/rc.d/jenkins
 ssh_users:
   - rvagg
   - jbergstroem
+  - joaocgreis
 packages:
   - openjdk
   - git

--- a/setup/smartos/ansible-vars.yaml
+++ b/setup/smartos/ansible-vars.yaml
@@ -7,6 +7,7 @@ ssh_users:
   - geek
   - rvagg
   - jbergstroem
+  - joaocgreis
 packages:
   - openjdk7
   - git

--- a/setup/ubuntu12.04/ansible-vars.yaml
+++ b/setup/ubuntu12.04/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - ryanstevens
+  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/ubuntu14.04/ansible-vars.yaml
+++ b/setup/ubuntu14.04/ansible-vars.yaml
@@ -5,6 +5,7 @@ ssh_users:
   - wblankenship
   - ryanstevens
   - mhdawson
+  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/ubuntu14.10/ansible-vars.yaml
+++ b/setup/ubuntu14.10/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - ryanstevens
+  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/ubuntu15.04/ansible-vars.yaml
+++ b/setup/ubuntu15.04/ansible-vars.yaml
@@ -4,6 +4,7 @@ ssh_users:
   - rvagg
   - wblankenship
   - jbergstroem
+  - joaocgreis
 packages:
   - openjdk-8-jre
   - git


### PR DESCRIPTION
I added myself to the `ssh_users` list in almost all Jenkins slaves.

Left out `armv7-wheezy`, `freebsd` and `raspberry-pi` because they are not listed in Digital Ocean or Rackspace and I don't have their IPs. Should I include them anyway?

I already have access to all machines but `debian8`.

cc @nodejs/build 