### PR TITLE
smartos: use Google DNS servers

### DIFF
--- a/setup/smartos/ansible-playbook.yaml
+++ b/setup/smartos/ansible-playbook.yaml
@@ -20,6 +20,15 @@
       with_items: packages
       tags: general
 
+    - name: Remove all DNS servers from resolv.conf
+      lineinfile: dest=/etc/resolv.conf state=absent regexp="^(\s*)nameserver(\s+)"
+      tags: general
+
+    - name: Add DNS servers to the list in resolv.conf
+      lineinfile: dest=/etc/resolv.conf state=present regexp="^(\s*)nameserver(\s+){{ item }}(\s*)$" line="nameserver {{ item }}"
+      with_items: dns_servers
+      tags: general
+
     - name: User | Add {{ server_user }} group
       command: groupadd {{ server_user }}
       tags: user

--- a/setup/smartos/ansible-vars.yaml
+++ b/setup/smartos/ansible-vars.yaml
@@ -18,3 +18,6 @@ packages:
   - automake
   - libtool
   - ccache
+dns_servers:
+  - 8.8.8.8
+  - 8.8.4.4


### PR DESCRIPTION
As seen recently in https://github.com/joyent/node/issues/25858 , DNS configuration is sensitive for the tests. The test machines should be configured to use Google DNS servers, and using other servers may cause tests to fail, as discussed in https://github.com/joyent/node/issues/8056 .

I changed the DNS configuration in the SmartOS slaves by editing `/etc/resolv.conf`. This PR makes this change permanent by adding it to the ansible playbook.

Fixes: https://github.com/joyent/node/issues/25858
Fixes: #155