### PR TITLE
added libcurl4-openssl-dev to git compile for https:// URLs

### DIFF
--- a/setup/raspberry-pi/ansible-playbook.yaml
+++ b/setup/raspberry-pi/ansible-playbook.yaml
@@ -80,14 +80,19 @@
       tags: jenkins
 
     - name: git | Install required packages for git compile
-      apt: name=gettext update_cache=yes state=latest
+      apt: name={{ item }} update_cache=yes state=latest
+      with_items:
+        - gettext
+        - libcurl4-openssl-dev
       tags: git
 
     - name: git | Download, compile and install git 2.5
-      shell: curl https://www.kernel.org/pub/software/scm/git/git-2.5.0.tar.xz -O && \
+      shell: rm -rf git-2.5.0* && \
+        curl https://www.kernel.org/pub/software/scm/git/git-2.5.0.tar.xz -O && \
         tar -xvf git-2.5.0.tar.xz && \
         cd git-2.5.0/ && \
         ./configure --prefix=/usr --with-gitconfig=/etc/gitconfig && \
         make && \
-        sudo make install
+        sudo make install && \
+        rm -rf git-2.5.0*
       tags: git


### PR DESCRIPTION
This is nearly complete on all of the Pi's in the cluster so they should be able to handle `https://` git urls

e.g https://jenkins-iojs.nodesource.com/job/node-test-commit-arm/265/nodes=pi1-raspbian-wheezy/console & https://jenkins-iojs.nodesource.com/job/node-test-commit-arm/265/nodes=pi2-raspbian-wheezy/console for https://github.com/nodejs/node/pull/2482