### PR TITLE
Raspbian ccache upgrade

### DIFF
--- a/setup/raspberry-pi/ansible-playbook.yaml
+++ b/setup/raspberry-pi/ansible-playbook.yaml
@@ -94,6 +94,11 @@
         ./configure --prefix=/usr --with-gitconfig=/etc/gitconfig && \
         make && \
         sudo make install && \
+        sudo mkdir -p /usr/lib/ccache && \
+        sudo ln -sf $(which gcc) /usr/lib/ccache/gcc && \
+        sudo ln -sf $(which cc) /usr/lib/ccache/cc && \
+        sudo ln -sf $(which g++) /usr/lib/ccache/g++ && \
+        sudo ln -sf $(which c++) /usr/lib/ccache/c++ && \
         rm -rf git-2.5.0*
       tags: git
 

--- a/setup/raspberry-pi/ansible-playbook.yaml
+++ b/setup/raspberry-pi/ansible-playbook.yaml
@@ -96,3 +96,14 @@
         sudo make install && \
         rm -rf git-2.5.0*
       tags: git
+
+    - name: git | Download, compile and install ccache 3.2
+      shell: rm -rf ccache-3.2.3 && \
+        curl -sL http://samba.org/ftp/ccache/ccache-3.2.3.tar.xz | tar -Jxv && \
+        cd ccache-3.2.3/ && \
+        ./configure --prefix=/usr --sysconfdir=/etc -q && \
+        make && \
+        sudo apt-get remove ccache -y && \
+        sudo make install && \
+        rm -rf ccache-3.2.3
+      tags: git

--- a/setup/raspberry-pi/ansible-vars.yaml
+++ b/setup/raspberry-pi/ansible-vars.yaml
@@ -13,4 +13,3 @@ packages:
   - curl
   - gcc-4.8
   - g++-4.8
-  - ccache


### PR DESCRIPTION
Grabbing ccache 3.2 from source, compiling and installing it on the raspberry pi machines

Also, I've changed the ccache config for all of these to be:

```
max_size = 10.7G
sloppiness = file_macro,include_file_ctime,include_file_mtime,pch_defines,time_macros
temporary_dir = /tmp
umask = 002
```

It did just have `max_size` previously but I'm tinkering with other options to speed things up.

Please review @orangemocha, @jbergstroem et. al. This is set on the RPi machines as of right now if you want to test it out and get some numbers.