### PR TITLE
Update nodejs.org

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -14,7 +14,7 @@ log_format nodejs    '$remote_addr - $remote_user [$time_local] '
 server {
     listen 80 default_server;
     listen [::]:80;
-    server_name www.nodejs.org nodejs.org;
+    server_name nodejs.org www.nodejs.org;
 
     access_log /var/log/nginx/nodejs.org-access.log nodejs;
     error_log /var/log/nginx/nodejs.org-error.log;


### PR DESCRIPTION
So looking at this a little more it turns out 443 request works  
https://www.nodejs.org successfully rewrites to https://nodejs.org but http://www.nodejs.org does not. 
Looking at line 150 I see the order of the server_name is different than line 17
Totally guessing as I can't test but this seems a reasonable try