### PR TITLE
setup: add monit to ansible-tasks

### DIFF
--- a/setup/ansible-tasks/monit.yaml
+++ b/setup/ansible-tasks/monit.yaml
@@ -1,0 +1,23 @@
+---
+# Installs and configures monit for Debian based systems.
+# @requires: monit_conf_file=../ansible-tasks/resources/monit-jenkins.conf
+
+- name: Monit | Install deb package
+  apt: name=monit update_cache=yes state=latest
+  tags: monit
+
+- name: Monit | Set the cycle length to 15 seconds
+  lineinfile: dest=/etc/monit/monitrc state=present regexp="^(\s*)set(\s+)daemon" line="set daemon 15"
+  tags: monit
+
+- name: Monit | Copy monit config
+  copy: src={{ monit_conf_file }} dest=/etc/monit/conf.d/jenkins owner=root group=root mode=0644
+  tags: monit
+
+- name: Monit | Copy server user name to monit config
+  replace: dest=/etc/monit/conf.d/jenkins regexp="\{\{server_user\}\}" replace="{{ server_user }}"
+  tags: monit
+
+- name: Monit | Restart service
+  service: name=monit state=restarted
+  tags: monit

--- a/setup/ansible-tasks/resources/monit-jenkins.conf
+++ b/setup/ansible-tasks/resources/monit-jenkins.conf
@@ -1,0 +1,4 @@
+check process jenkins
+  matching slave.jar
+  start program = "/bin/su {{server_user}} -c 'cd /home/{{server_user}} && /home/{{server_user}}/start.sh'"
+  stop program = "/bin/su {{server_user}} -c 'pkill -f slave.jar'"


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/pull/187#issuecomment-137994003

Also changed the cycle to 15 seconds (was 2 minutes).

I don't like the way the conf file is found, but didn't find a better one. Suggestions?

@jbergstroem 

> (re suggestion above) Config probably needs to live elsewhere though since some machines are into init scripts. Also, newer upstarts and systemd afaik handles restarting/keepalive for you.

For now this is only apt-get, but we could generalize. Should not be a problem on current machines.
