### PR TITLE
Add testing for nodejs.org

### DIFF
--- a/tools/nodejs.org-test/.editorconfig
+++ b/tools/nodejs.org-test/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[package.json]
+indent_style = space
+indent_size = 2

--- a/tools/nodejs.org-test/.eslintrc
+++ b/tools/nodejs.org-test/.eslintrc
@@ -1,0 +1,24 @@
+{
+  "parser": "babel-eslint",
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+    "complexity": [1, 8],
+    "consistent-return": 0,
+    "eol-last": 1,
+    "key-spacing": 0,
+    "max-depth": [1, 2],
+    "max-nested-callbacks": [2, 3],
+    "max-params": [1, 4],
+    "new-cap": 0,
+    "no-multi-spaces": 0,
+    "no-shadow": 0,
+    "no-trailing-spaces": 1,
+    "no-underscore-dangle": 0,
+    "no-use-before-define": 0,
+    "quotes": [1, "single"],
+    "space-before-function-paren": [1, "always"]
+  }
+}

--- a/tools/nodejs.org-test/index.js
+++ b/tools/nodejs.org-test/index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert');
+const test = require('./lib/test.js');
+const redirects = require('./redirects.js');
+
+
+describe('nodejs.org', function () {
+
+    it('should have an English homepage', function (done) {
+
+        test.url('https://nodejs.org/en/', function (status) {
+
+            assert.equal(status, 200);
+            done();
+        });
+    });
+
+    redirects.main['301'].forEach(test.redirect(301));
+    redirects.main['302'].forEach(test.redirect(302));
+});
+
+
+describe('blog.nodejs.org', function () {
+
+    redirects.blog['301'].forEach(test.redirect(301));
+    redirects.blog['302'].forEach(test.redirect(302));
+});
+
+// describe('doc(s).nodejs.org');
+// describe('dist.nodejs.org');

--- a/tools/nodejs.org-test/index.js
+++ b/tools/nodejs.org-test/index.js
@@ -28,4 +28,53 @@ describe('blog.nodejs.org', function () {
 });
 
 // describe('doc(s).nodejs.org');
-// describe('dist.nodejs.org');
+describe('dist.nodejs.org', function () {
+
+    let nodeVersions;
+
+    before(function (done) {
+
+        test.download('https://nodejs.org/dist/index.json', function (err, versions) {
+            if (err) { return done(err); }
+            nodeVersions = versions;
+            done();
+        });
+    });
+
+
+    it('https://nodejs.org/dist/latest/ should contain the latest release', function (done) {
+
+        test.url(`https://nodejs.org/dist/latest/node-${nodeVersions[0].version}.tar.gz`, function (status) {
+
+            assert.equal(status, 200);
+            done();
+        });
+
+    });
+
+
+    it('https://nodejs.org/dist/latest/latest-v0.10.x/ should contain the latest v0.10 release', function (done) {
+
+        let latestVersion = test.getLatestRelease(nodeVersions, '^0.10');
+
+        test.url(`https://nodejs.org/dist/latest-v0.10.x/node-${latestVersion}.tar.gz`, function (status) {
+
+            assert.equal(status, 200);
+            done();
+        });
+
+    });
+
+
+    it('https://nodejs.org/dist/latest/latest-v0.12.x/ should contain the latest v0.12 release', function (done) {
+
+        let latestVersion = test.getLatestRelease(nodeVersions, '^0.12');
+
+        test.url(`https://nodejs.org/dist/latest-v0.12.x/node-${latestVersion}.tar.gz`, function (status) {
+
+            assert.equal(status, 200);
+            done();
+        });
+
+    });
+});

--- a/tools/nodejs.org-test/lib/test.js
+++ b/tools/nodejs.org-test/lib/test.js
@@ -5,6 +5,7 @@ const http = require('http');
 const https = require('https');
 const assert = require('assert');
 const merge = require('lodash.merge');
+const semver = require('semver');
 
 
 const testUrl = module.exports.url = function (requestUrl, callback) {
@@ -41,4 +42,35 @@ module.exports.redirect = function (expectedStatus) {
 
         });
     };
+};
+
+
+module.exports.download = function (url, cb) {
+
+    let data = '';
+    https
+        .get(url, function (res) {
+
+            res.on('data', function (chunk) { data += chunk; });
+            res.on('end', function () {
+
+                try {
+                    cb(null, JSON.parse(data));
+                } catch (e) {
+                    return cb(e);
+                }
+            });
+        })
+        .on('error', function (e) { cb(e); });
+};
+
+
+module.exports.getLatestRelease = function (releases, range) {
+
+    const versions = releases.map(function (release) {
+
+        return release.version;
+    });
+
+    return semver.maxSatisfying(versions, range);
 };

--- a/tools/nodejs.org-test/package.json
+++ b/tools/nodejs.org-test/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "lodash.merge": "^3.3.2",
-    "mocha": "^2.3.2"
+    "mocha": "^2.3.2",
+    "semver": "^5.0.1"
   }
 }

--- a/tools/nodejs.org-test/package.json
+++ b/tools/nodejs.org-test/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "nodejs.org-test",
+  "description": "Tests for nodejs.org",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "mocha index.js"
+  },
+  "dependencies": {
+    "lodash.merge": "^3.3.2",
+    "mocha": "^2.3.2"
+  }
+}

--- a/tools/nodejs.org-test/redirects.js
+++ b/tools/nodejs.org-test/redirects.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+    main: {
+        301: [
+            { src: 'http://nodejs.org/', dest: 'https://nodejs.org/' }
+        ],
+        302: [
+            { src: 'https://nodejs.org/', dest: 'https://nodejs.org/en/' }
+        ]
+    },
+    'blog': {
+        301: [
+            { src: 'http://blog.nodejs.org/', dest: 'https://nodejs.org/en/blog/' }
+        ],
+        302: [
+            { src: 'https://blog.nodejs.org/', dest: 'https://nodejs.org/en/blog/' }
+        ]
+    },
+    dist: {},
+    docs: {}
+};


### PR DESCRIPTION
First idea for implementing #191, a mocha test-suite issuing HEAD requests.
- [x] http/https links to dist tarballs
- [ ] http/https links to old windows x32/x64 builds
- [ ] http/https links to new windows x32/x64 builds (different file name/directory)
- [x] http/https links to dist/latest/, dist/latest-v0.10.x/, dist/latest-v0.12.x/
- [ ] http/https links to previous versions of the api docs
- [ ] http/https links for [subdomain].nodejs.org

One redirect test deliberately failing: https://blog.nodejs.org/ redirects to http://blog.nodejs.org/ (which redirects again) instead of redirecting directly to https://nodejs.org/en/blog/.
