### PR TITLE
build: Add ubuntu14 benchmarking machine

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -32,6 +32,7 @@ iojs-build-ubuntu1410-64-1
 iojs-build-ubuntu1404-64-1
 iojs-build-ubuntu1404-32-1
 iojs-ibm-ppcle-ubuntu1404-64-1
+iojs-softlayer-benchmark
 
 [iojs-build-ubuntu1204]
 iojs-build-ubuntu1204-64-1

--- a/setup/ubuntu14.04/resources/start.sh
+++ b/setup/ubuntu14.04/resources/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 rm -f nohup.out
-PATH=/usr/lib/ccache/:$PATH NODE_COMMON_PIPE=/home/iojs/test.pipe OSTYPE=linux-gnu nohup java -jar slave.jar -jnlpUrl https://jenkins-iojs.nodesource.com/computer/iojs-digitalocean-ubuntu1404-{{id}}/slave-agent.jnlp -secret {{secret}} &
-PATH=/usr/lib/ccache/:$PATH OSTYPE=linux-gnu-gyp nohup java -jar slave.jar -jnlpUrl https://jenkins-iojs.nodesource.com/computer/iojs-digitalocean-ubuntu1404-{{gyp_id}}/slave-agent.jnlp -secret {{gyp_secret}} &
+PATH=/usr/lib/ccache/:$PATH NODE_COMMON_PIPE=/home/iojs/test.pipe OSTYPE=linux-gnu nohup java -jar slave.jar -jnlpUrl https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp -secret {{secret}} &
+PATH=/usr/lib/ccache/:$PATH OSTYPE=linux-gnu-gyp nohup java -jar slave.jar -jnlpUrl https://ci.nodejs.org/computer/{{gyp_id}}/slave-agent.jnlp -secret {{gyp_secret}} &


### PR DESCRIPTION
Add iojs-softlayer-benchark to the inventory
Update template for start script so that it points
to the right CI and does not assume a fixed naming of the
machines