### PR TITLE
add lts field and support older versions in index.*

### DIFF
--- a/setup/www/tools/dist-indexer/dist-indexer.js
+++ b/setup/www/tools/dist-indexer/dist-indexer.js
@@ -354,7 +354,7 @@ function inspectDir (dir, callback) {
     , date
 
   if (!gitref) {
-    return fs.stat(dir, function (err, stat) {
+    return fs.stat(path.join(argv.dist, dir), function (err, stat) {
       if (err)
         return callback(err)
       if (stat.isDirectory() && !(/^(latest|npm$|patch$|v0\.10\.16-isaacs-manual$)/).test(dir))


### PR DESCRIPTION
See https://nodejs.org/download/release/index.json and https://nodejs.org/download/release/index.tab for the output of these changes. The "lts" field is "Argon" for `^0.4.2` and otherwise `"-"` in index.tab and `false` in index.json.

I'm not doing anything other than the LTS name, #217 suggests adding "stable", "lts" and "maintenance" and currently I don't see a need for this, nor is there easy logic to fetch this full information from the repos.

I've also added SHASUMS256.txt (tho not a signed version) and therefore support for the index.* files for all of the older directories, back to v0.5.1. @ljharb may be interested in this.