### PR TITLE
freebsd: improve init resiliency and jenkins environment

### DIFF
--- a/setup/ansible-includes/global-vars.yaml
+++ b/setup/ansible-includes/global-vars.yaml
@@ -1,0 +1,5 @@
+----
+# Varibles we use globally
+# Avoid pollution at all costs :)
+jenkins_user: iojs
+jenkins_base_url: https://ci.nodejs.org/

--- a/setup/ansible-includes/global-vars.yaml
+++ b/setup/ansible-includes/global-vars.yaml
@@ -1,4 +1,4 @@
-----
+---
 # Varibles we use globally
 # Avoid pollution at all costs :)
 jenkins_user: iojs

--- a/setup/freebsd/README.md
+++ b/setup/freebsd/README.md
@@ -1,6 +1,12 @@
 # io.js Build FreeBSD Setup
 
-The current FreeBSD lives at Digitalocean.
+The current FreeBSD VMs lives at Digitalocean.
+
+You have to install `python` before running ansible. Log in to the VM
+and run the following:
+```
+sudo pkg update && sudo pkg install -y python
+```
 
 To set up hosts, make sure you add them to your ssh config first:
 ```
@@ -13,14 +19,12 @@ Host test-digitalocean-freebsd10-x64-2
   User freebsd
 ```
 
-Note that these hostnames are also used in the ansible-inventory file. The IP addresses will need to be updated each time the servers are reprovisioned.
+Note that these hostnames are also used in the ansible-inventory file.
+The IP addresses will need to be updated each time
+the servers are reprovisioned.
 
 To set up a host, run:
 
 ```text
 $ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
 ```
-
-**Users**: The ansible-vars.yaml file contains a list of users who's GitHub public keys are pulled and placed into
-authorized_keys for both root and iojs users. This file should be updates when new users are added to the build project
-who are able to help maintain the containerized builds.

--- a/setup/freebsd/README.md
+++ b/setup/freebsd/README.md
@@ -28,3 +28,7 @@ To set up a host, run:
 ```text
 $ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
 ```
+
+If you have to update settings related to how jenkins is deployed,
+the configuration lives in `/usr/local/etc/rc.conf.d/jenkins`.
+

--- a/setup/freebsd/README.md
+++ b/setup/freebsd/README.md
@@ -2,12 +2,6 @@
 
 The current FreeBSD VMs lives at Digitalocean.
 
-You have to install `python` before running ansible. Log in to the VM
-and run the following:
-```
-sudo pkg update && sudo pkg install -y python
-```
-
 To set up hosts, make sure you add them to your ssh config first:
 ```
 Host test-digitalocean-freebsd10-x64-1

--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -1,4 +1,4 @@
----
+----
 - hosts: iojs-freebsd10
 
   remote_user: freebsd
@@ -17,7 +17,7 @@
       tags: general
 
     - name: General | Install required packages
-      command: pkg install -U -y  {{ item }}
+      command: pkg install -U -y {{ item }}
       with_items: packages
       tags: general
 
@@ -49,22 +49,36 @@
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins
 
-    - name: Jenkins | Copy init script
-      copy: src=./resources/jenkins dest={{ init_script_path }} owner={{ server_user }} group={{ server_user }} mode=0755
-      tags: jenkins
+    - name: Assures that {{ init_base }}/{rc.d, rc.conf.d} directories exists
+      file: path={{ init_base }}/{{ item }} state=directory
+      with_items:
+        - rc.d
+        - rc.conf.d
+      tags: init
 
-    - name: Jenkins | Copy secret into init script
-      replace: dest={{ init_script_path }} regexp="\{\{secret\}\}" replace="{{ server_secret }}"
-      tags: jenkins
+    - name: Init | Copy init script
+      copy: src=./resources/jenkins dest={{ init_base }}/rc.d/jenkins owner={{ server_user }} group={{ server_user }} mode=0755
+      tags: init
 
-    - name: Jenkins | Copy server id into init script
-      replace: dest={{ init_script_path }} regexp="\{\{id\}\}" replace="{{ server_id }}"
-      tags: jenkins
+    - name: Init | Copy config template
+      copy: src=./resources/jenkins.conf dest={{ init_base }}/rc.conf.d/jenkins owner={{ server_user }} group={{ server_user }} mode=0600
+      tags: init
 
-    - name: Jenkins | Enable init script at startup
-      lineinfile: dest=/etc/rc.conf line="jenkins_enable=YES"
-      tags: jenkins
+    - name: Init | Copy secret to config`
+      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{secret\}\}" replace="{{ server_secret }}"
+      tags: init
 
-    - name: Jenkins | Start service
-      command: service jenkins start
-      tags: jenkins
+    - name: Init | Copy user/group to config`
+      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{{{item}}\}\}" replace="{{ server_user }}"
+      with_items:
+        - user
+        - group
+      tags: init
+
+    - name: Init | Copy id to config
+      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{id\}\}" replace="{{ inventory_hostname }}"
+      tags: init
+
+    - name: Init | Add to boot and start service
+      service: name=jenkins state=started enabled=yes
+      tags: init

--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -1,32 +1,36 @@
 ----
 - hosts: iojs-freebsd10
-
+  gather_facts: no
   remote_user: freebsd
   sudo: yes
+
+  vars_files:
+    - ../ansible-includes/global-vars.yaml
+    - ansible-vars.yaml
 
   vars:
     - ansible_python_interpreter: "/usr/bin/env python"
 
   tasks:
-
-    - include_vars: ansible-vars.yaml
-      tags: vars
-
-    - name: General | Update package repository
-      command: pkg update
-      tags: general
+    - name: Bootstrap | Install python
+      raw: pkg install -y python
+      tags: bootstrap
 
     - name: General | Install required packages
-      command: pkg install -U -y {{ item }}
+      command: pkg install -y {{ item }}
       with_items: packages
       tags: general
 
-    - name: User | Add {{ server_user }} group
-      group: name="{{ server_user }}" state=present
+    - name: General | Start ntpd (and enable at boot)
+      service: name=ntpd state=started enabled=yes
+      tags: general
+
+    - name: User | Add group
+      group: name="{{ jenkins_user }}" state=present
       tags: user
 
-    - name: User | Add {{ server_user }} user
-      user: name="{{ server_user }}" shell=/bin/sh append=yes groups={{ server_user }}
+    - name: User | Add user
+      user: name="{{ jenkins_user }}" shell=/bin/sh createhome=yes append=yes groups={{ jenkins_user }}
       tags: user
 
     - name: User | Download pubkey(s)
@@ -40,16 +44,16 @@
       with_items: ssh_users
       tags: user
 
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
+    - name: General | Create authorized_keys for user
+      authorized_key: user="{{ jenkins_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
       with_items: ssh_users
       tags: user
 
-    - name: Jenkins | Download Jenkins' slave.jar
-      command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
+    - name: Jenkins | Download Jenkins slave.jar
+      get_url: url={{ jenkins_base_url }}/jnlpJars/slave.jar dest=/home/{{ jenkins_user }}/slave.jar
       tags: jenkins
 
-    - name: Assures that {{ init_base }}/{rc.d, rc.conf.d} directories exists
+    - name: Init | Assure that {rc.d, rc.conf.d} directories exists
       file: path={{ init_base }}/{{ item }} state=directory
       with_items:
         - rc.d
@@ -57,26 +61,11 @@
       tags: init
 
     - name: Init | Copy init script
-      copy: src=./resources/jenkins dest={{ init_base }}/rc.d/jenkins owner={{ server_user }} group={{ server_user }} mode=0755
+      copy: src=./resources/jenkins dest={{ init_base }}/rc.d/jenkins mode=0755
       tags: init
 
-    - name: Init | Copy config template
-      copy: src=./resources/jenkins.conf dest={{ init_base }}/rc.conf.d/jenkins owner={{ server_user }} group={{ server_user }} mode=0600
-      tags: init
-
-    - name: Init | Copy secret to config`
-      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{secret\}\}" replace="{{ server_secret }}"
-      tags: init
-
-    - name: Init | Copy user/group to config`
-      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{{{item}}\}\}" replace="{{ server_user }}"
-      with_items:
-        - user
-        - group
-      tags: init
-
-    - name: Init | Copy id to config
-      replace: dest={{ init_base }}/rc.conf.d/jenkins regexp="\{\{id\}\}" replace="{{ inventory_hostname }}"
+    - name: Init | Generate config
+      template: src=./resources/jenkins.conf.j2 dest={{ init_base }}/rc.conf.d/jenkins
       tags: init
 
     - name: Init | Add to boot and start service

--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -1,4 +1,4 @@
-----
+---
 - hosts: iojs-freebsd10
   gather_facts: no
   remote_user: freebsd

--- a/setup/freebsd/ansible-vars.yaml
+++ b/setup/freebsd/ansible-vars.yaml
@@ -1,12 +1,11 @@
 ---
-server_user: iojs
 init_base: /usr/local/etc/
 ssh_users:
   - rvagg
   - jbergstroem
   - joaocgreis
 packages:
-  - openjdk
+  - openjdk-jre
   - git
   - gmake
   - ccache

--- a/setup/freebsd/ansible-vars.yaml
+++ b/setup/freebsd/ansible-vars.yaml
@@ -10,3 +10,4 @@ packages:
   - git
   - gmake
   - ccache
+  - bash

--- a/setup/freebsd/ansible-vars.yaml
+++ b/setup/freebsd/ansible-vars.yaml
@@ -1,11 +1,12 @@
 ---
 server_user: iojs
-init_script_path: /usr/local/etc/rc.d/jenkins
+init_base: /usr/local/etc/
 ssh_users:
   - rvagg
   - jbergstroem
+  - joaocgreis
 packages:
-  - openjdk-jre
+  - openjdk
   - git
   - gmake
   - ccache

--- a/setup/freebsd/resources/jenkins
+++ b/setup/freebsd/resources/jenkins
@@ -1,13 +1,9 @@
 #!/bin/sh
 
-# $FreeBSD: $
 #
-# Based on the jenkins init script
-#
-# PROVIDE: jenkins-iojs
+# PROVIDE: jenkins
 # REQUIRE: LOGIN
 # KEYWORD: shutdown
-
 #
 # Configuration settings for jenkins in /etc/rc.conf:
 #
@@ -21,31 +17,32 @@
 name="jenkins"
 rcvar=jenkins_enable
 
-load_rc_config "${name}"
+load_rc_config ${name}
 
-
-OSTYPE="freebsd"
-NODE_COMMON_PIPE="/home/iojs/test.pipe"
 PATH="/usr/local/libexec/ccache:/usr/local/bin:${PATH}"
+NODE_COMMON_PIPE="/home/iojs/test.pipe"
 
-jenkins_jnlpurl="https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp"
-jenkins_secret="{{secret}}"
 jenkins_jar="/home/iojs/slave.jar"
-jenkins_log_file="/home/iojs/jenkins_console.log"
-jenkins_args="-jnlpUrl ${jenkins_jnlpurl} -secret ${jenkins_secret}"
-jenkins_user="iojs"
-jenkins_group="iojs"
+jenkins_log_file="/home/${jenkins_user}/${name}_console.log"
+jenkins_args="-jar ${jenkins_jar} \
+	-jnlpUrl ${jenkins_jnlpurl} \
+	-secret ${jenkins_secret}"
 jenkins_jobs="$(getconf NPROCESSORS_ONLN)"
 
-pidfile="/var/run/jenkins/jenkins.pid"
+# FreeBSD uses a java wrapper. Without full path pid monitoring won't work
+procname=`cat /usr/local/etc/javavms | cut -d "#" -f 1`
+pidfile="/var/run/${name}/${name}.pid"
+monitor_pidfile="/var/run/${name}/${name}_monitor.pid"
 command="/usr/sbin/daemon"
-procname="/usr/local/openjdk7-jre/bin/java"
-command_args="-r -p ${pidfile} ${procname} -jar ${jenkins_jar} ${jenkins_args} > ${jenkins_log_file} 2>&1"
-env="PATH=${PATH} JOBS=${jenkins_jobs} OSTYPE=${OSTYPE} NODE_COMMON_PIPE=${NODE_COMMON_PIPE} CC=cc CXX=c++"
+command_args="-r -p ${pidfile} -P ${monitor_pidfile} ${procname} \
+	${jenkins_args} > ${jenkins_log_file} 2>&1"
+env="PATH=${PATH} JOBS=${jenkins_jobs} OSTYPE=${OSTYPE} \
+	NODE_COMMON_PIPE=${NODE_COMMON_PIPE} CC=cc CXX=c++"
 required_files="${procname} ${jenkins_jar}"
 
-start_precmd="jenkins_prestart"
-start_cmd="jenkins_start"
+start_precmd="${name}_prestart"
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
 
 jenkins_prestart() {
 	if [ ! -f "${jenkins_log_file}" ]; then
@@ -53,8 +50,9 @@ jenkins_prestart() {
 		chown "${jenkins_user}:${jenkins_group}" "${jenkins_log_file}"
 		chmod 640 "${jenkins_log_file}"
 	fi
-	if [ ! -d "/var/run/jenkins" ]; then
-		install -d -o "${jenkins_user}" -g "${jenkins_group}" -m 750 "/var/run/jenkins"
+	if [ ! -d `basename ${pidfile}` ]; then
+		install -d -o "${jenkins_user}" -g "${jenkins_group}" \
+			-m 750 `basename ${pidfile}`
 	fi
 
 	if [ ! $jenkins_secret ]; then
@@ -64,8 +62,21 @@ jenkins_prestart() {
 
 jenkins_start()
 {
-	check_startmsgs && echo "Starting ${name}."
+	check_startmsgs && echo -n "Starting ${name}"
 	su -l ${jenkins_user} -c "${env} exec ${command} ${command_args}"
+	echo .
+}
+
+jenkins_stop()
+{
+	if [ ! -f ${pidfile} ]; then
+		echo "${name} isn't running."
+	else
+		echo -n "Stopping service: ${name}"
+		kill `cat ${monitor_pidfile}`
+		rm ${pidfile} ${monitor_pidfile}
+		echo .
+	fi
 }
 
 run_rc_command "$1"

--- a/setup/freebsd/resources/jenkins
+++ b/setup/freebsd/resources/jenkins
@@ -30,7 +30,7 @@ jenkins_args="-jar ${jenkins_jar} \
 jenkins_jobs="$(getconf NPROCESSORS_ONLN)"
 
 # FreeBSD uses a java wrapper. Without full path pid monitoring won't work
-procname=`cat /usr/local/etc/javavms | cut -d "#" -f 1`
+procname=$(cat /usr/local/etc/javavms | cut -d "#" -f 1)
 pidfile="/var/run/${name}/${name}.pid"
 monitor_pidfile="/var/run/${name}/${name}_monitor.pid"
 command="/usr/sbin/daemon"
@@ -50,9 +50,9 @@ jenkins_prestart() {
 		chown "${jenkins_user}:${jenkins_group}" "${jenkins_log_file}"
 		chmod 640 "${jenkins_log_file}"
 	fi
-	if [ ! -d `basename ${pidfile}` ]; then
+	if [ ! -d $(dirname ${pidfile}) ]; then
 		install -d -o "${jenkins_user}" -g "${jenkins_group}" \
-			-m 750 `basename ${pidfile}`
+			-m 750 $(dirname ${pidfile})
 	fi
 
 	if [ ! $jenkins_secret ]; then
@@ -62,9 +62,10 @@ jenkins_prestart() {
 
 jenkins_start()
 {
-	check_startmsgs && echo -n "Starting ${name}"
+	check_startmsgs
+	echo "Starting ${name}."
+	# @TODO: get rid of nasty banner when su -l
 	su -l ${jenkins_user} -c "${env} exec ${command} ${command_args}"
-	echo .
 }
 
 jenkins_stop()
@@ -74,7 +75,8 @@ jenkins_stop()
 	else
 		echo -n "Stopping service: ${name}"
 		kill `cat ${monitor_pidfile}`
-		rm ${pidfile} ${monitor_pidfile}
+		# files are removed on exit, but be extra sure
+		rm -f ${pidfile} ${monitor_pidfile}
 		echo .
 	fi
 }

--- a/setup/freebsd/resources/jenkins.conf
+++ b/setup/freebsd/resources/jenkins.conf
@@ -1,0 +1,4 @@
+jenkins_jnlpurl="https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp"
+jenkins_secret="{{secret}}"
+jenkins_user="{{user}}"
+jenkins_group="{{group}}"

--- a/setup/freebsd/resources/jenkins.conf
+++ b/setup/freebsd/resources/jenkins.conf
@@ -1,4 +1,0 @@
-jenkins_jnlpurl="https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp"
-jenkins_secret="{{secret}}"
-jenkins_user="{{user}}"
-jenkins_group="{{group}}"

--- a/setup/freebsd/resources/jenkins.conf.j2
+++ b/setup/freebsd/resources/jenkins.conf.j2
@@ -1,0 +1,4 @@
+jenkins_jnlpurl="{{ jenkins_base_url }}computer/{{ inventory_hostname }}/slave-agent.jnlp"
+jenkins_secret="{{ server_secret }}"
+jenkins_user="{{ jenkins_user }}"
+jenkins_group="{{ jenkins_user }}"

--- a/setup/linter/ansible-vars.yaml
+++ b/setup/linter/ansible-vars.yaml
@@ -11,4 +11,5 @@ packages:
   - gmake
   - ccache
   - node
+  - bash
   - llvm-devel


### PR DESCRIPTION
We have to sunset our freebsd vm's at Voxer. This commit replaces The FreeBSD ones and then some:

- resolve java path which makes changes to openjdk "just work"
- remove unnecessary environment variables

With this, we will unfortunately not test for 32-bit freebsd any longer (because DO only have 64-bit freebsd vm's). On the other hand, we now run two 64-bit vm's in parallel, allowing for slightly higher throughput.