### PR TITLE
doc: add Softlayer to list of Hardware Sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The following companies are contributing hardware to this project:
 * [Scaleway](https://www.scaleway.com/)
 * [NodeSource](https://nodesource.com/)
 * [IBM](https://ibm.com) through [OSU Open Source Lab](http://osuosl.org/services/powerdev)
+* [IBM](https://ibm.com) through [Softlayer](www.softlayer.com)
 
 
 People


### PR DESCRIPTION
Add another line to identify IBM is also contributing
through Softlayer

Not sure if this is the best way but I would like to call out Softlayer and the OSU Open Source Lab separately.