### PR TITLE
redirect for Windows Environment wiki page

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -380,4 +380,6 @@ server {
     rewrite ^/images/yahoo-logo.png                               https://$server_name/static/legacy/images/yahoo-logo.png permanent;
 
     rewrite ^/images/(.*)                                         https://$server_name/static/images/$1 permanent;
+
+    rewrite ^/windows-environment$                                https://github.com/nodejs/node/wiki/Windows-Environment permanent;
 }


### PR DESCRIPTION
This is necessary to land https://github.com/nodejs/node/pull/4111

@rvagg is this the correct way to add the redirect?
