### PR TITLE
nodejs.org: remove SSL-config for new.nodejs.org

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -150,7 +150,7 @@ server {
     listen *:443 default_server ssl spdy;
     listen [::]:443 default_server ipv6only=on ssl spdy;
 
-    server_name nodejs.org www.nodejs.org new.nodejs.org;
+    server_name nodejs.org www.nodejs.org;
 
     ssl_certificate ssl/nodejs_chained.crt;
     ssl_certificate_key ssl/nodejs.key;


### PR DESCRIPTION
Its been a while since we launched nodejs.org and thereby moved from new.nodejs.org.
This minor cleanup removes the last evidence of new.nodejs.org from the nginx config.