### PR TITLE
nodejs.org: changed www host check to its own server directive

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -14,7 +14,7 @@ log_format nodejs    '$remote_addr - $remote_user [$time_local] '
 server {
     listen *:80 default_server;
     listen [::]:80 default_server ipv6only=on;
-    server_name www.nodejs.org nodejs.org;
+    server_name nodejs.org;
 
     access_log /var/log/nginx/nodejs.org-access.log nodejs;
     error_log /var/log/nginx/nodejs.org-error.log;
@@ -40,10 +40,6 @@ server {
     default_type text/plain;
     index index.html;
 
-    if ($host ~* ^www\.){
-        rewrite ^(.*)$ http://nodejs.org$1;
-    }
-
     location / {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
@@ -59,6 +55,14 @@ server {
             add_header access-control-allow-origin *;
         }
     }
+}
+
+server {
+    listen *:80;
+    listen [::]:80 ipv6only=on;
+    server_name www.nodejs.org;
+    
+    rewrite ^(.*)$ http://nodejs.org$1;
 }
 
 server {


### PR DESCRIPTION
Fixes the [server name (if)](https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#server-name-if) pitfall mentioned by nginx.

> When NGINX receives a request no matter what is the subdomain being requested, be it www.example.com or just the plain example.com this if directive is **always** evaluated. Since you’re requesting NGINX to check for the Host header for **every request**. It’s extremely inefficient. You should avoid it.