### PR TITLE
nodejs.org: falling back to english when page hasn't been translated

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -40,7 +40,11 @@ server {
     default_type text/plain;
     index index.html;
 
+    error_page 404 @localized_404;
+
     location / {
+        try_files $uri $uri/ @english_fallback;
+
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
@@ -54,6 +58,19 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
+    }
+
+    # instead of serving a 404 page when a page hasn't been translated
+    location @english_fallback {
+        if ($uri ~* ^/(it|ko)/) {
+            set $lang $1;
+        }
+        rewrite ^/(it|ko)/(.*)$ http://nodejs.org/en/$2;
+    }
+
+    # serve a localized 404 page if we've got $lang set from @english_fallback
+    location @localized_404 {
+        try_files /$lang/404.html /en/404.html;
     }
 }
 
@@ -190,7 +207,7 @@ server {
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-    error_page 404 /en/404.html;
+    error_page 404 @localized_404;
 
     root /home/www/nodejs;
     default_type text/plain;
@@ -199,9 +216,24 @@ server {
     location / {
         rewrite ^/$ /en/ redirect;
 
+        try_files $uri $uri/ @english_fallback;
+
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
+    }
+
+    # instead of serving a 404 page when a page hasn't been translated
+    location @english_fallback {
+        if ($uri ~* ^/(it|ko)/) {
+            set $lang $1;
+        }
+        rewrite ^/(it|ko)/(.*)$ https://nodejs.org/en/$2;
+    }
+
+    # serve a localized 404 page if we've got $lang set from @english_fallback
+    location @localized_404 {
+        try_files /$lang/404.html /en/404.html;
     }
 
     location /documentation/ {

--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -62,10 +62,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(it|ko)/) {
+        if ($uri ~* ^/(it|ko|zh-cn)/) {
             set $lang $1;
         }
-        rewrite ^/(it|ko)/(.*)$ /en/$2;
+        rewrite ^/(it|ko|zh-cn)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback
@@ -225,10 +225,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(it|ko)/) {
+        if ($uri ~* ^/(it|ko|zh-cn)/) {
             set $lang $1;
         }
-        rewrite ^/(it|ko)/(.*)$ /en/$2;
+        rewrite ^/(it|ko|zh-cn)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback

--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -65,7 +65,7 @@ server {
         if ($uri ~* ^/(it|ko)/) {
             set $lang $1;
         }
-        rewrite ^/(it|ko)/(.*)$ http://nodejs.org/en/$2;
+        rewrite ^/(it|ko)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback
@@ -228,7 +228,7 @@ server {
         if ($uri ~* ^/(it|ko)/) {
             set $lang $1;
         }
-        rewrite ^/(it|ko)/(.*)$ https://nodejs.org/en/$2;
+        rewrite ^/(it|ko)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback


### PR DESCRIPTION
Refs https://github.com/nodejs/nodejs.org/pull/490

Currently translation working groups will have to translate all pages to their respective
language, if not most pages would end in displaying a (english) 404 page. That's a massive
requirement on translation groups, and keeping up with future changes are probably near impossible.

Lowering the barrier and letting translation groups start on the frontpage and work their way
down a couple of page depths, should be alot simpler and more rewarding.

NB! This only affects local development as nodejs.org runs nginx serving strictly static content.
Getting the same behaviour in production requires changes to the nginx config.

Example of the current 404 issue; navigate any of the headers links in the current Korean translation: https://nodejs.org/ko/. I haven't done my dues when it comes to translating (yet), this is one of the main reasons I've decided not to.