### PR TITLE
build: add step for enabling aha fs

### DIFF
--- a/setup/aix61/manualBootstrap.txt
+++ b/setup/aix61/manualBootstrap.txt
@@ -51,6 +51,18 @@ subversion-1.8.0-1.aix6.1.ppc.rpm-with-deps.zip
 unzip subversion-1.8.0-1.aix6.1.ppc.rpm-with-deps.zip
 sh install-subversion-rpm.sh
 
+#enable the aha fs by adding the following to /etc/filesystems
+
+/aha:
+        dev             = /aha
+        vfs             = ahafs
+        mount           = true
+        vol             = /aha
+
+then either reboot or run
+
+mount /aha
+
 
 Apply this APAR depending on your OS level http://www-01.ibm.com/support/docview.wss?uid=isg1IV46651
 In particular on the default siteox install it required:


### PR DESCRIPTION
aha fs is needed on AIX  to pass fs watch tests both in libuv and node.js 

This adds the instructions on how to enable for AIX in order to support the work
being done under https://github.com/libuv/libuv/pull/776