### PR TITLE
build: relax firewall on rhel72-linuxone

### DIFF
--- a/setup/rhel72-linuxonecc/ansible-playbook.yaml
+++ b/setup/rhel72-linuxonecc/ansible-playbook.yaml
@@ -41,6 +41,18 @@
       with_items: ssh_users
       tags: user
 
+    - name: Firewall | add basic rule to allow communication locally
+      lineinfile: dest=/etc/sysconfig/iptables insertafter=":OUTPUT ACCEPT.*]" line="-A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT"
+      tags: firewall
+
+    - name: Firewall | add additional rule to allow communication from 127.0.0.2
+      lineinfile: dest=/etc/sysconfig/iptables insertafter=":OUTPUT ACCEPT.*]" line="-A INPUT -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT"
+      tags: firewall
+
+    - name: Firewall | make the new firewall rules take effect
+      command: systemctl restart iptables
+      tags: firewall
+
     - name: General | Create authorized_keys for root
       authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
       with_items: ssh_users


### PR DESCRIPTION
The initial firewall settings were way too
restrictive to be able to run our tests.  These
additional to the ansible playbook relax the
default rules.

both libuv and node tests pass with this change:

https://ci.nodejs.org/job/libuv+any-pr+multi-mdawson-test390/
https://ci.nodejs.org/job/node-test-commit-linuxone-mdawson/nodes=rhel72-s390x/15/console