### PR TITLE
build: add support for ccache for linuxone

### DIFF
--- a/setup/rhel72-linuxonecc/ansible-playbook.yaml
+++ b/setup/rhel72-linuxonecc/ansible-playbook.yaml
@@ -17,6 +17,10 @@
       with_items: packages
       tags: general
 
+    - name: ccache | Install ccache
+      include: ../ansible-tasks/ccache.yaml version=3.2.4
+      tags: ccache
+
     - name: NTP | Run initial NTP
       command: ntpdate -u pool.ntp.org
       tags: ntp

--- a/setup/rhel72-linuxonecc/resources/jenkins.service.j2
+++ b/setup/rhel72-linuxonecc/resources/jenkins.service.j2
@@ -12,7 +12,7 @@ User={{ server_user }}
 Environment="USER={{ server_user }}" \
             "SHELL=/bin/bash" \
             "HOME=/data/{{ server_user }}" \
-            "PATH=/usr/lib64/ccache:/usr/bin" \
+            "PATH=/usr/local/bin:/usr/bin" \
             "NODE_COMMON_PIPE=$HOME/test.pipe" \
             "NODE_TEST_DIR=$HOME/tmp" \
             "JOBS={{ ansible_processor_cores }}" \


### PR DESCRIPTION
- Add in steps to build ccache for linuxone machines
- Update path set when starting jenkins agent to include
  directory with ccache links

Build/test time when from 6.5 mins to 3.5 mins with this
change