### PR TITLE
setup: remove github/pubkey mechanism

### DIFF
--- a/setup/aix61/ansible-playbook.yaml
+++ b/setup/aix61/ansible-playbook.yaml
@@ -16,22 +16,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}/slave.jar validate_certs=no
       tags: jenkins

--- a/setup/aix61/ansible-vars.yaml
+++ b/setup/aix61/ansible-vars.yaml
@@ -1,8 +1,2 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - joaocgreis
-  - mhdawson

--- a/setup/armv7-wheezy/ansible-playbook.yaml
+++ b/setup/armv7-wheezy/ansible-playbook.yaml
@@ -69,22 +69,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/armv7-wheezy/ansible-vars.yaml
+++ b/setup/armv7-wheezy/ansible-vars.yaml
@@ -1,9 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - jbergstroem
-  - orangemocha
 packages:
   - openjdk-7-jre
   - python-all

--- a/setup/centos5/ansible-playbook.yaml
+++ b/setup/centos5/ansible-playbook.yaml
@@ -84,22 +84,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: General | Create python26 symlink
       file: src=/usr/bin/python26 dest=/usr/local/bin/python owner={{ server_user }} state=link
       tags: jenkins

--- a/setup/centos5/ansible-vars.yaml
+++ b/setup/centos5/ansible-vars.yaml
@@ -1,11 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - jbergstroem
-  - joaocgreis
 packages:
   - git
   - java-1.7.0-openjdk

--- a/setup/centos6/ansible-playbook.yaml
+++ b/setup/centos6/ansible-playbook.yaml
@@ -54,22 +54,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/centos6/ansible-vars.yaml
+++ b/setup/centos6/ansible-vars.yaml
@@ -1,11 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - jbergstroem
-  - joaocgreis
 packages:
   - git
   - java-1.8.0-openjdk

--- a/setup/centos7/ansible-playbook.yaml
+++ b/setup/centos7/ansible-playbook.yaml
@@ -42,22 +42,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins
@@ -77,7 +61,7 @@
     - name: Jenkins | Copy server ids to jenkins.service
       replace: dest=/usr/lib/systemd/system/jenkins.service regexp="\{\{id\}\}" replace="{{ inventory_hostname }}"
       tags: jenkins
-      
+
     - name: Jenkins | Start service
       service: name=jenkins state=started
       tags: jenkins

--- a/setup/centos7/ansible-vars.yaml
+++ b/setup/centos7/ansible-vars.yaml
@@ -1,11 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - jbergstroem
-  - joaocgreis
 packages:
   - java-1.7.0-openjdk
   - git

--- a/setup/containers/ansible-playbook.yaml
+++ b/setup/containers/ansible-playbook.yaml
@@ -40,22 +40,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Docker | Set up docker.io
       command: sh -c 'curl -sL http://get.docker.io/ | bash -'
       tags: docker
@@ -76,12 +60,11 @@
       copy: src=./resources/start.sh dest=/home/{{ server_user }}/start.sh owner={{ server_user }} group={{ server_user }} mode=0755
       tags: jenkins
 
-    - name: Jenkins | Copy secrets to start.sh script 
+    - name: Jenkins | Copy secrets to start.sh script
       replace: dest=/home/{{ server_user }}/start.sh regexp="\{\{iojs-{{ item.key }}-secret\}\}" replace="{{ item.value.secret }}"
       with_dict: distributions
       tags: jenkins
 
-    - name: Jenkins | Copy server ids to start.sh script 
+    - name: Jenkins | Copy server ids to start.sh script
       replace: dest=/home/{{ server_user }}/start.sh regexp="\{\{id\}\}" replace="{{ server_id }}"
       tags: jenkins
-

--- a/setup/containers/ansible-vars.yaml
+++ b/setup/containers/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ghostbar
-  - joaocgreis
 packages:
   - nodejs
   - openjdk-7-jre

--- a/setup/debian8/ansible-playbook.yaml
+++ b/setup/debian8/ansible-playbook.yaml
@@ -21,22 +21,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/debian8/ansible-vars.yaml
+++ b/setup/debian8/ansible-vars.yaml
@@ -1,11 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - kenperkins
-  - joaocgreis
 packages:
   - ntp
   - openjdk-7-jre

--- a/setup/fedora20/ansible-playbook.yaml
+++ b/setup/fedora20/ansible-playbook.yaml
@@ -33,22 +33,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/fedora20/ansible-vars.yaml
+++ b/setup/fedora20/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - mhdawson
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/fedora21/ansible-playbook.yaml
+++ b/setup/fedora21/ansible-playbook.yaml
@@ -42,22 +42,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/fedora21/ansible-vars.yaml
+++ b/setup/fedora21/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - joaocgreis
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/fedora22/ansible-playbook.yaml
+++ b/setup/fedora22/ansible-playbook.yaml
@@ -42,22 +42,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/fedora22/ansible-vars.yaml
+++ b/setup/fedora22/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - joaocgreis
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/freebsd/ansible-playbook.yaml
+++ b/setup/freebsd/ansible-playbook.yaml
@@ -29,21 +29,6 @@
       user: name="{{ server_user }}" shell=/bin/sh append=yes groups={{ server_user }}
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
 
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar

--- a/setup/freebsd/ansible-vars.yaml
+++ b/setup/freebsd/ansible-vars.yaml
@@ -1,9 +1,6 @@
 ---
 server_user: iojs
 init_script_path: /usr/local/etc/rc.d/jenkins
-ssh_users:
-  - rvagg
-  - jbergstroem
 packages:
   - openjdk-jre
   - git

--- a/setup/linter/ansible-playbook.yaml
+++ b/setup/linter/ansible-playbook.yaml
@@ -29,22 +29,6 @@
       user: name="{{ server_user }}" shell=/bin/sh append=yes groups={{ server_user }}
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-      
     - name: General | Keep iojs up to date
       cron: name="update iojs" minute="0" hour="0" day="*/7" job="pkg update -q && pkg upgrade -yq iojs >/dev/null 2>&1"
       tags: cron
@@ -72,4 +56,3 @@
     - name: Jenkins | Start service
       command: service jenkins start
       tags: jenkins
-      

--- a/setup/linter/ansible-vars.yaml
+++ b/setup/linter/ansible-vars.yaml
@@ -1,10 +1,6 @@
 ---
 server_user: iojs
 init_script_path: /usr/local/etc/rc.d/jenkins
-ssh_users:
-  - rvagg
-  - jbergstroem
-  - joaocgreis
 packages:
   - openjdk
   - git

--- a/setup/raspberry-pi/ansible-playbook.yaml
+++ b/setup/raspberry-pi/ansible-playbook.yaml
@@ -55,22 +55,6 @@
         shell: /bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url:
-        url: "https://github.com/{{ item }}.keys"
-        dest: "/tmp/{{ item }}.keys"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: Jenkins | Download Jenkins' slave.jar to {{ server_user }}
-      command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
-      tags: jenkins
-
     - name: NFS | Make NFS mounted directories
       file:
         path: "/home/{{ server_user }}/{{ item }}"
@@ -129,4 +113,3 @@
 
     - include: ../ansible-tasks/monit.yaml monit_conf_file=../ansible-tasks/resources/monit-jenkins.conf
       tags: monit
-

--- a/setup/raspberry-pi/ansible-vars.yaml
+++ b/setup/raspberry-pi/ansible-vars.yaml
@@ -1,9 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - orangemocha
-  - jbergstroem
 packages:
   - openjdk-7-jre
   - python-all

--- a/setup/rhel72-linuxonecc/ansible-playbook.yaml
+++ b/setup/rhel72-linuxonecc/ansible-playbook.yaml
@@ -39,12 +39,6 @@
       user: name="{{ server_user }}" shell=/bin/bash home=/data/iojs
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
     - name: Firewall | add basic rule to allow communication locally
       lineinfile: dest=/etc/sysconfig/iptables insertafter=":OUTPUT ACCEPT.*]" line="-A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT"
       tags: firewall
@@ -56,16 +50,6 @@
     - name: Firewall | make the new firewall rules take effect
       command: systemctl restart iptables
       tags: firewall
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
 
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/data/{{ server_user }}/slave.jar

--- a/setup/rhel72-linuxonecc/ansible-vars.yaml
+++ b/setup/rhel72-linuxonecc/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - joaocgreis
 packages:
   - java-1.8.0-openjdk
   - git

--- a/setup/smartos/ansible-playbook.yaml
+++ b/setup/smartos/ansible-playbook.yaml
@@ -32,22 +32,6 @@
       command: passwd -N {{ server_user }}
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: CCache | Create directory that hold symlinks to ccache
       file: path=/opt/local/libexec/ccache state=directory mode=0755
       tags: ccache

--- a/setup/smartos/ansible-vars.yaml
+++ b/setup/smartos/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - geek
-  - rvagg
-  - jbergstroem
-  - joaocgreis
 packages:
   - openjdk7
   - git

--- a/setup/ubuntu12.04/ansible-playbook.yaml
+++ b/setup/ubuntu12.04/ansible-playbook.yaml
@@ -36,21 +36,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
 
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}/slave.jar

--- a/setup/ubuntu12.04/ansible-vars.yaml
+++ b/setup/ubuntu12.04/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/ubuntu14.04/ansible-playbook.yaml
+++ b/setup/ubuntu14.04/ansible-playbook.yaml
@@ -31,22 +31,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
     - name: Clone the gyp git repo
       git: repo=https://chromium.googlesource.com/external/gyp dest=/home/iojs/gyp
       tags: gyp

--- a/setup/ubuntu14.04/ansible-vars.yaml
+++ b/setup/ubuntu14.04/ansible-vars.yaml
@@ -1,11 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - ryanstevens
-  - mhdawson
-  - joaocgreis
 packages:
   - openjdk-7-jre
   - git

--- a/setup/ubuntu15.04/ansible-playbook.yaml
+++ b/setup/ubuntu15.04/ansible-playbook.yaml
@@ -29,21 +29,6 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: User | Download pubkey(s)
-      get_url: url=https://github.com/{{ item }}.keys dest=/tmp/{{ item }}.keys
-      delegate_to: 127.0.0.1
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for root
-      authorized_key: user="root" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
-
-    - name: General | Create authorized_keys for {{ server_user }}
-      authorized_key: user="{{ server_user }}" key="{{ lookup('file', '/tmp/' + item + '.keys') }}"
-      with_items: ssh_users
-      tags: user
 
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}/slave.jar

--- a/setup/ubuntu15.04/ansible-vars.yaml
+++ b/setup/ubuntu15.04/ansible-vars.yaml
@@ -1,10 +1,5 @@
 ---
 server_user: iojs
-ssh_users:
-  - rvagg
-  - wblankenship
-  - jbergstroem
-  - joaocgreis
 packages:
   - openjdk-8-jre
   - git


### PR DESCRIPTION
The majority of our machines now use shared keys that are accessed through a encrypted github repo. Additionally, the list of users were out of date.

There's a catch 22 when it comes to adding pubkeys to newly deployed servers. Optimally, this PR should replace what is removed with adding a test* key, but since this is in most of the cases already added through the VM provider (most often you choose what key to deploy an image with), I'd like to see if there's a better solution.