### PR TITLE
build:  changes to support ubuntu 14 for PPC BE

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -43,6 +43,8 @@ test-digitalocean-ubuntu14-x86-1
 test-digitalocean-ubuntu14-x64-1
 release-osuosl-ubuntu14-ppc64_le-1
 test-osuosl-ubuntu14-ppc64_be-1
+test-osuosl-ubuntu14-ppc64_be-2
+release-osuosl-ubuntu14-ppc64_be-1
 
 [iojs-build-ubuntu1204]
 test-digitalocean-ubuntu12-x64-1

--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -42,6 +42,7 @@ test-softlayer-ubuntu14-x86-1
 test-digitalocean-ubuntu14-x86-1
 test-digitalocean-ubuntu14-x64-1
 release-osuosl-ubuntu14-ppc64_le-1
+test-osuosl-ubuntu14-ppc64_be-1
 
 [iojs-build-ubuntu1204]
 test-digitalocean-ubuntu12-x64-1

--- a/setup/ubuntu14.04/README.md
+++ b/setup/ubuntu14.04/README.md
@@ -24,6 +24,10 @@ Host release-osuosl-ubuntu14-ppc64_le-1
   HostName 140.211.168.188
 Host test-osuosl-ubuntu14-ppc64_be-1
   HostName 140.211.168.3
+Host test-osuosl-ubuntu14-ppc64_be-2
+  HostName 140.211.168.4
+Host release-osuosl-ubuntu14-ppc64_be-1
+  HostName 140.211.168.5
 ```
 
 Note that these hostnames are also used in the *ansible-inventory* file. The IP addresses will need to be updated each time the servers are reprovisioned.

--- a/setup/ubuntu14.04/README.md
+++ b/setup/ubuntu14.04/README.md
@@ -22,6 +22,8 @@ Host test-digitalocean-ubuntu14-x64-1
   HostName 45.55.252.223
 Host release-osuosl-ubuntu14-ppc64_le-1
   HostName 140.211.168.188
+Host test-osuosl-ubuntu14-ppc64_be-1
+  HostName 140.211.168.3
 ```
 
 Note that these hostnames are also used in the *ansible-inventory* file. The IP addresses will need to be updated each time the servers are reprovisioned.

--- a/setup/ubuntu14.04/ansible-playbook.yaml
+++ b/setup/ubuntu14.04/ansible-playbook.yaml
@@ -17,6 +17,12 @@
       with_items: packages
       tags: general
 
+    - name: General | Install additional packages for PPC be
+      apt: name={{ item }} update_cache=yes state=latest
+      with_items: additional_ppc_be_packages
+      when: (ansible_architecture == "ppc64" and ansible_nodename.find('ppc64-be') != -1)
+      tags: general
+
     - name: NTP | Run initial NTP
       command: ntpdate -u pool.ntp.org
       tags: ntp

--- a/setup/ubuntu14.04/ansible-vars.yaml
+++ b/setup/ubuntu14.04/ansible-vars.yaml
@@ -17,3 +17,5 @@ packages:
   - ntp
   - ccache
   - subversion
+additional_ppc_be_packages:
+  - g++-4.8-multilib


### PR DESCRIPTION
ubuntu PPC BE defaults to 32 bit compiles as opposed to
the rest of the distros (including PPC LE) which default to 64
bit.  This is the case even though the OS is 64 bit. The
net is that since we want to ship/support 64 bit binaries we
need to install the multi-lib package and only do that
for PPC BE.  Looking at the ansible vars there does not
seem to be one that can be used to identify between
BE versus LE so I first check that we are on PPC from the
vars which are available, and if we are PPC then use
the node name (which includes PPC64_be for be machines)
to figure out if it is BE or LE.

This change adds the required changes to support BE
ubuntu machines as well as the definition of the
initial ubuntu BE machine