### PR TITLE
build: extend timeout for git for AIX

### DIFF
--- a/setup/aix61/resources/S20jenkins
+++ b/setup/aix61/resources/S20jenkins
@@ -17,7 +17,7 @@ start )
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
               export OSTYPE=AIX61; \
               export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
-        java -Xmx256m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
+        java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'
         ;;

--- a/setup/aix61/resources/S20jenkins
+++ b/setup/aix61/resources/S20jenkins
@@ -17,7 +17,7 @@ start )
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
               export OSTYPE=AIX61; \
               export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
-        java -Xmx128m -jar "$HOME/slave.jar" \
+        java -Xmx256m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'
         ;;


### PR DESCRIPTION
We were seeing timeouts in git checkouts. Extended
the timeout through a parameter passed to the plugin
as a command line option when starting the jenkins
agent

Increased the memory available to the JVM in hopes
that might speed up actions like the checkout
which are being handled by a java plugin

Addresses https://github.com/nodejs/build/issues/381