### PR TITLE
Replace outdated ES6 page with node.green

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -392,4 +392,5 @@ server {
     rewrite ^/images/(.*)                                         https://$server_name/static/images/$1 permanent;
 
     rewrite ^/windows-environment$                                https://github.com/nodejs/node/wiki/Windows-Environment permanent;
+    rewrite ^/en/docs/es6/                                        http://node.green permanent;
 }


### PR DESCRIPTION
This should land one v6 comes out.
Ref:
- https://github.com/nodejs/nodejs.org/issues/671
- https://github.com/nodejs/nodejs.org/pull/674