### PR TITLE
www: redirect from '/<lang>/downloads/stable' to '/<lang>/downloads/current'

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -394,5 +394,5 @@ server {
     rewrite ^/windows-environment$                                https://github.com/nodejs/node/wiki/Windows-Environment permanent;
 
     # Rename 'Stable' release to 'Current'
-    rewrite ^/(.*)/downloads/stable$                              https://$server_name/$1/downloads/current permanent;
+    rewrite ^/(.*)/download/stable$                               https://$server_name/$1/download/current permanent;
 }

--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -392,4 +392,7 @@ server {
     rewrite ^/images/(.*)                                         https://$server_name/static/images/$1 permanent;
 
     rewrite ^/windows-environment$                                https://github.com/nodejs/node/wiki/Windows-Environment permanent;
+
+    # Rename 'Stable' release to 'Current'
+    rewrite ^/(.*)/downloads/stable$                              https://$server_name/$1/downloads/current permanent;
 }


### PR DESCRIPTION
With the change of release names from 'Stable' to 'Current' (introduced with
Node.js v6), the old download page needs to be redirected.

Ref:
- https://github.com/nodejs/node/pull/6318
- https://github.com/nodejs/nodejs.org/pull/672