### PR TITLE
www: add a open file cache

### DIFF
--- a/setup/www/resources/config/open-file-cache.conf
+++ b/setup/www/resources/config/open-file-cache.conf
@@ -1,0 +1,4 @@
+open_file_cache          max=10000 inactive=30s;
+open_file_cache_valid    60s;
+open_file_cache_min_uses 5;
+open_file_cache_errors   off;

--- a/setup/www/tasks/nginx.yaml
+++ b/setup/www/tasks/nginx.yaml
@@ -45,6 +45,11 @@
   copy:
     src: ./resources/config/ssl-defaults.conf
     dest: /etc/nginx/conf.d/ssl-defaults.conf
+
+- name: nginx | Install open file cache config
+  copy:
+    src: ./resources/config/open-file-cache.conf
+    dest: /etc/nginx/conf.d/open-file-cache.conf
     mode: 0644
   tags: nginx
 


### PR DESCRIPTION
Avoid re-reading file handles when serving downloads (well, most things). This lessens the strain on nginx.