### PR TITLE
www: cleanup new.nodejs.org from build-site script

### DIFF
--- a/setup/www/resources/scripts/build-site.sh
+++ b/setup/www/resources/scripts/build-site.sh
@@ -17,10 +17,6 @@ clonedir=/home/www/github/${site}
 
 if [ ! -d "${clonedir}" ]; then
   repo="${site}.org"
-  #TODO: remove this when repo is renamed
-  if [ "$site" == "nodejs" ]; then
-    repo="new.${site}.org"
-  fi
   git clone https://github.com/nodejs/${repo}.git $clonedir
 fi
 


### PR DESCRIPTION
The nodejs.org repo has been renamed from new.nodejs.org -> nodejs.org a long time ago.