### PR TITLE
qualify /blog url with ^

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -28,7 +28,7 @@ server {
     gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
     # let the blog.nodejs.org redirector handle this
-    location ~ /blog(.*) {
+    location ~ ^/blog(.*) {
         rewrite ^/blog(.*) http://blog.nodejs.org/$1 permanent;
     }
 


### PR DESCRIPTION
I happened to notice that (some of?) our blog content wasn't redirecting from http to https and I _believe_ this was the culprit. It's live now and the redirects appear to be working now. I can't find anything else to explain it, although this one doesn't really make sense to me either!