### PR TITLE
add basic osx instructions

### DIFF
--- a/setup/osx/README.md
+++ b/setup/osx/README.md
@@ -1,7 +1,5 @@
 # Node.js Build OS X Setup
 
-_Documentation pending ..._
-
 Add this to your ssh config:
 
 ```text
@@ -27,4 +25,31 @@ Host test-voxer-osx1010-2
   # IdentityFile nodejs_build_test
 ```
 
-The `start.sh` script starts and manages the slave process. `tunnel.sh` manages an outgoing HTTP proxy tunnel and incoming SSH and should always be running.
+## Configuration
+
+Required steps:
+
+* Create user `iojs`
+* `xcode-select --install` to install XCode tools, or install from App Store
+* Sun Java (JDK)
+* `git clone http://git.chromium.org/external/gyp.git /Users/iojs/gyp`
+* For release machines:
+  - Install PackageMaker, download "Auxiliary Tools for Xcode - Late July 2012" from the Apple Developer site to get it
+  - Install Packages from http://s.sudre.free.fr/Software/Packages/about.html
+  - Install Node.js Foundation code signing and package signing tools, available from the Node.js Foundation Apple Developer account (shared org, you need to be a member), `/usr/bin/codesign` and `/usr/bin/productsign` need to be able to use the keys non-interactively, Keychain Access may be able to be used for this except on El Capitain where you'll have to pull your hair out for a few hours before figuring it out (note that Keychain Access won't accept user/password for some actions unless your keyboard is connected directly to the physical computer) [TODO: insert instructions for doing this on El Capitain and prior versions next time hair pulling is performed and the magical incantation is figured out].
+* Install `start.sh` and `tunnel.sh` to `/Users/iojs`
+* Install `org.nodejs.osx.jenkins.plist` and `org.nodejs.osx.tunnel.plist` to `/Library/LaunchDaemons`
+* As root (or using `sudo`), run:
+  - `launchctl load /Library/LaunchDaemons/org.nodejs.osx.tunnel.plist`
+  - `launchctl load /Library/LaunchDaemons/org.nodejs.osx.jenkins.plist`
+  - `launchctl start org.nodejs.osx.tunnel`
+  - `launchctl start org.nodejs.osx.jenkins`
+
+## Operating
+
+The tunnel connects the machines to ci.nodejs.org for a local tunnel to handle HTTP proxying and a remote tunnel to allow external SSH connections. It should always be running.
+
+The Jenkins process is managed by launched and should be automatically restarted when it dies. It can be manually started and stopped using:
+
+* `launchctl stop org.nodejs.osx.jenkins`
+* `launchctl start org.nodejs.osx.jenkins`

--- a/setup/osx/README.md
+++ b/setup/osx/README.md
@@ -1,0 +1,30 @@
+# Node.js Build OS X Setup
+
+_Documentation pending ..._
+
+Add this to your ssh config:
+
+```text
+Host release-voxer-osx1010-1
+  User iojs
+  HostName ci.nodejs.org
+  Port 3222
+  # IdentityFile nodejs_build_release
+Host release-voxer-osx1010-2
+  User iojs
+  HostName ci.nodejs.org
+  Port 3223
+  # IdentityFile nodejs_build_release
+Host test-voxer-osx1010-1
+  User iojs
+  HostName ci.nodejs.org
+  Port 3224
+  # IdentityFile nodejs_build_test
+Host test-voxer-osx1010-2
+  User iojs
+  HostName ci.nodejs.org
+  Port 3225
+  # IdentityFile nodejs_build_test
+```
+
+The `start.sh` script starts and manages the slave process. `tunnel.sh` manages an outgoing HTTP proxy tunnel and incoming SSH and should always be running.

--- a/setup/osx/org.nodejs.osx.jenkins.plist
+++ b/setup/osx/org.nodejs.osx.jenkins.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+        <dict>
+                <key>Label</key>
+                <string>org.nodejs.osx.jenkins</string>
+
+                <key>UserName</key>
+                <string>iojs</string>
+
+                <key>WorkingDirectory</key>
+                <string>/Users/iojs</string>
+
+                <key>Program</key>
+                <string>/Users/iojs/start.sh</string>
+
+                <key>RunAtLoad</key>
+                <true/>
+
+                <key>KeepAlive</key>
+                <true/>
+        </dict>
+</plist>

--- a/setup/osx/org.nodejs.osx.tunnel.plist
+++ b/setup/osx/org.nodejs.osx.tunnel.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+        <dict>
+                <key>Label</key>
+                <string>org.nodejs.osx.tunnel</string>
+
+                <key>UserName</key>
+                <string>iojs</string>
+
+                <key>Program</key>
+                <string>/Users/iojs/tunnel.sh</string>
+
+                <key>RunAtLoad</key>
+                <true/>
+
+                <key>KeepAlive</key>
+                <true/>
+        </dict>
+</plist>

--- a/setup/osx/start.sh
+++ b/setup/osx/start.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+curl -O https://ci.nodejs.org/jnlpJars/slave.jar
+
+SECRET=<INSERT SECRET>
+SERVER_ID=<INSERT SERVER>
+CI_SERVER=ci.nodejs.org
+
+export JOBS=2
+export NODE_COMMON_PIPE=/Users/iojs/test.pipe
+export OSTYPE=osx
+
+java -jar slave.jar -jnlpUrl https://${CI_SERVER}/computer/${SERVER_ID}/slave-agent.jnlp -secret $SECRET

--- a/setup/osx/tunnel.sh
+++ b/setup/osx/tunnel.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+REMOTE_PORT=3222
+SSH_KEY=~/.ssh/ci-osx
+REMOTE_HOST=ci.nodejs.org
+PROXY_PORT=8118
+
+ssh -C -N -o ServerAliveInterval=3 -R "*:${REMOTE_PORT}:localhost:22" -L "${PROXY_PORT}:localhost:${PROXY_PORT}" $REMOTE_HOST -l osx -i $SSH_KEY
+sleep 10 # give the server a break before auto restart


### PR DESCRIPTION
I added ssh tunnels to all of the OSX build machines, connected to ci.nodejs.org, authenticated with _test and _release keys so y'all can get in and mess around. The slave process is started via `./start.sh` on a local terminal but we should probably change that to something that can be more easily managed remotely. Not sure what yet tho, open to suggestions.
