### PR TITLE
ubuntu12: add new slave

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -52,6 +52,7 @@ iojs-ns-xgene-3
 
 [iojs-build-ubuntu1204]
 test-digitalocean-ubuntu12-x64-1
+test-digitalocean-ubuntu12-x64-2
 
 [iojs-build-smartos]
 test-joyent-smartos14-x64-1

--- a/setup/ubuntu12.04/README.md
+++ b/setup/ubuntu12.04/README.md
@@ -5,6 +5,9 @@ For setting up a Ubuntu 12.04 box
 ```text
 Host test-digitalocean-ubuntu12-x64-1
   HostName 104.236.234.182
+
+Host test-digitalocean-ubuntu12-x64-2
+  HostName 107.170.104.83
 ```
 
 Note that these hostnames are also used in the *ansible-inventory* file. The IP addresses will need to be updated each time the servers are reprovisioned.


### PR DESCRIPTION
We were runnning short of ubuntu12 slaves which made the build slow down, especially during smoketests. 