### PR TITLE
add support for Odroid C2 (ARMv7) with Ubuntu 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 **/host_vars/iojs-*
+**/host_vars/node-*
+**/host_vars/test-*
+**/host_vars/release-*

--- a/setup/ubuntu16.04/.gitignore
+++ b/setup/ubuntu16.04/.gitignore
@@ -1,1 +1,0 @@
-host_vars/iojs-build-*

--- a/setup/ubuntu16.04/README.md
+++ b/setup/ubuntu16.04/README.md
@@ -8,9 +8,24 @@ Host test-digitalocean-ubuntu1604-x64-1
 
 Host test-digitalocean-ubuntu1604-x86-1
   HostName 159.203.77.233
+
+Host test-mininodes-ubuntu1604-arm64_odroid_c2-1
+  User odroid
+  HostName 70.167.220.147
+  # IdentityFile nodejs_build_test
+
+Host test-mininodes-ubuntu1604-arm64_odroid_c2-2
+  User odroid
+  HostName 70.167.220.148
+  # IdentityFile nodejs_build_test
+
+Host test-mininodes-ubuntu1604-arm64_odroid_c2-3
+  User odroid
+  HostName 70.167.220.149
+  # IdentityFile nodejs_build_test
 ```
 
-..then run:
+Build the host_var config files for each host, including `server_jobs: 2` for the lower powered hosts, then run:
 
 ```bash
 $ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml

--- a/setup/ubuntu16.04/ansible-playbook.yaml
+++ b/setup/ubuntu16.04/ansible-playbook.yaml
@@ -1,6 +1,8 @@
 ---
 - hosts: iojs-build-ubuntu1604
-  remote_user: root
+  remote_user: "{{ remote_user }}" # from inventory
+  become: yes
+  become_user: root
   gather_facts: False
 
   tasks:
@@ -9,20 +11,27 @@
       register: python_exists
       failed_when: python_exists.rc > 1
 
-    - name: Bootstrap for the apt package
+    - name: Check for aptitude
+      raw: which aptitude
+      register: aptitude_exists
+      failed_when: aptitude_exists.rc > 1
+
+    - name: Bootstrap python and aptitude
       raw: apt install -y python-minimal aptitude
       tags: bootstrap
-      when: python_exists.rc == 1
+      when: python_exists.rc == 1 or aptitude_exists.rc == 1
 
 - hosts: iojs-build-ubuntu1604
-  remote_user: root
+  remote_user: "{{ remote_user }}"
+  become: yes
+  become_user: root
   gather_facts: True
 
   tasks:
     - include_vars: ansible-vars.yaml
       tags: vars
 
-    - name: General | APT Update and upgrade
+    - name: General | APT update and upgrade
       apt: update_cache=yes upgrade=full
       tags: general
 
@@ -34,7 +43,6 @@
     - name: User | Add {{ server_user }} user
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
-
 
     - name: Jenkins | Download Jenkins slave.jar
       get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}/slave.jar

--- a/setup/ubuntu16.04/resources/jenkins.service.j2
+++ b/setup/ubuntu16.04/resources/jenkins.service.j2
@@ -11,7 +11,7 @@ Type=simple
 User={{ server_user }}
 
 Environment="USER={{ server_user }}" 
-Environment="JOBS={{ ansible_processor_vcpus }}"
+Environment="JOBS={{ server_jobs | default(ansible_processor_vcpus) }}"
 Environment="SHELL=/bin/bash"
 Environment="HOME=/home/{{ server_user }}"
 Environment="NODE_TEST_DIR=/home/{{ server_user }}/tmp"


### PR DESCRIPTION
A few fixups and some compatibility things for 16.04 to support the new C2's that are now in CI ("ubuntu1604-armv8"). Note that I'm using `server_jobs: 2` for these, they have 8 cores but not a ton of RAM and we've hit OOMs compiling with `-j4` already.

R=@jbergstroem 