### PR TITLE
backup: lower periodic history to 20 days

### DIFF
--- a/backup/backup_scripts/remove_old.sh
+++ b/backup/backup_scripts/remove_old.sh
@@ -11,7 +11,7 @@ if [ "x" == "x$1" ]; then
 fi
 
 HOST=$1
-DAYS=30
+DAYS=20
 ROOTDIR=/var/lib/jenkins/jobs
 JOBS="$ROOTDIR/*/builds/"
 MULTIJOBS="$ROOTDIR/*/configurations/axis-nodes/*/builds/"


### PR DESCRIPTION
In an attempt to make our CI faster, reduce the amount of stored jobs from 30 days to 20 days.

Refs https://github.com/nodejs/build/issues/426.

