### PR TITLE
Preliminary Alpine support for CI

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -196,3 +196,6 @@ node-win2012r2-x64-3.cloudapp.net
 
 [github-bot]
 infra-rackspace-debian8-x64-1
+
+[test-ubuntu1604_docker_alpine34]
+test-digitalocean-ubuntu1604_docker_alpine34-x64-1

--- a/setup/ubuntu16.04_docker_alpine3.4/.gitignore
+++ b/setup/ubuntu16.04_docker_alpine3.4/.gitignore
@@ -1,0 +1,2 @@
+host_vars/test-*
+roles/*

--- a/setup/ubuntu16.04_docker_alpine3.4/README.md
+++ b/setup/ubuntu16.04_docker_alpine3.4/README.md
@@ -1,0 +1,17 @@
+# Alpine Linux 3.4 via Docker on Ubuntu 16.04 Setup
+
+Add this to your ssh config:
+
+```text
+Host test-digitalocean-ubuntu1604_adocker_alpine34-x64-1
+  HostName 107.170.75.204
+  User root
+  #IdentityFile nodejs_build_test
+```
+
+..then run:
+
+```bash
+$ ansible-galaxy install -p . angstwad.docker_ubuntu
+$ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
+```

--- a/setup/ubuntu16.04_docker_alpine3.4/ansible-playbook.yaml
+++ b/setup/ubuntu16.04_docker_alpine3.4/ansible-playbook.yaml
@@ -1,0 +1,76 @@
+---
+- hosts: test-ubuntu1604_docker_alpine34
+  remote_user: root
+  gather_facts: False
+
+  tasks:
+    - name: Check for python
+      raw: which python
+      register: python_exists
+      failed_when: python_exists.rc > 1
+
+    - name: Bootstrap for the apt package
+      raw: apt install -y python-minimal aptitude
+      tags: bootstrap
+      when: python_exists.rc == 1
+
+- hosts: test-ubuntu1604_docker_alpine34
+  remote_user: root
+  gather_facts: True
+
+  tasks:
+    - include_vars: ansible-vars.yaml
+      tags: vars
+
+    - name: General | APT Update and upgrade
+      apt: update_cache=yes upgrade=full
+      tags: general
+
+    - name: General | Install required packages
+      apt: name={{ item }} update_cache=yes state=latest
+      with_items: packages
+      tags: general
+
+    - name: User | Add {{ server_user }} user
+      user: name="{{ server_user }}" shell=/bin/bash
+      tags: user
+
+    - name: User | Make work directories
+      file:
+        path: "/home/{{ server_user }}/{{ item }}"
+        state: directory
+        mode: 0755
+        owner: "{{ server_user }}"
+        group: "{{ server_user }}"
+      with_items:
+        - build
+        - tmp
+      tags: user
+
+- name: Docker | Install Docker
+  hosts: test-ubuntu1604_docker_alpine34
+  remote_user: root
+  gather_facts: True
+  roles:
+    - angstwad.docker_ubuntu
+  tags: docker
+
+- hosts: test-ubuntu1604_docker_alpine34
+  remote_user: root
+  gather_facts: True
+
+  tasks:
+    - name: Docker | Generate Dockerfile
+      template: src=./resources/Dockerfile.j2 dest=/root/Dockerfile
+      tags: docker
+
+    - name: Docker | Build Alpine image
+      command: docker build -t node-ci:alpine-build /root/
+
+    - name: Init | Generate and copy init script
+      template: src=./resources/jenkins.service.j2 dest=/lib/systemd/system/jenkins.service
+      tags: init
+
+    - name: Init | Start Jenkins
+      service: name=jenkins state=started enabled=yes
+      tags: init

--- a/setup/ubuntu16.04_docker_alpine3.4/ansible-playbook.yaml
+++ b/setup/ubuntu16.04_docker_alpine3.4/ansible-playbook.yaml
@@ -22,7 +22,7 @@
     - include_vars: ansible-vars.yaml
       tags: vars
 
-    - name: General | APT Update and upgrade
+    - name: General | APT update and upgrade
       apt: update_cache=yes upgrade=full
       tags: general
 
@@ -60,17 +60,29 @@
   gather_facts: True
 
   tasks:
-    - name: Docker | Generate Dockerfile
-      template: src=./resources/Dockerfile.j2 dest=/root/Dockerfile
-      tags: docker
+    - include: tasks/setup-image.yaml image_type=test ci_host=ci.nodejs.org secret={{ test_secret }}
+    - include: tasks/setup-image.yaml image_type=release ci_host=ci-release.nodejs.org secret={{ release_secret }}
 
-    - name: Docker | Build Alpine image
-      command: docker build -t node-ci:alpine-build /root/
+    - name: SSH | Make release ssh config directory
+      file:
+        path: "/home/{{ server_user }}/release/.ssh/"
+        state: directory
+        mode: 0700
+        owner: "{{ server_user }}"
+      tags: docker_build
 
-    - name: Init | Generate and copy init script
-      template: src=./resources/jenkins.service.j2 dest=/lib/systemd/system/jenkins.service
-      tags: init
+    - name: SSH | Copy release ssh config
+      template:
+        src: ./resources/release_ssh_config
+        dest: "/home/{{ server_user }}/release/.ssh/config"
+        mode: 0600
+        owner: "{{ server_user }}"
+      tags: docker_init
 
-    - name: Init | Start Jenkins
-      service: name=jenkins state=started enabled=yes
-      tags: init
+    - name: SSH | Copy release ssh staging key
+      template:
+        src: ./resources/node-www-staging-key
+        dest: "/home/{{ server_user }}/release/.ssh/node-www-staging"
+        mode: 0600
+        owner: "{{ server_user }}"
+      tags: docker_init

--- a/setup/ubuntu16.04_docker_alpine3.4/ansible-vars.yaml
+++ b/setup/ubuntu16.04_docker_alpine3.4/ansible-vars.yaml
@@ -1,0 +1,4 @@
+---
+server_user: iojs
+packages:
+  - curl

--- a/setup/ubuntu16.04_docker_alpine3.4/ansible.cfg
+++ b/setup/ubuntu16.04_docker_alpine3.4/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles/

--- a/setup/ubuntu16.04_docker_alpine3.4/requirements.yml
+++ b/setup/ubuntu16.04_docker_alpine3.4/requirements.yml
@@ -1,0 +1,1 @@
+- src: angstwad.docker_ubuntu

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/.gitignore
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/.gitignore
@@ -1,0 +1,1 @@
+node-www-staging-key

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
@@ -1,0 +1,47 @@
+FROM alpine:3.4
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV HOME /home/{{ server_user }}
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV PATH /usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV OSTYPE linux-gnu
+ENV DESTCPU x64
+ENV ARCH x64
+
+RUN apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        binutils-gold \
+        curl \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        paxctl \
+        python \
+        tar \
+        ccache \
+        openjdk8 \
+        git \
+        procps \
+        openssh-client
+
+RUN addgroup -g 1000 {{ server_user }}
+
+RUN adduser -G {{ server_user }} -D -u 1000 {{ server_user }}
+
+VOLUME [ "/home/{{ server_user }}/" ]
+
+USER iojs
+
+CMD cd /home/iojs \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java \
+      -jar slave.jar \
+      -jnlpUrl https://ci.nodejs.org/computer/test-digitalocean-ubuntu1604_docker_alpine34-x64-1/slave-agent.jnlp \
+      -secret efbfadbf4807af0f1084a1e120ef5467b49432113661e11ce2ecc1ab71b96f38

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
@@ -29,7 +29,8 @@ RUN apk add --no-cache \
         openjdk8 \
         git \
         procps \
-        openssh-client
+        openssh-client \
+        bash
 
 RUN addgroup -g 1000 {{ server_user }}
 

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/Dockerfile.j2
@@ -8,6 +8,7 @@ ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
 ENV PATH /usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
 ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
 ENV DESTCPU x64
 ENV ARCH x64
 
@@ -44,5 +45,5 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java \
       -jar slave.jar \
-      -jnlpUrl https://ci.nodejs.org/computer/test-digitalocean-ubuntu1604_docker_alpine34-x64-1/slave-agent.jnlp \
-      -secret efbfadbf4807af0f1084a1e120ef5467b49432113661e11ce2ecc1ab71b96f38
+      -jnlpUrl https://{{ ci_host }}/computer/{{ image_type }}-digitalocean-ubuntu1604_docker_alpine34-x64-1/slave-agent.jnlp \
+      -secret {{ secret }}

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/jenkins.service.j2
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/jenkins.service.j2
@@ -9,8 +9,8 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}:/home/{{ server_user }} --name node-ci-alpine node-ci:alpine-build
-ExecStop=/usr/bin/docker stop -t 5 node-ci-alpine
+ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}/{{ image_type }}:/home/{{ server_user }} --name node-ci-alpine-{{ image_type }} node-ci:alpine-{{ image_type }}
+ExecStop=/usr/bin/docker stop -t 5 node-ci-alpine-{{ image_type }}
 Restart=always
 RestartSec=30
 StartLimitInterval=0

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/jenkins.service.j2
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/jenkins.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Jenkins Slave in Docker
+Wants=network.target
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}:/home/{{ server_user }} --name node-ci-alpine node-ci:alpine-build
+ExecStop=/usr/bin/docker stop -t 5 node-ci-alpine
+Restart=always
+RestartSec=30
+StartLimitInterval=0

--- a/setup/ubuntu16.04_docker_alpine3.4/resources/release_ssh_config
+++ b/setup/ubuntu16.04_docker_alpine3.4/resources/release_ssh_config
@@ -1,0 +1,4 @@
+Host iojs-www node-www
+  HostName direct.nodejs.org
+  User staging
+  IdentityFile ~/.ssh/node-www-staging

--- a/setup/ubuntu16.04_docker_alpine3.4/tasks/setup-image.yaml
+++ b/setup/ubuntu16.04_docker_alpine3.4/tasks/setup-image.yaml
@@ -1,0 +1,41 @@
+---
+# requires: @image_type
+# requires: @ci_host
+# requires: @secret
+
+- name: Docker | Make build directory
+  file:
+    path: /root/{{ image_type }}
+    state: directory
+  tags: docker_build
+
+- name: Docker | Generate Dockerfile
+  template:
+    src: ./resources/Dockerfile.j2
+    dest: /root/{{ image_type }}/Dockerfile
+  tags: docker_build
+
+- name: Docker | Build Alpine image
+  command: docker build -t node-ci:alpine-{{ image_type }} /root/{{ image_type }}/
+  tags: docker_build
+
+- name: Docker | Make mountable home directory
+  file:
+    path: "/home/{{ server_user }}/{{ image_type }}"
+    state: directory
+    mode: 0755
+    owner: "{{ server_user }}"
+  tags: docker_build
+
+- name: Init | Generate and copy init script
+  template:
+    src: ./resources/jenkins.service.j2
+    dest: /lib/systemd/system/jenkins-{{ image_type }}.service
+  tags: docker_init
+
+- name: Init | Start Jenkins
+  service:
+    name: jenkins-{{ image_type }}
+    state: started
+    enabled: yes
+  tags: docker_init


### PR DESCRIPTION
This adds a config for Ubuntu 16.04 + Docker that builds and manages an Alpine Linux 3.3 container which has the Jenkins slave running inside it.

After some digging I discovered that the preferable way to run Node in Alpine is to build it in alpine rather than reusing binaries that we build for generic Linux. Initially I started down the track of emulating our nodejs.org binaries by building in a CentOS 5 container before transferring to the Alpine container for testing. I scrapped that and went for everything in Alpine, assuming that we're going to ship images with binaries created inside them specifically for Alpine.

I'm using 3.3 because I had trouble getting 3.4 to run. It doesn't seem to like something about the combination of the mount point and the `CMD` and gives a weird `sh` error (`su: can't execute ',,,:/home/': No such file or directory` if anyone wants to chase this up).

It's temporarily in CI, you can see an example run @ https://ci.nodejs.org/job/node-test-commit-linux/nodes=ubuntu1604_docker_alpine34-64/3796 (the host is misnamed btw, it's "alpine34" but should be "alpine33").

Failures that we have are:
- parallel/test-net-better-error-messages-port-hostname
- parallel/test-net-connect-immediate-finish
- parallel/test-os
- parallel/test-process-getgroups
- parallel/test-setproctitle

If we don't have a path to resolving these fairly quickly then we should remove it from CI so collaborators don't get upset at all their runs failing. ATM I don't think we have a way of marking these tests flaky _just_ for Alpine, it's done by operating system, not distro.

Where to next?

/cc @nodejs/docker @nodejs/testing @mhart 
