### PR TITLE
github-bot: ansible setup

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -149,3 +149,6 @@ test-ibm-aix61-ppc64-1:18822
 [iojs-build-rhel72-linuxonecc]
 test-linuxonecc-rhel72-s390x-1
 test-linuxonecc-rhel72-s390x-2
+
+[github-bot]
+infra-rackspace-debian8-x64-1

--- a/setup/github-bot/README.md
+++ b/setup/github-bot/README.md
@@ -1,0 +1,19 @@
+# Node.js build Debian setup for github-bot
+
+Add this to your ssh config:
+
+```text
+Host infra-rackspace-debian8-x64-1
+  HostName 23.253.100.79
+```
+
+Run playbook:
+
+```bash
+$ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
+```
+
+If you need to restart github-bot:
+```bash
+$ systemctl restart github-bot
+```

--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -1,0 +1,71 @@
+---
+- hosts: github-bot
+  remote_user: root
+  gather_facts: False
+
+  tasks:
+
+    - name: Bootstrap | Install baseline packages
+      raw: apt-get install -y aptitude python-apt apt-transport-https
+      tags: bootstrap
+
+- hosts: github-bot
+  remote_user: root
+
+  tasks:
+
+    - include_vars: ansible-vars.yaml
+      tags: vars
+
+    - name: General | Add the NodeSource GPG key
+      apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+      tags: general
+
+    - name: General | Add the NodeSource Node.js repo
+      apt_repository: repo='deb https://deb.nodesource.com/node_6.x jessie main' state=present
+      tags: general
+
+    - name: General | APT Update and upgrade
+      apt: update_cache=yes upgrade=full
+      tags: general
+
+    - name: General | Install required packages
+      apt: name="{{ item }}" state=latest
+      with_items: "{{ packages }}"
+      tags: general
+
+    - name: General | Enable time syncing
+      service: name=systemd-timesyncd state=started enabled=yes
+      tags: general
+
+    - name: User | Add {{ server_user }} user
+      user: name="{{ server_user }}" shell=/bin/bash
+      tags: user
+
+    - name: Init | Generate and copy init script
+      template: src=./resources/github-bot.service dest=/lib/systemd/system/github-bot.service
+      tags: init
+
+    - name: Init | Create directory for EnvironmentFile
+      file: path="/home/{{ server_user }}/environment" state=directory mode=0755 owner="{{ server_user }}"
+      tags: init
+
+    - name: Init | Generate and copy systemd EnvironmentFile
+      template: src=./resources/environment-file dest="/home/{{ server_user }}/environment/github-bot"
+      tags: init
+
+    - name: Init | Clone github-bot repo
+      become: yes
+      become_user: "{{ server_user }}"
+      git: repo=https://github.com/nodejs/github-bot.git dest="/home/{{ server_user }}/github-bot"
+      tags: init
+
+    - name: Init | Install npm dependencies
+      become: yes
+      become_user: "{{ server_user }}"
+      npm: path="/home/{{ server_user }}/github-bot"
+      tags: init
+
+    - name: Init | Start github-bot
+      service: name=github-bot state=started enabled=yes
+      tags: init

--- a/setup/github-bot/ansible-vars.yaml
+++ b/setup/github-bot/ansible-vars.yaml
@@ -1,0 +1,5 @@
+---
+server_user: iojs
+packages:
+  - git
+  - nodejs

--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -1,0 +1,6 @@
+NODE_ENV=production
+PORT={{envs.port}}
+TRAVIS_TOKEN={{envs.travis_token}}
+GITHUB_TOKEN={{envs.github_token}}
+GITHUB_WEBHOOK_SECRET={{envs.github_webhook_secret}}
+LOGIN_CREDENTIALS={{envs.login_credentials}}

--- a/setup/github-bot/resources/github-bot.service
+++ b/setup/github-bot/resources/github-bot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=github-bot
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/node server.js
+EnvironmentFile=/home/{{server_user}}/environment/github-bot
+WorkingDirectory=/home/{{server_user}}/github-bot
+Restart=always
+RestartSec=10
+User={{server_user}}


### PR DESCRIPTION
Sooo, here's my first shot at creating an ansible setup for the bot. Has been run on the test host @jbergstroem created for this purpose, seems to be working nicely.

Primarly installs necessary binaries, checks out the application code from github.com, before starting the created systemd service which runs (and supervises) `npm start`.

As there's a big ansible refactor just around the corner, these changes doesn't need to be merged asap, but would be nice to get some feedback about obviously missing/wrong parts.