### PR TITLE
iptables/dgram: Allow local origin traffic on the test port

### DIFF
--- a/setup/fedora22/ansible-playbook.yaml
+++ b/setup/fedora22/ansible-playbook.yaml
@@ -42,6 +42,32 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
+    - name: Firewall | check basic rule to allow test port communication
+      command: iptables -C INPUT -p udp --dport 12346 -j ACCEPT
+      register: iptables_find_basic
+      ignore_errors: True
+      tags: firewall
+
+    - name: Firewall | add basic rule to allow test port communication
+      command: firewall-cmd --permanent --direct --passthrough ipv4 -I INPUT 1 -p udp --dport 12346 -j ACCEPT
+      when: iptables_find_basic|failed
+      tags: firewall
+
+    - name: Firewall | check rule to prevent external communication on test port
+      command: iptables -t nat -C PREROUTING -p udp --dport 12346 -j DNAT --to 127.0.0.1:12345
+      register: iptables_find_dnat
+      ignore_errors: True
+      tags: firewall
+
+    - name: Firewall | add rule to prevent external communication on test port
+      command: firewall-cmd --permanent --direct --passthrough ipv4 -t nat -I PREROUTING 1 -p udp --dport 12346 -j DNAT --to 127.0.0.1:12345
+      when: iptables_find_dnat|failed
+      tags: firewall
+
+    - name: Firewall | load the new permanent firewall configuration
+      command: firewall-cmd --reload
+      tags: firewall
+
     - name: Jenkins | Download Jenkins' slave.jar
       command: curl -sL https://ci.nodejs.org/jnlpJars/slave.jar -o /home/{{ server_user }}/slave.jar
       tags: jenkins

--- a/setup/rhel72-linuxonecc/ansible-playbook.yaml
+++ b/setup/rhel72-linuxonecc/ansible-playbook.yaml
@@ -39,16 +39,52 @@
       user: name="{{ server_user }}" shell=/bin/bash home=/data/iojs
       tags: user
 
+    - name: Firewall | check basic rule to allow communication locally
+      command: iptables -C INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT
+      register: iptables_find_local
+      ignore_errors: True
+      tags: firewall
+
     - name: Firewall | add basic rule to allow communication locally
-      lineinfile: dest=/etc/sysconfig/iptables insertafter=":OUTPUT ACCEPT.*]" line="-A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT"
+      command: iptables -I INPUT 1 -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT
+      when: iptables_find_local|failed
+      tags: firewall
+
+    - name: Firewall | check additional rule to allow communication from 127.0.0.2
+      command: iptables -C INPUT -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT
+      register: iptables_find_local2
+      ignore_errors: True
       tags: firewall
 
     - name: Firewall | add additional rule to allow communication from 127.0.0.2
-      lineinfile: dest=/etc/sysconfig/iptables insertafter=":OUTPUT ACCEPT.*]" line="-A INPUT -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT"
+      command: iptables -I INPUT 1 -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT
+      when: iptables_find_local2|failed
       tags: firewall
 
-    - name: Firewall | make the new firewall rules take effect
-      command: systemctl restart iptables
+    - name: Firewall | check basic rule to allow communication on test port
+      command: iptables -C INPUT -p udp --dport 12346 -j ACCEPT
+      register: iptables_find_testport
+      ignore_errors: True
+      tags: firewall
+
+    - name: Firewall | add basic rule to allow communication on test port
+      command: iptables -I INPUT 1 -p udp --dport 12346 -j ACCEPT
+      when: iptables_find_testport|failed
+      tags: firewall
+
+    - name: Firewall | check rule to prevent external communication to test port
+      command: iptables -t nat -C PREROUTING -p udp --dport 12346 -j DNAT --to 127.0.0.1:12345
+      register: iptables_find_nattestport
+      ignore_errors: True
+      tags: firewall
+
+    - name: Firewall | add rule to prevent external communication to test port
+      command: iptables -t nat -A PREROUTING -p udp --dport 12346 -j DNAT --to 127.0.0.1:12345
+      when: iptables_find_nattestport|failed
+      tags: firewall
+
+    - name: Firewall | add basic rule to allow communication locally
+      shell: iptables-save > /etc/sysconfig/iptables
       tags: firewall
 
     - name: Jenkins | Download Jenkins slave.jar


### PR DESCRIPTION
Some Fedora/Redhat versions have overly restrictive firewall rules
that prevent local tests involving the system's real IP or
multicast IPs.

While making this [putback with a dgram multicast test](https://github.com/nodejs/node/pull/7855), I encountered issues with several systems that stem from their default iptables rules. I have done some testing on fedora 22 to determine a correct configuration to allow local tests on the test port without opening it for remote traffic. I have used these changes to make changes that I think will work for redhat 7.2, but I don't have access to one of these systems.
