### PR TITLE
github-bot: auto deploy upon new commits

### DIFF
--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -85,7 +85,7 @@
       template:
         src=./resources/deploy-github-bot.sh
         dest="/home/{{ server_user }}/bin/deploy-github-bot.sh"
-        mode=0744
+        mode=0755
         owner="{{ server_user }}"
       tags: deploy-webhook
 

--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -42,12 +42,13 @@
       user: name="{{ server_user }}" shell=/bin/bash
       tags: user
 
-    - name: Init | Generate and copy init script
-      template: src=./resources/github-bot.service dest=/lib/systemd/system/github-bot.service
+    - name: Init | Create required directories
+      file: path="/home/{{ server_user }}/{{ item }}" state=directory mode=0755 owner="{{ server_user }}"
+      with_items: "{{ required_dirs }}"
       tags: init
 
-    - name: Init | Create directory for EnvironmentFile
-      file: path="/home/{{ server_user }}/environment" state=directory mode=0755 owner="{{ server_user }}"
+    - name: Init | Generate and copy init script
+      template: src=./resources/github-bot.service dest=/lib/systemd/system/github-bot.service
       tags: init
 
     - name: Init | Generate and copy systemd EnvironmentFile
@@ -63,9 +64,41 @@
     - name: Init | Install npm dependencies
       become: yes
       become_user: "{{ server_user }}"
-      npm: path="/home/{{ server_user }}/github-bot"
+      npm: path="/home/{{ server_user }}/github-bot" production=yes
       tags: init
 
     - name: Init | Start github-bot
       service: name=github-bot state=started enabled=yes
       tags: init
+
+    - name: GitHub Deploy Webhook | Install github-webhook
+      npm: name=github-webhook global=yes
+      tags: deploy-webhook
+
+    - name: GitHub Deploy Webhook | Copy config
+      template:
+        src=./resources/github-bot-deploy-webhook.json
+        dest="/home/{{ server_user }}/config/github-bot-deploy-webhook.json"
+      tags: deploy-webhook
+
+    - name: GitHub Deploy Webhook | Copy deploy script
+      template:
+        src=./resources/deploy-github-bot.sh
+        dest="/home/{{ server_user }}/bin/deploy-github-bot.sh"
+        mode=0744
+        owner="{{ server_user }}"
+      tags: deploy-webhook
+
+    - name: GitHub Deploy Webhook | Generate and copy service script
+      template:
+        src=./resources/github-bot-deploy-webhook.service
+        dest=/lib/systemd/system/github-bot-deploy-webhook.service
+      tags: deploy-webhook
+
+    - name: GitHub Deploy Webhook | Start service
+      service: name=github-bot-deploy-webhook state=started
+      tags: deploy-webhook
+
+    - name: GitHub Deploy Webhook | Allow user to restart github-bot
+      lineinfile: "dest=/etc/sudoers state=present regexp='^{{ server_user }}' line='{{ server_user }} ALL=(ALL) NOPASSWD: /bin/systemctl restart github-bot'"
+      tags: deploy-webhook

--- a/setup/github-bot/ansible-vars.yaml
+++ b/setup/github-bot/ansible-vars.yaml
@@ -3,3 +3,9 @@ server_user: iojs
 packages:
   - git
   - nodejs
+required_dirs:
+  - bin
+  - config
+  - environment
+  - logs
+

--- a/setup/github-bot/resources/deploy-github-bot.sh
+++ b/setup/github-bot/resources/deploy-github-bot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+pidof -s -o '%PPID' -x $(basename $0) > /dev/null 2>&1 && \
+  echo "$(basename $0) already running" && \
+  exit 1
+
+cd /home/{{server_user}}/github-bot
+git reset --hard
+git clean -fdx
+git fetch origin
+git checkout origin/master
+
+npm install --cache-min 1440 --production
+sudo systemctl restart github-bot

--- a/setup/github-bot/resources/github-bot-deploy-webhook.json
+++ b/setup/github-bot/resources/github-bot-deploy-webhook.json
@@ -1,7 +1,7 @@
 {
   "port": 9999,
   "path": "/deploy-webhook",
-  "secret": "{{ envs.github_webhook_secret }}",
+  "secret": "{{ conf.github_deploy_webhook_secret }}",
   "log": "/home/{{ server_user }}/logs/github-bot-webhook.log",
   "rules": [
     {

--- a/setup/github-bot/resources/github-bot-deploy-webhook.json
+++ b/setup/github-bot/resources/github-bot-deploy-webhook.json
@@ -1,0 +1,13 @@
+{
+  "port": 9999,
+  "path": "/deploy-webhook",
+  "secret": "{{ envs.github_webhook_secret }}",
+  "log": "/home/{{ server_user }}/logs/github-bot-webhook.log",
+  "rules": [
+    {
+      "event": "push",
+      "match": "ref == \"refs/heads/master\"",
+      "exec": "/home/{{ server_user }}/bin/deploy-github-bot.sh"
+    }
+  ]
+}

--- a/setup/github-bot/resources/github-bot-deploy-webhook.service
+++ b/setup/github-bot/resources/github-bot-deploy-webhook.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=github-bot-deploy-webhook
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/github-webhook --config config/github-bot-deploy-webhook.json
+WorkingDirectory=/home/{{server_user}}
+Restart=always
+RestartSec=10
+User={{server_user}}


### PR DESCRIPTION
This re-deploys the github-bot whenever new commits lands in the master branch. It's a simplified version of the nodejs.org setup, which roughly includes:
- A new web application needed as the GitHub webhook receiver, implemented with the [github-webhook npm package](https://www.npmjs.com/package/github-webhook).
- systemd service (`github-bot-deploy-webhook.service`) to run and monitor the webhook application.
- bash script (`deploy-github-bot.sh`) triggered by the webhook application which checks out the latest changes in the master branch and restarts the github-bot.service

Any thoughts more than welcome!

Refs https://github.com/nodejs/github-bot/issues/69
