### PR TITLE
www: enable fallback for Japanese locale

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -62,10 +62,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(es|it|ko|zh-cn|uk)/) {
+        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja)/) {
             set $lang $1;
         }
-        rewrite ^/(es|it|ko|zh-cn|uk)/(.*)$ /en/$2;
+        rewrite ^/(es|it|ko|zh-cn|uk|ja)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback
@@ -225,10 +225,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(es|it|ko|zh-cn|uk)/) {
+        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja)/) {
             set $lang $1;
         }
-        rewrite ^/(es|it|ko|zh-cn|uk)/(.*)$ /en/$2;
+        rewrite ^/(es|it|ko|zh-cn|uk|ja)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback


### PR DESCRIPTION
Japanese has been added to nodejs.org, these changes enabled the english fallback for pages the translation WG hasn't translated yet.

Refs: https://github.com/nodejs/nodejs.org/pull/900