### PR TITLE
build: add SSL_CERT_FILE env variable

### DIFF
--- a/setup/aix61/resources/S20jenkins
+++ b/setup/aix61/resources/S20jenkins
@@ -16,6 +16,7 @@ start )
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
               export OSTYPE=AIX61; \
               export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
+              export SSL_CERT_FILE="$HOME/ca-bundle.crt"; \
         java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'


### PR DESCRIPTION
When building v4.x ICU is downloaded and without
setting SSL_CERT_FILE the download fails on AIX
because by default the required certificates are not
found.  Add the SSL_CERT_FILE environment variable
to point to the certs we install as part of the
ansible configuration  in a manner similar to what
we already do for GIT_SSL_CAINFO.