### PR TITLE
github-bot: clone nodejs/node repository

### DIFF
--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -102,3 +102,9 @@
     - name: GitHub Deploy Webhook | Allow user to restart github-bot
       lineinfile: "dest=/etc/sudoers state=present regexp='^{{ server_user }}' line='{{ server_user }} ALL=(ALL) NOPASSWD: /bin/systemctl restart github-bot'"
       tags: deploy-webhook
+
+    - name: Runtime dependencies | Clone node repo
+      become: yes
+      become_user: "{{ server_user }}"
+      git: repo=https://github.com/nodejs/node.git dest="/home/{{ server_user }}/repos/node"
+      tags: runtime-dependencies

--- a/setup/github-bot/ansible-vars.yaml
+++ b/setup/github-bot/ansible-vars.yaml
@@ -8,4 +8,4 @@ required_dirs:
   - config
   - environment
   - logs
-
+  - repos

--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -4,3 +4,4 @@ TRAVIS_TOKEN={{envs.travis_token}}
 GITHUB_TOKEN={{envs.github_token}}
 GITHUB_WEBHOOK_SECRET={{envs.github_webhook_secret}}
 LOGIN_CREDENTIALS={{envs.login_credentials}}
+NODE_REPO_DIR=/home/{{server_user}}/repos/node


### PR DESCRIPTION
These changes clones the nodejs/node repository required for the bot to automatically attempt backport of new PRs.

Refs https://github.com/nodejs/github-bot/pull/90

/cc @nodejs/github-bot 