### PR TITLE
Update Vagrantfile in local ansible test guide

### DIFF
--- a/setup/TESTING_LOCALLY.md
+++ b/setup/TESTING_LOCALLY.md
@@ -17,18 +17,23 @@ Create a directory with a file named `Vagrantfile` inside it, somewhere outside 
 The `Vagrantfile` configures the virtual machine about to be created, with the following:
 
 1. Specify which OS we want
-2. Use root as user (rather than the default vagrant user)
-3. Prevent Vagrant from generating a random SSH key
-4. Copy your own public SSH key onto the machine
+2. Prevent Vagrant from generating a random SSH key
+3. Copy your own public SSH key onto the machine
+4. Use your SSH key for the root user as well
 
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/jessie64"
 
-  config.ssh.username = 'root'
+  # the insecure key is needed for the first login attempt by vagrant itself
+  config.ssh.private_key_path = ["~/.ssh/id_rsa", "~/.vagrant.d/insecure_private_key"]
   config.ssh.insert_key = false
+  # fixes "stdin: is not a tty" error when provisioning
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
   config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/authorized_keys"
+  # allows us to ssh into the box as root
+  config.vm.provision "shell", inline: "mkdir /root/.ssh && cp /home/vagrant/.ssh/authorized_keys /root/.ssh/authorized_keys"
 end
 ```
 


### PR DESCRIPTION
For some reason, the previous Vagrantfile example didn't work anymore. When running `vagrant up` the root user was simply not able to do the initial login to the server anymore, it stalled at:

```
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: root
    default: SSH auth method: private key
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
```

Therefore the virtual machine setup procedure had to be manually aborted.

With these changes, we don't initially login with root anymore as that turned out to be quite brittle. We now use the traditional vagrant user and copy the custom SSH key into root's .ssh-folder as the last step, still allowing us to login as root after the virtual machine has been setup.