### PR TITLE
github-bot: redirect stdout to file

### DIFF
--- a/setup/github-bot/resources/github-bot.service
+++ b/setup/github-bot/resources/github-bot.service
@@ -5,7 +5,7 @@ Description=github-bot
 WantedBy=multi-user.target
 
 [Service]
-ExecStart=/usr/bin/node server.js
+ExecStart=/usr/bin/node server.js &> /home/{{server_user}}/logs/github-bot.log
 EnvironmentFile=/home/{{server_user}}/environment/github-bot
 WorkingDirectory=/home/{{server_user}}/github-bot
 Restart=always


### PR DESCRIPTION
Fixes an issue we have currently, where all current logs are deleted whenever the bot is redeployed because of two things:

1. We have the github-bot repo cloned and write logs to a sub-directory of repo root (`logs`)
2. Upon deploy `git clean -fdx` deletes any untracked files in the repo

Simply writing out bunyan logs to stdout would also simplify our current log related code in the bot.

Is `logrotate` the way to go for rotating this?