### PR TITLE
doc: document process for access to jenkins jobs

### DIFF
--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -4,8 +4,9 @@ There are a number of cases were we would like working group members
 to be able to run and or edit jobs within jenkins. Examples include
 the CITGM jobs and the Benchmarking jobs.
 
-By default jobs can only be edited by build working group members
-and start/stopped etc. by collaborators. We do not give access to
+By default jobs can only be edited by members of the
+'nodejs/jenkins-admins' group which contains a subset of the build
+workgroup members. We do not give access to
 everbody to run/edit as it would be a potential security issue,
 both through the potential disclosure of secrets used as
 part of the builds, as well as a potential denial
@@ -16,75 +17,56 @@ people outside the build working group to edit jobs as well
 as allowing people who are not collaborators run specific jobs.
 
 Unfortunately jenkins does not allow us to easily delegate the
-creation of new jobs.  As such the creation of a new job will
+creation of new jobs in an appropriate manner.
+As such, the creation of a new job will
 need to be requested through an issue in the build repo.  Any
 build member can then create a blank job in the group for the
 working group which can then be edited by those with access
 to the jobs for that working group.
 
-## Ongoing access
+## Ability to run/cancel jobs
 
-In the first case we want to be able to provide ongoing access to
-an individual to edit or run a job associated with a working group
-when this supports the efforts of a working group/team. For
-example, some members of the benchmarking team will be regularly
-modifying benchmarking jobs and therefore the ability to configure
-benchmarking jobs needs to be granted in an ongoing manner.
+All members of a workgroup will be able to run and cancel
+the jobs tied to their workgroup.  This will be accomplished
+by enabling project-based security for the jobs and adding
+the group corresponding to the github team for the
+working group where the Build/Cancel rights have been
+enabled.
 
-In these cases the following will be used to decide if ongoing access
-can be provided:
+## Ability to modify jobs
+
+A subset of the members of a workgroup will be able to modify
+and delete jobs. This will be accomplished by enabling
+project-based security for the jobs and adding the group
+corresponding to the github team for the working group admins
+where there Build/Cancel/Discover/Read/Delete/Update
+rights have been set.
+
+Since the ability to modify jobs opens up new attack vectors,
+we ask that the workgroups limit this access to those
+individuals that require it, and when appropriate the length,
+of time access is granted.
+
+In the case of granting access to edit jobs the following
+should be considered:
 
 * Does the scope and size of the need justify providing access.
-* Is the invidual a collaborator? If so then access should be allowed
-  provided the first point is satisfied.
+* Is the invidual a Node.js collaborator? If so then access should
+  be allowed provided the first point is satisfied.
 * Length and consistency of involvement with Node.js working groups
   and/or community.
-* Consequences to the invidudal in case of mis-bahaviour. For example,
+* Consequences to the invidudal in case of mis-behaviour. For example,
   would they potentially lose their job if they were reported as
   mis-behaving to their employer ? Would being banned from involvement
-  in the Node.js community negatively affect them personally in some other
-  way ?
-* Are there collaborators who work with the individual and can vouch for
-  them.
+  in the Node.js community negatively affect them personally
+  in some other way ?
+* Are there collaborators who work with the individual and can vouch
+  for them.
 
-The build team will review such requests through an issue on the build
-repo which lists:
+It is suggested that this consideration be documented in an
+issue on the workgroups repo.
 
-* individual
-* collaborator status
-* information supporting request as per the items listed above
-* run/cancel requested: yes/no
-* edit requested: yes/no
-* Period requested for:  Indefinite or a specific from -> to
-
-The request should start with 2 lgtms from working group members and
-then the the build WG will review and vote on the request.
-
-Once approved the individual will be
-added to the list of people who can either
-
-* run/cancel the job
-* edit the job
-
-The minimum required level of access needed to get the job
-done should be requested.
-
-## Temporary access
-
-Collaborators can be given temporary access to edit jobs without
-further process (They already have access to run/cancel jobs).
-A simple request as an issue in the build repo from one of the
-other working group members (ex CITGM or benchmarking WG), with
-the period for which is being requested will be sufficient.
-Any member of the build
-working group can validate their collaborator status and provide
-access for up to 1 month.  The issue for the request will stay
-open in the repo until access is removed.
-
-For non-collaborators, if the considerations listed for ongoing
-access are satisfied, access can
-be granted after discussion in a issue on the repo and 2 lgtms
-from a build team member (1 working group team member raises issue
-2 build working group members lgtm).  The issue will remain
-open in the build repo until access is removed.
+Once approved by the working group and existing workgroup admins, one
+of the existing workgroup admins can then add the new individual to
+the github admin team for the workgroup (ex benchmarking-admins).
 

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -48,7 +48,7 @@ Since the ability to modify jobs opens up new attack vectors,
 we ask that the working group limits this access to those
 individuals that require it, and when appropriate, the length
 of time access is granted. In addition, since build resources
-are finate we also ask that the working group members are
+are finite we also ask that the working group members are
 mindful of the number of long-running jobs that they start.
 In particular, spawning long-running jobs on arm and windows
 can easily pile up.

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -1,0 +1,90 @@
+# Introduction
+
+There are a number of cases were we would like working group members
+to be able to run and or edit jobs within jenkins. Examples include
+the CITGM jobs and the Benchmarking jobs.
+
+By default jobs can only be edited by build working group members
+and start/stopped etc. by collaborators. We do not give access to
+everbody to run/edit as it would be a potential security issue,
+both through the potential disclosure of secrets used as
+part of the builds, as well as a potential denial
+of service if jobs are launched maliciously.
+
+This document outlines the processes by which we will allow
+people outside the build working group to edit jobs as well
+as allowing people who are not collaborators run specific jobs.
+
+Unfortunately jenkins does not allow us to easily delegate the
+creation of new jobs.  As such the creation of a new job will
+need to be requested through an issue in the build repo.  Any
+build member can then create a blank job in the group for the
+working group which can then be edited by those with access
+to the jobs for that working group.
+
+## Ongoing access
+
+In the first case we want to be able to provide ongoing access to
+an individual to edit or run a job associated with a working group
+when this supports the efforts of a working group/team. For
+example, some members of the benchmarking team will be regularly
+modifying benchmarking jobs and therefore the ability to configure
+benchmarking jobs needs to be granted in an ongoing manner.
+
+In these cases the following will be used to decide if ongoing access
+can be provided:
+
+* Does the scope and size of the need justify providing access.
+* Is the invidual a collaborator? If so then access should be allowed
+  provided the first point is satisfied.
+* Length and consistency of involvement with Node.js working groups
+  and/or community.
+* Consequences to the invidudal in case of mis-bahaviour. For example,
+  would they potentially lose their job if they were reported as
+  mis-behaving to their employer ? Would being banned from involvement
+  in the Node.js community negatively affect them personally in some other
+  way ?
+* Are there collaborators who work with the individual and can vouch for
+  them.
+
+The build team will review such requests through an issue on the build
+repo which lists:
+
+* individual
+* collaborator status
+* information supporting request as per the items listed above
+* run/cancel requested: yes/no
+* edit requested: yes/no
+* Period requested for:  Indefinite or a specific from -> to
+
+The request should start with 2 lgtms from working group members and
+then the the build WG will review and vote on the request.
+
+Once approved the individual will be
+added to the list of people who can either
+
+* run/cancel the job
+* edit the job
+
+The minimum required level of access needed to get the job
+done should be requested.
+
+## Temporary access
+
+Collaborators can be given temporary access to edit jobs without
+further process (They already have access to run/cancel jobs).
+A simple request as an issue in the build repo from one of the
+other working group members (ex CITGM or benchmarking WG), with
+the period for which is being requested will be sufficient.
+Any member of the build
+working group can validate their collaborator status and provide
+access for up to 1 month.  The issue for the request will stay
+open in the repo until access is removed.
+
+For non-collaborators, if the considerations listed for ongoing
+access are satisfied, access can
+be granted after discussion in a issue on the repo and 2 lgtms
+from a build team member (1 working group team member raises issue
+2 build working group members lgtm).  The issue will remain
+open in the build repo until access is removed.
+

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -7,7 +7,7 @@ the CITGM jobs and the Benchmarking jobs.
 By default jobs can only be edited by members of the
 [@nodejs/jenkins-admins](https://github.com/orgs/nodejs/teams/jenkins-admins)
 group which contains a subset of the build
-workgroup members. We do not give access to
+working group members. We do not give access to
 everybody to run/edit as it would be a potential security issue,
 both through the potential disclosure of secrets used as
 part of the builds, as well as a potential denial
@@ -24,30 +24,34 @@ need to be requested through an issue in the build repo. Any
 build member can then create a blank job in the group for the
 working group which can then be edited by those with access
 to the jobs for that working group. As and when more jobs are
-needed, a build member can clone one of the workgroup's 
+needed, a build member can clone one of the working group's 
 existing jobs, which will preserve the right permissions.
 
 ## Ability to run/cancel jobs
 
-All members of a workgroup will be able to run and cancel
-the jobs tied to their workgroup. This will be accomplished
+All members of a working group will be able to run and cancel
+the jobs tied to their working group. This will be accomplished
 by enabling project-based security for the jobs, and then
 giving the jenkins group, corresponding to the github
-team for the workgroup, Build/Cancel permissions.
+team for the working group, Build/Cancel permissions.
 
 ## Ability to modify jobs
 
-A subset of the members of a workgroup will be able to modify
+A subset of the members of a working group will be able to modify
 and delete jobs.  This will be accomplished
 by enabling project-based security for the jobs, and then
 giving the jenkins group, corresponding to the github
-team for the workgroup admins,
+team for the working group admins,
 the Build/Cancel/Discover/Read/Delete/Update permissions.
 
 Since the ability to modify jobs opens up new attack vectors,
-we ask that the workgroups limit this access to those
+we ask that the working group limits this access to those
 individuals that require it, and when appropriate, the length
-of time access is granted.
+of time access is granted. In addition, since build resources
+are finate we also ask that the working group members are
+mindful of the number of long-running jobs that they start.
+In particular, spawning long-running jobs on arm and windows
+can easily pile up.
 
 In the case of granting access to edit jobs the following
 should be considered:
@@ -66,9 +70,10 @@ should be considered:
   for them.
 
 It is suggested that this consideration be documented in an
-issue on the workgroups repo.
+issue on the working groups repo.
 
-Once approved by the working group and existing workgroup admins, one
-of the existing workgroup admins can then add the new individual to
-the github admin team for the workgroup (e.g. benchmarking-admins).
+Once approved by the working group and existing working group admins,
+one of the existing working group admins can then add the new
+individual to the github admin team for the working group
+(e.g. benchmarking-admins).
 

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -1,6 +1,6 @@
 # Introduction
 
-There are a number of cases were we would like working group members
+There are a number of cases where we would like working group members
 to be able to run and or edit jobs within jenkins. Examples include
 the CITGM jobs and the Benchmarking jobs.
 
@@ -19,10 +19,12 @@ as allowing people who are not collaborators run specific jobs.
 Unfortunately jenkins does not allow us to easily delegate the
 creation of new jobs in an appropriate manner.
 As such, the creation of a new job will
-need to be requested through an issue in the build repo.  Any
+need to be requested through an issue in the build repo. Any
 build member can then create a blank job in the group for the
 working group which can then be edited by those with access
-to the jobs for that working group.
+to the jobs for that working group. As and when more jobs are
+needed, a build member can clone one of the workgroup's 
+existing jobs, which will preserve the right permissions.
 
 ## Ability to run/cancel jobs
 
@@ -44,7 +46,7 @@ rights have been set.
 
 Since the ability to modify jobs opens up new attack vectors,
 we ask that the workgroups limit this access to those
-individuals that require it, and when appropriate the length,
+individuals that require it, and when appropriate, the length
 of time access is granted.
 
 In the case of granting access to edit jobs the following
@@ -56,10 +58,10 @@ should be considered:
 * Length and consistency of involvement with Node.js working groups
   and/or community.
 * Consequences to the invidudal in case of mis-behaviour. For example,
-  would they potentially lose their job if they were reported as
-  mis-behaving to their employer ? Would being banned from involvement
+  would they potentially lose their job if they where reported as
+  mis-behaving to their employer? Would being banned from involvement
   in the Node.js community negatively affect them personally
-  in some other way ?
+  in some other way?
 * Are there collaborators who work with the individual and can vouch
   for them.
 
@@ -68,5 +70,5 @@ issue on the workgroups repo.
 
 Once approved by the working group and existing workgroup admins, one
 of the existing workgroup admins can then add the new individual to
-the github admin team for the workgroup (ex benchmarking-admins).
+the github admin team for the workgroup (e.g. benchmarking-admins).
 

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -5,16 +5,17 @@ to be able to run and or edit jobs within jenkins. Examples include
 the CITGM jobs and the Benchmarking jobs.
 
 By default jobs can only be edited by members of the
-'nodejs/jenkins-admins' group which contains a subset of the build
+[@nodejs/jenkins-admins](https://github.com/orgs/nodejs/teams/jenkins-admins)
+group which contains a subset of the build
 workgroup members. We do not give access to
-everbody to run/edit as it would be a potential security issue,
+everybody to run/edit as it would be a potential security issue,
 both through the potential disclosure of secrets used as
 part of the builds, as well as a potential denial
 of service if jobs are launched maliciously.
 
 This document outlines the processes by which we will allow
 people outside the build working group to edit jobs as well
-as allowing people who are not collaborators run specific jobs.
+as allowing people who are not collaborators to run specific jobs.
 
 Unfortunately jenkins does not allow us to easily delegate the
 creation of new jobs in an appropriate manner.
@@ -29,11 +30,11 @@ existing jobs, which will preserve the right permissions.
 ## Ability to run/cancel jobs
 
 All members of a workgroup will be able to run and cancel
-the jobs tied to their workgroup.  This will be accomplished
-by enabling project-based security for the jobs and adding
-the group corresponding to the github team for the
-working group where the Build/Cancel rights have been
-enabled.
+the jobs tied to their workgroup. This will be accomplished
+by enabling project-based security for the jobs, and then
+giving the jenkins group corresponding to the github
+team for the workgroup admins
+Build/Cancel/Discover/Read/Delete/Update permissions.
 
 ## Ability to modify jobs
 
@@ -58,7 +59,7 @@ should be considered:
 * Length and consistency of involvement with Node.js working groups
   and/or community.
 * Consequences to the invidudal in case of mis-behaviour. For example,
-  would they potentially lose their job if they where reported as
+  would they potentially lose their job if they were reported as
   mis-behaving to their employer? Would being banned from involvement
   in the Node.js community negatively affect them personally
   in some other way?

--- a/doc/process/jenkins_job_configuation_access.md
+++ b/doc/process/jenkins_job_configuation_access.md
@@ -32,18 +32,17 @@ existing jobs, which will preserve the right permissions.
 All members of a workgroup will be able to run and cancel
 the jobs tied to their workgroup. This will be accomplished
 by enabling project-based security for the jobs, and then
-giving the jenkins group corresponding to the github
-team for the workgroup admins
-Build/Cancel/Discover/Read/Delete/Update permissions.
+giving the jenkins group, corresponding to the github
+team for the workgroup, Build/Cancel permissions.
 
 ## Ability to modify jobs
 
 A subset of the members of a workgroup will be able to modify
-and delete jobs. This will be accomplished by enabling
-project-based security for the jobs and adding the group
-corresponding to the github team for the working group admins
-where there Build/Cancel/Discover/Read/Delete/Update
-rights have been set.
+and delete jobs.  This will be accomplished
+by enabling project-based security for the jobs, and then
+giving the jenkins group, corresponding to the github
+team for the workgroup admins,
+the Build/Cancel/Discover/Read/Delete/Update permissions.
 
 Since the ability to modify jobs opens up new attack vectors,
 we ask that the workgroups limit this access to those
@@ -54,11 +53,11 @@ In the case of granting access to edit jobs the following
 should be considered:
 
 * Does the scope and size of the need justify providing access.
-* Is the invidual a Node.js collaborator? If so then access should
+* Is the individual a Node.js collaborator? If so then access should
   be allowed provided the first point is satisfied.
 * Length and consistency of involvement with Node.js working groups
   and/or community.
-* Consequences to the invidudal in case of mis-behaviour. For example,
+* Consequences to the individual in case of mis-behaviour. For example,
   would they potentially lose their job if they were reported as
   mis-behaving to their employer? Would being banned from involvement
   in the Node.js community negatively affect them personally


### PR DESCRIPTION
Document process for allowing members outside
of the build working group the access required to be able
to edit or run jobs associated with their working group.