### PR TITLE
github-bot: config git author name and email

### DIFF
--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -108,3 +108,19 @@
       become_user: "{{ server_user }}"
       git: repo=https://github.com/nodejs/node.git dest="/home/{{ server_user }}/repos/node"
       tags: runtime-dependencies
+
+    - name: Runtime dependencies | Config node repo author email
+      become: yes
+      become_user: "{{ server_user }}"
+      shell: git config user.email "github-bot@nodejs.org"
+      args:
+        chdir: "/home/{{ server_user }}/repos/node"
+      tags: runtime-dependencies
+
+    - name: Runtime dependencies | Config node repo author name
+      become: yes
+      become_user: "{{ server_user }}"
+      shell: git config user.name "nodejs-github-bot"
+      args:
+        chdir: "/home/{{ server_user }}/repos/node"
+      tags: runtime-dependencies


### PR DESCRIPTION
Needed for the attempt-backport functionality of the bot since it does
some git actions requiring author name and email, such as `git am`.

Seeing this when running locally:

```
TASK [Runtime dependencies | Config node repo author email] ***********************
changed: [github-bot]
 [WARNING]: Consider using git module rather than running git
```

But as far as I see, manipulating config isn't possible with the [git module](http://docs.ansible.com/ansible/git_module.html). Found [git_config module](http://docs.ansible.com/ansible/git_config_module.html) tho, if we're fine with requiring ansible v2.1?

Refs: https://github.com/nodejs/build/issues/561

