### PR TITLE
Windows Ansible playbook optimization

### DIFF
--- a/setup/windows/vcbt2015-ansible-playbook.yaml
+++ b/setup/windows/vcbt2015-ansible-playbook.yaml
@@ -3,6 +3,14 @@
 
   tasks:
 
+    - name: Download and Install Windows Update
+      win_updates:
+        register: update_result
+    
+    - name: Reboot machine if necessary
+      win_reboot:
+        when: update_result.reboot_required 
+
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
 
@@ -28,6 +36,9 @@
             /Full
             /Log C:\TEMP\vsbt2015_install_log.txt'
       tags: [install, visualstudio]
+    
+    - name: Reboot machine after Visual C++ Build installation
+      win_reboot:
 
     - include: ./common-ansible-playbook.yaml
       tags: common

--- a/setup/windows/vs2013-ansible-playbook.yaml
+++ b/setup/windows/vs2013-ansible-playbook.yaml
@@ -2,6 +2,13 @@
 - hosts: node-windows
 
   tasks:
+    - name: Download and Install Windows Update
+      win_updates:
+        register: update_result
+    
+    - name: Reboot machine if necessary
+      win_reboot:
+        when: update_result.reboot_required 
 
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
@@ -16,6 +23,9 @@
       raw: 'C:\TEMP\vs2013_community.exe /Silent /NoRestart
             /Log C:\TEMP\vs2013_install_log.txt'
       tags: [install, visualstudio]
+    
+    - name: Reboot machine after Visual Studio installation
+      win_reboot:
 
     - include: ./common-ansible-playbook.yaml
       tags: common

--- a/setup/windows/vs2015-ansible-playbook.yaml
+++ b/setup/windows/vs2015-ansible-playbook.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: windows
+- hosts: node-windows
 
   tasks:
 

--- a/setup/windows/vs2015-ansible-playbook.yaml
+++ b/setup/windows/vs2015-ansible-playbook.yaml
@@ -1,7 +1,15 @@
 ---
-- hosts: node-windows
+- hosts: windows
 
   tasks:
+
+    - name: Download and Install Windows Update
+      win_updates:
+        register: update_result
+    
+    - name: Reboot machine if necessary
+      win_reboot:
+        when: update_result.reboot_required 
 
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
@@ -17,6 +25,9 @@
             /InstallSelectableItems NativeLanguageSupport_Group
             /Log C:\TEMP\vs2015_install_log.txt'
       tags: [install, visualstudio]
-
+    
+    - name: Reboot machine after Visual Studio installation
+      win_reboot:
+         
     - include: ./common-ansible-playbook.yaml
       tags: common


### PR DESCRIPTION
Starting from suggestions for a good first contribution that I received (https://github.com/nodejs/build/issues/495) I've  added few extra steps to Windows Ansible scripts:

- Force Windows to do update
- Reboot machine if necessary after update installation
- Reboot machine after Visual Studio installation 

As per https://github.com/nodejs/build/issues/574 @joaocgreis can you test it on Windows 2008 Server R2 ? I already tested it on windows 10 and Windows Server 2012.