### PR TITLE
github-bot: add $LOGS_DIR env variable

### DIFF
--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -5,3 +5,4 @@ GITHUB_TOKEN={{envs.github_token}}
 GITHUB_WEBHOOK_SECRET={{envs.github_webhook_secret}}
 LOGIN_CREDENTIALS={{envs.login_credentials}}
 NODE_REPO_DIR=/home/{{server_user}}/repos/node
+LOGS_DIR=/home/{{server_user}}/logs


### PR DESCRIPTION
We've had an issue with all logs written by the github-bot being deleted whenever the bot is re-deployed. That's especially bad when we want to debug issues happening a few days ago, which would be impossible if we've done a re-deploy in between.

The root cause of that issue is that we clone the github-bot repo onto the server and write logs to `./logs` of that cloned repo. Whenever we re-deploy we run `git clean -fdx` before updating the repo, resulting in any untracked files to be deleted.

By adding a `$LOGS_DIR` pointing to a directory *outside* the git repo,
will prevent logs being deleted cause of re-deploys.

~P.S. we haven't added support for `$LOGS_DIR` in the bot yet, will do that as soon as this lands.~