### PR TITLE
github-bot: dont update nodejs/node repo

### DIFF
--- a/setup/github-bot/ansible-playbook.yaml
+++ b/setup/github-bot/ansible-playbook.yaml
@@ -106,7 +106,7 @@
     - name: Runtime dependencies | Clone node repo
       become: yes
       become_user: "{{ server_user }}"
-      git: repo=https://github.com/nodejs/node.git dest="/home/{{ server_user }}/repos/node"
+      git: repo=https://github.com/nodejs/node.git dest="/home/{{ server_user }}/repos/node" update=no
       tags: runtime-dependencies
 
     - name: Runtime dependencies | Config node repo author email


### PR DESCRIPTION
Chore to keep playbook running smoothly without errors being generated.

Got this error when running the playbook:

```bash
$ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
...
TASK [Runtime dependencies | Clone node repo] **********************************
fatal: [infra-rackspace-debian8-x64-1]: FAILED! => {"changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no)."}
```

Local changes to that nodejs/node repo is expected, as the github-bot continously tries to backport PR patches onto staging branches. Therefore simply avoiding this error by not trying to update that git repo at all when the playbook is run -- as long as it is present, we are happy.

Refs the ansible git module docs: http://docs.ansible.com/ansible/git_module.html#options