### PR TITLE
build: update jenkins agent to 256m

### DIFF
--- a/setup/ubuntu14.04/resources/jenkins.conf.j2
+++ b/setup/ubuntu14.04/resources/jenkins.conf.j2
@@ -20,7 +20,7 @@ setgid iojs
 setuid iojs
 
 script
-  exec java -Xmx128m -jar "$HOME/slave.jar" \
+  exec java -Xmx256m -jar "$HOME/slave.jar" \
 	-secret {{ secret }} \
 	-jnlpUrl https://ci.nodejs.org/computer/{{ inventory_hostname }}/slave-agent.jnlp
 end script


### PR DESCRIPTION
We seemed to be having out of memory issues on some machines.
For example:  https://github.com/nodejs/build/issues/548#issuecomment-269974066.
Bumping up to 256m seems to have resolved so modifying the
ansible config to reflect that.

Fixes: https://github.com/nodejs/build/issues/548