### PR TITLE
doc: update AIX curl instructions

### DIFF
--- a/setup/aix61/manualBootstrap.md
+++ b/setup/aix61/manualBootstrap.md
@@ -23,7 +23,6 @@ rpm -e git  # If necessary
 rpm -e curl # If necessary
 rpm -ivh curl-7.44.0-2.aix6.1.ppc.rpm
 rpm -i unzip-6.0-3.aix6.1.ppc.rpm
-export LIBPATH=/usr/lib # Needed to get curl to work
 ```
 
 #### gcc
@@ -40,7 +39,7 @@ sh install-gcc-rpm.sh
 #### git
 
 ```bash
-curl --insecure -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/git/git-2.8.1-1.aix6.1.ppc.rpm
+LIBPATH=/usr/lib curl --insecure -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/git/git-2.8.1-1.aix6.1.ppc.rpm
 rpm -ivh git-2.8.1-1.aix6.1.ppc.rpm
 ```
 
@@ -66,7 +65,7 @@ installp -Y -qaXgd . openssl openssh
 #### gettext, java, make
 
 ```bash
-curl --insecure -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/gettext/gettext-0.19.7-1.aix6.1.ppc.rpm
+LIBPATH=/usr/lib curl --insecure -O https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/gettext/gettext-0.19.7-1.aix6.1.ppc.rpm
 rpm -e gettext
 rpm -hUv gettext-0.19.7-1.aix6.1.ppc.rpm
 
@@ -75,7 +74,7 @@ gunzip Java7r1_64.jre.7.1.0.200.tar.gz
 tar -xvf Java7r1_64.jre.7.1.0.200.tar
 installp -agXYd . Java71_64.jre 2>&1 | tee installp.log
 
-curl --insecure -O http://www.oss4aix.org/download/everything/RPMS/make-3.82-1.aix5.3.ppc.rpm
+LIBPATH=/usr/lib curl --insecure -O http://www.oss4aix.org/download/everything/RPMS/make-3.82-1.aix5.3.ppc.rpm
 rpm -i make-3.82-1.aix5.3.ppc.rpm
 ```
 
@@ -94,7 +93,7 @@ sh install-libtool-rpm.sh
 #### pip
 
 ```bash
-curl https://bootstrap.pypa.io/get-pip.py | python
+LIBPATH=/usr/lib curl https://bootstrap.pypa.io/get-pip.py | python
 ln -s /opt/freeware/bin/pip /usr/bin/pip
 ```
 
@@ -107,7 +106,7 @@ Install on the new linux machines did not seem to work so use cp and chmod inste
 ```bash
 mkdir tmp
 cd tmp
-curl --insecure -O https://www.samba.org/ftp/ccache/ccache-3.2.7.tar.gz
+LIBPATH=/usr/lib curl --insecure -O https://www.samba.org/ftp/ccache/ccache-3.2.7.tar.gz
 gunzip ccache-3.2.7.tar.gz
 tar -xvf ccache-3.2.7.tar
 cd ccache-3.2.7


### PR DESCRIPTION
Setting the LIBPATH for curl breaks it for other programs (e.g. python), so we
need to only set it for the commands that need it.

cc/ @mhdawson 