### PR TITLE
ubuntu: bump gcc to 4.9 on 12.04

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -104,5 +104,12 @@ packages: {
     'g++',
     'gcc',
     'git',
+    ],
+
+  ubuntu12: [
+    'ccache',
+    'g++-4.9',
+    'gcc-4.9',
+    'git'
     ]
   }

--- a/setup/ubuntu12.04/ansible-vars.yaml
+++ b/setup/ubuntu12.04/ansible-vars.yaml
@@ -9,7 +9,7 @@ packages:
   - automake
   - libtool
   - curl
-  - gcc-4.8
-  - g++-4.8
+  - gcc-4.9
+  - g++-4.9
   - ccache
   - subversion


### PR DESCRIPTION
The latest version of 4.8 available for 12.04 is 4.8.4.
It is not able to build V8 from version 5.7 and does not
satisfy the requirements to build Node.js.

Refs: https://github.com/nodejs/node/pull/11840
Refs: https://github.com/nodejs/v8/issues/5

/cc @nodejs/build @bnoordhuis @rvagg 