### PR TITLE
github-bot: add Jenkins $ENVs to kick off builds for CITGM

### DIFF
--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -6,3 +6,6 @@ GITHUB_WEBHOOK_SECRET={{envs.github_webhook_secret}}
 LOGIN_CREDENTIALS={{envs.login_credentials}}
 NODE_REPO_DIR=/home/{{server_user}}/repos/node
 LOGS_DIR=/home/{{server_user}}/logs
+JENKINS_API_CREDENTIALS={{envs.jenkins_api_credentials}}
+JENKINS_JOB_URL_CITGM={{envs.jenkins_job_url_citgm}}
+JENKINS_BUILD_TOKEN_CITGM={{envs.jenkins_build_token_citgm}}


### PR DESCRIPTION
These $ENVs are needed for @nodejs-github-bot to kick off Jenkins builds based off PR comments. 

P.S. these are already present on the bot server in production.

Refs https://github.com/nodejs/github-bot/pull/128