### PR TITLE
initial support for openbsd

### DIFF
--- a/setup/openbsd/README.md
+++ b/setup/openbsd/README.md
@@ -1,0 +1,31 @@
+# io.js Build OpenBSD Setup
+
+## Setting up
+
+To set up hosts, make sure you add them to your ssh config first:
+```
+Host test-digitalocean-openbsd61-x64-1
+  HostName 162.243.204.248
+  User openbsd
+
+Host test-digitalocean-openbsd61-x64-2
+  HostName 104.236.54.140
+  User openbsd
+```
+
+You will also have to install python (ansible dependency) and sudo:
+```bash
+$ ssh test-digitalocean-openbsd61-x64-1 "doas pkg_add -z python-2.7 sudo"
+```
+
+Now you're ready to run the playbook:
+```bash
+$ ansible-playbook -i ../ansible-inventory ansible-playbook.yaml
+```
+
+## Restarting jenkins
+
+If you ever need to restart jenkins:
+```bash
+$ ssh test-digitalocean-openbsd61-x64-1 "sudo rcctl restart jenkins"
+```

--- a/setup/openbsd/ansible-playbook.yaml
+++ b/setup/openbsd/ansible-playbook.yaml
@@ -1,0 +1,39 @@
+---
+- hosts: iojs-openbsd
+
+  remote_user: root
+  #remote_user: puffy
+  #become: True
+
+  vars:
+    - ansible_python_interpreter: "/usr/local/bin/python2.7"
+
+  tasks:
+    - include_vars: ./ansible-vars.yaml
+      tags: vars
+
+    - name: General | Install required packages
+      openbsd_pkg: name="{{ item }}" state=present # build=yes
+      with_items:
+        - "{{ packages }}"
+      tags: general
+
+    - name: User | Add {{ server_user }} group
+      group: name="{{ server_user }}" state=present
+      tags: user
+
+    - name: User | Add {{ server_user }} user
+      user: name="{{ server_user }}" append=yes groups={{ server_user }}
+      tags: user
+
+    - name: Jenkins | Download Jenkins' slave.jar
+      get_url: url=https://ci.nodejs.org/jnlpJars/slave.jar dest=/home/{{ server_user }}
+      tags: jenkins
+
+    - name: Init | Generate and copy init script
+      template: src=./resources/jenkins.j2 dest=/etc/rc.d/jenkins
+      tags: init
+
+    - name: Init | Start Jenkins
+      service: name=jenkins state=started enabled=yes
+      tags: init

--- a/setup/openbsd/ansible-vars.yaml
+++ b/setup/openbsd/ansible-vars.yaml
@@ -1,0 +1,12 @@
+---
+server_user: iojs
+packages:
+  - automake-1.15p0
+  - bash
+  - ccache
+  - git
+  - gmake
+  - jenkins-1.656p2
+  - libtool--
+  - subversion
+  - sudo--

--- a/setup/openbsd/host_vars/.gitignore
+++ b/setup/openbsd/host_vars/.gitignore
@@ -1,0 +1,1 @@
+iojs-build-openbsd*

--- a/setup/openbsd/resources/jenkins.j2
+++ b/setup/openbsd/resources/jenkins.j2
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+
+jenkins_jnlpurl="https://ci.nodejs.org/computer/{{ inventory_hostname }}/slave-agent.jnlp"
+jenkins_secret="{{ secret | default('potato')}}"
+jenkins_user="{{ server_user | default('potato')}}"
+jenkins_group="{{ server_user | default('potato')}}"
+jenkins_env=" \
+	OSTYPE=openbsd \
+	NODE_COMMON_PIPE=/home/${jenkins_user}/test.pipe \
+	PATH=/usr/local/bin:${PATH} \
+	JOBS=$(sysctl -n hw.ncpu) \
+	CC=ecc \
+	CXX=ec++"
+jenkins_jar="/home/${jenkins_user}/slave.jar"
+jenkins_log_file="/home/${jenkins_user}/${name}_console.log"
+jenkins_args="-jar ${jenkins_jar} \
+	-jnlpUrl ${jenkins_jnlpurl} \
+	-secret ${jenkins_secret}"
+
+daemon="$(/usr/local/bin/javaPathHelper -c jenkins)"
+daemon_flags="${jenkins_args}"
+daemon_user="_jenkins"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+rc_reload=NO
+
+rc_start() {
+	${rcexec} ${jenkins_env} ${daemon} ${daemon_flags} ${_bg}
+}
+
+rc_cmd $1
+


### PR DESCRIPTION
This still needs some love. The rc script isn't right, but I am not familiar enough with jenkins to know why.

Also on OpenBSD, node won't build on partitions that don't have `wxallowed` set. This means we need to have a fairly well configured system up and running before we can even get to the phase of running ansible on it.

OpenBSD has built in support for automated installs using [autoinstall](http://man.openbsd.org/autoinstall), it would be super cool if we could use this, but I am not too hopeful, as it needs a tftp server and a http server to host config files like the following:

```
System hostname = iojs-openbsd
Password for root = *************
Public ssh key for root = ssh-ed25519 .....
Setup a user = iojs
Password for user = *************
Public ssh key for user = ssh-ed25519 ......
Allow root ssh login = prohibit-password
What timezone are you in = US/Mountain
Location of sets = http
HTTP Server = ftp3.usa.openbsd.org
Server directory = pub/OpenBSD/6.1/amd64
URL to autopartitioning template for disklabel = https://serverwithdisklabel.com/disklabel
```
