### PR TITLE
ansible: support for Ubuntu 14.04

### DIFF
--- a/ansible/playbooks/create-webhost.yml
+++ b/ansible/playbooks/create-webhost.yml
@@ -11,8 +11,8 @@
 - hosts: infra-digitalocean-ubuntu1604-x64-1
   roles:
     - bootstrap
-    - baselayout
     - package-upgrade
+    - baselayout
     - { role: nginx, sites: [ 'nodejs.org', 'iojs.org', 'dist.libuv.org' ] }
 
   pre_tasks:

--- a/ansible/playbooks/jenkins/linter.yml
+++ b/ansible/playbooks/jenkins/linter.yml
@@ -10,8 +10,8 @@
 
   roles:
     - bootstrap
-    - baselayout
     - package-upgrade
+    - baselayout
     - jenkins-worker
 
   vars:

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -12,8 +12,8 @@
 
   roles:
     - bootstrap
-    - baselayout
     - package-upgrade
+    - baselayout
     - jenkins-worker
 
   pre_tasks:

--- a/ansible/roles/baselayout/handlers/main.yml
+++ b/ansible/roles/baselayout/handlers/main.yml
@@ -5,4 +5,4 @@
 #
 
 - name: restart sshd
-  service: name=sshd state=restarted
+  service: name="{{ sshd_service_name }}" state=restarted

--- a/ansible/roles/baselayout/tasks/partials/ntp/ntp_package.yml
+++ b/ansible/roles/baselayout/tasks/partials/ntp/ntp_package.yml
@@ -6,8 +6,5 @@
 # package and service are 'ntp' but 'ntpd' is started
 #
 
-- name: install ntpd
-  package: name=ntp state=present
-
 - name: start ntpd
   service: name=ntp state=started enabled=yes

--- a/ansible/roles/baselayout/tasks/partials/ntp/ntp_package.yml
+++ b/ansible/roles/baselayout/tasks/partials/ntp/ntp_package.yml
@@ -1,0 +1,13 @@
+---
+
+#
+# enable/start the os-bundled ntpd
+#
+# package and service are 'ntp' but 'ntpd' is started
+#
+
+- name: install ntpd
+  package: name=ntp state=present
+
+- name: start ntpd
+  service: name=ntp state=started enabled=yes

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -14,6 +14,12 @@ git_version: 2.10.2
 
 ssh_config: /etc/ssh/sshd_config
 
+sshd_service_map: {
+  'ubuntu1404': 'ssh',
+  }
+
+sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
+
 ntp_service: {
   systemd: ['debian8', 'ubuntu1604', 'ubuntu1610'],
   ntp_package: ['ubuntu1404']

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -106,4 +106,8 @@ packages: {
     'gcc',
     'git',
     ]
+
+  ubuntu1404: [
+    'ntp',
+    ]
   }

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -15,7 +15,8 @@ git_version: 2.10.2
 ssh_config: /etc/ssh/sshd_config
 
 ntp_service: {
-  systemd: ['debian8', 'ubuntu1404', 'ubuntu1604', 'ubuntu1610']
+  systemd: ['debian8', 'ubuntu1604', 'ubuntu1610'],
+  ntp_package: ['ubuntu1404']
   }
 
 common_packages: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -105,7 +105,7 @@ packages: {
     'g++',
     'gcc',
     'git',
-    ]
+    ],
 
   ubuntu1404: [
     'ntp',

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -4,8 +4,7 @@
 # installs java
 #
 
-- name: install java
-  package: name="{{ java_package_name }}" state=present
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.
-  failed_when: "'{{ java_package_name }}' == 'missing'"
+- name: install java
+  package: name="{{ java_package_name }}" state=present

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -14,6 +14,7 @@ packages: {
   'freebsd': 'openjdk8-jre',
   'smartos': 'openjdk8',
   'ubuntu': 'openjdk-8-jre-headless',
+  'ubuntu1404': 'openjdk-7-jre-headless',
   }
 
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -36,6 +36,7 @@
     url: "{{ jenkins_worker_jar }}"
     dest: /home/{{ server_user }}/slave.jar
     mode: 0644
+    timeout: 60
 
 - name: render init script into place
   template:

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -9,10 +9,10 @@ init: {
   debian:  ['debian7', 'ubuntu1204'],
   freebsd: 'freebsd',
   openrc:  'alpine',
-  systemd: ['centos7', 'debian8', 'fedora', 'ubuntu1404', 'ubuntu1604',
+  systemd: ['centos7', 'debian8', 'fedora', 'ubuntu1604',
             'ubuntu1610'],
   svc:     'smartos',
-  upstart: 'ubuntu12'
+  upstart: ['ubuntu12', 'ubuntu1404']
   }
 
 jenkins_init: {


### PR DESCRIPTION
This adds a few adjustments needed to create a Jenkins worker on Ubuntu 14.04.

The second commit is necessary because there is already a package name specified for Ubuntu, which is not available on 14.04. With the when statement, Ansible prints a warning and then ignores the failure installing the package.

cc @jbergstroem 
