### PR TITLE
Update CentOS6 support, add support for release nodes

### DIFF
--- a/setup/centos6/README.md
+++ b/setup/centos6/README.md
@@ -9,6 +9,12 @@ Host test-softlayer-centos6-x64-1
 Host test-softlayer-centos6-x64-2
   HostName 184.173.120.137
   User root
+Host release-softlayer-centos6-x64-1
+  HostName 50.97.245.10
+  User root
+Host release-digitalocean-centos6-x86-1
+  HostName 162.243.248.28
+  User root
 ```
 
 Note that these hostnames are also used in the *ansible-inventory* file. The IP addresses will need to be updated each time the servers are reprovisioned.

--- a/setup/centos6/ansible-playbook.yaml
+++ b/setup/centos6/ansible-playbook.yaml
@@ -17,7 +17,7 @@
       tags: general
 
     - name: General | Add SLC devtoolset repo GPG key
-      command: rpm --import http://ftp.scientificlinux.org/linux/scientific/5x/x86_64/RPM-GPG-KEYs/RPM-GPG-KEY-cern
+      command: rpm --import http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern
       tags: general
 
     - name: General | Download SLC SCL repo config
@@ -26,7 +26,7 @@
 
     - name: General | Install required packages
       yum: name={{ item }} state=latest
-      with_items: packages
+      with_items: "{{ packages }}"
       tags: general
 
     - name: NTP | Run initial NTP
@@ -38,7 +38,7 @@
       tags: ntp
 
     - name: ccache | Install ccache
-      include: ../ansible-tasks/ccache.yaml version=3.2.4
+      include: ../ansible-tasks/ccache.yaml version=3.3.4
       tags: ccache
 
     - name: General | Increase file descriptor limits
@@ -63,15 +63,7 @@
       tags: jenkins
 
     - name: Jenkins | Copy environment files
-      copy: src=./resources/jenkins.sysconfig dest=/etc/sysconfig/jenkins owner={{ server_user }} group={{ server_user }} mode=0400
-      tags: jenkins
-
-    - name: Jenkins | Copy secret to environment
-      replace: dest=/etc/sysconfig/jenkins regexp="\{\{secret\}\}" replace="{{ secret }}"
-      tags: jenkins
-
-    - name: Jenkins | Copy server id to environment
-      replace: dest=/etc/sysconfig/jenkins regexp="\{\{id\}\}" replace="{{ inventory_hostname }}"
+      template: src=./resources/jenkins.sysconfig.j2 dest=/etc/sysconfig/jenkins owner={{ server_user }} group={{ server_user }} mode=0400
       tags: jenkins
 
     - name: Jenkins | Enable and start init scripts

--- a/setup/centos6/host_vars/_tmpl
+++ b/setup/centos6/host_vars/_tmpl
@@ -1,0 +1,3 @@
+---
+server_secret: ""
+ci_server: "ci-release.nodejs.org"

--- a/setup/centos6/resources/jenkins.sysconfig
+++ b/setup/centos6/resources/jenkins.sysconfig
@@ -1,7 +1,0 @@
-JENKINS_SLAVE_USER="iojs"
-JENKINS_SLAVE_JAR="/home/iojs/slave.jar"
-JENKINS_SLAVE_LOG="/home/iojs/$NAME.log"
-JENKINS_SECRET="{{secret}}"
-JENKINS_SLAVE_ARGS="-jnlpUrl https://ci.nodejs.org/computer/{{id}}/slave-agent.jnlp -secret $JENKINS_SECRET"
-JENKINS_ENV="OSTYPE=linux-gnu NODE_COMMON_PIPE=/home/iojs/test.pipe"
-JENKINS_PATH="/opt/rh/devtoolset-2/root/usr/bin"

--- a/setup/centos6/resources/jenkins.sysconfig.j2
+++ b/setup/centos6/resources/jenkins.sysconfig.j2
@@ -1,0 +1,14 @@
+JENKINS_SLAVE_USER="iojs"
+JENKINS_SLAVE_JAR="/home/iojs/slave.jar"
+JENKINS_SLAVE_LOG="/home/iojs/$NAME.log"
+JENKINS_SECRET="{{ secret }}"
+JENKINS_SLAVE_ARGS="-jnlpUrl https://{{ ci_server }}/computer/{{ ansible_hostname }}/slave-agent.jnlp -secret $JENKINS_SECRET"
+JENKINS_ENV="OSTYPE=linux-gnu NODE_COMMON_PIPE=/home/iojs/test.pipe"
+JENKINS_PATH="/opt/rh/devtoolset-2/root/usr/bin"
+JENKINS_ENV="JOBS={{ ansible_processor_vcpus }} \
+  HOME=/home/{{ server_user }} \
+  NODE_TEST_DIR=$HOME/tmp \
+  DESTCPU={{ server_arch }} \
+  ARCH={{ server_arch }} \
+  OSTYPE=linux-gnu \
+  NODE_COMMON_PIPE=/home/iojs/test.pipe"


### PR DESCRIPTION
ref https://github.com/nodejs/build/issues/718

Also added these 2 release machines to ci-release and gave them a label `post-8-release` and added the following to the iojs+release scripting:

```bash
if [[ \
  $OSTYPE =~ linux && \
  $ARCH =~ x86_64|x64|i386|x86|ia32 && \
  ( \
    ( ${NODE_VERSION:0:1} -gt "7" && ! $NODE_LABELS =~ post-8-release ) || \
    ( ${NODE_VERSION:0:1} -lt "7" && $NODE_LABELS =~ post-8-release ) \
  ) \
]]; then
  echo "Not building Node.js ${NODE_VERSION:0:1} on $NODE_NAME"
  exit 0
fi
```
