### PR TITLE
ansible: update windows link to vcbt2015

### DIFF
--- a/setup/windows/vcbt2015-ansible-playbook.yaml
+++ b/setup/windows/vcbt2015-ansible-playbook.yaml
@@ -27,7 +27,7 @@
 
     - name: VCBT2015 | Download Visual C++ Build Tools 2015 Setup
       win_get_url:
-        url: 'https://download.microsoft.com/download/3/8/E/38EE4758-7C31-4D96-8FF9-83CC313F0F78/VisualCppBuildTools_Full.exe'
+        url: 'https://go.microsoft.com/fwlink/?LinkId=691126&__hstc=268264337.ac84b29e86c2d7ca8d7b5d72067568e7.1497344355585.1497344355585.1497859835361.2&__hssc=268264337.1.1497859835361&__hsfp=589409609&fixForIE=.exe'
         dest: 'C:\TEMP\vcbt2015.exe'
       tags: [download, visualstudio]
 


### PR DESCRIPTION
The existing link to visual studio build tools 2015 is broken. Updated
with new link and tested on windows 7 and windows 10