### PR TITLE
ansible: install clang38 on FreeBSD 10.x machines

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -28,3 +28,7 @@ ansible_python_interpreter = /opt/local/bin/python
 
 [hosts:freebsd]
 ansible_python_interpreter = /usr/local/bin/python
+
+[hosts:freebsd10]
+custom_cc_command = clang38
+custom_cxx_command = clang++38

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -28,7 +28,3 @@ ansible_python_interpreter = /opt/local/bin/python
 
 [hosts:freebsd]
 ansible_python_interpreter = /usr/local/bin/python
-
-[hosts:freebsd10]
-custom_cc_command = clang38
-custom_cxx_command = clang++38

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -72,6 +72,10 @@ packages: {
     'gmake'
   ],
 
+  freebsd10: [
+    'clang38'
+  ],
+
   smartos14: [
     'gcc48',
     'gcc48-libs',

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -28,8 +28,8 @@ jenkins_env=" \
   NODE_TEST_DIR=/home/{{ server_user }}/tmp \
   PATH=/usr/local/libexec/ccache:/usr/local/bin:${PATH} \
   JOBS={{ server_jobs|default(ansible_processor_vcpus|default('2')) }} \
-  CC=cc \
-  CXX=c++"
+  CC={{ custom_cc_command|default('cc') }} \
+  CXX={{ custom_cxx_command|default('c++') }}"
 
 jenkins_jar="/home/{{ server_user }}/slave.jar"
 jenkins_log_file="/home/{{ server_user }}/${name}_console.log"

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -28,8 +28,8 @@ jenkins_env=" \
   NODE_TEST_DIR=/home/{{ server_user }}/tmp \
   PATH=/usr/local/libexec/ccache:/usr/local/bin:${PATH} \
   JOBS={{ server_jobs|default(ansible_processor_vcpus|default('2')) }} \
-  CC={{ custom_cc_command|default('cc') }} \
-  CXX={{ custom_cxx_command|default('c++') }}"
+  CC={{ 'clang38' if os == 'freebsd10' else 'cc' }} \
+  CXX={{ 'clang++38' if os == 'freebsd10' else 'c++' }}"
 
 jenkins_jar="/home/{{ server_user }}/slave.jar"
 jenkins_log_file="/home/{{ server_user }}/${name}_console.log"


### PR DESCRIPTION
FreeBSD 10.x ships by default with clang-3.4.1, which is below the minimum for Node.js builds.  That version (as well as 3.4.2 and 3.5.2) crashes when attempting to build V8 6.0.  Specifically install the `clang38` package on those hosts.

#### Validation steps
- Installed FreeBSD 10 and 11 on VMs
- Added them to the local Ansible inventory
- Added fake `secret` entries for each machine
- Ran the `jenkins/worker/create` playbook against both hosts
- Verified that `clang38` is only installed on the FreeBSD 10 host
- Verified that the custom CC/CXX variables are only applied to the FreeBSD 10 host