### PR TITLE
Add Intel/nearForm boxes to Ansible

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -222,3 +222,6 @@ hosts:
         ubuntu1604-arm64-1: {ip: 147.75.203.102}
         ubuntu1604-arm64-2: {ip: 147.75.88.10}
 
+    - nearform:
+        intel-ubuntu1604-x64-1: {ip: 92.51.196.114}
+        intel-ubuntu1604-x64-2: {ip: 92.51.196.115}

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -48,7 +48,7 @@ valid = {
   # providers - validated for consistency
   'provider': ('azure', 'digitalocean', 'joyent', 'ibm', 'linuxonecc',
                'mininodes', 'msft', 'osuosl', 'rackspace', 'requireio',
-               'scaleway', 'softlayer', 'voxer', 'packetnet')
+               'scaleway', 'softlayer', 'voxer', 'packetnet', 'nearform')
 }
 
 # customisation options per host:


### PR DESCRIPTION
/cc @mcollina 
fixes #791

In rotation @ https://ci.nodejs.org/computer/test-nearform_intel-ubuntu1604-x64-1/ and https://ci.nodejs.org/computer/test-nearform_intel-ubuntu1604-x64-2/ now and are part of node-test-commit-linux under the new ubuntu1604-intel-64 label (e.g. https://ci.nodejs.org/job/node-test-commit-linux/11267/nodes=ubuntu1604-intel-64/).

As they are intended ultimately for benchmarking work, this usage is temporary and they'll be moved out of that configuration when there's new work set up for them to do. In the meantime they are making themselves useful!