### PR TITLE
ansible: use gcc 4.9 on CentOS 6

### DIFF
--- a/setup/centos6/ansible-playbook.yaml
+++ b/setup/centos6/ansible-playbook.yaml
@@ -12,16 +12,8 @@
       yum: name=* state=latest
       tags: general
 
-    - name: General | Add SLC devtoolset repo
-      command: curl -sL http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo -o /etc/yum.repos.d/slc6-devtoolset.repo
-      tags: general
-
-    - name: General | Add SLC devtoolset repo GPG key
-      command: rpm --import http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern
-      tags: general
-
-    - name: General | Download SLC SCL repo config
-      command: curl http://linuxsoft.cern.ch/cern/scl/slc6-scl.repo -o /etc/yum.repos.d/slc6-scl.repo
+    - name: General | Add SCL repo
+      yum: name=centos-release-scl state=latest
       tags: general
 
     - name: General | Install required packages

--- a/setup/centos6/ansible-vars.yaml
+++ b/setup/centos6/ansible-vars.yaml
@@ -3,7 +3,7 @@ server_user: iojs
 packages:
   - git
   - java-1.8.0-openjdk
-  - devtoolset-2
+  - devtoolset-6
   - git19
   - libtool
   - make

--- a/setup/centos6/resources/jenkins.sysconfig.j2
+++ b/setup/centos6/resources/jenkins.sysconfig.j2
@@ -4,7 +4,7 @@ JENKINS_SLAVE_LOG="/home/iojs/$NAME.log"
 JENKINS_SECRET="{{ secret }}"
 JENKINS_SLAVE_ARGS="-jnlpUrl https://{{ ci_server }}/computer/{{ ansible_hostname }}/slave-agent.jnlp -secret $JENKINS_SECRET"
 JENKINS_ENV="OSTYPE=linux-gnu NODE_COMMON_PIPE=/home/iojs/test.pipe"
-JENKINS_PATH="/opt/rh/devtoolset-2/root/usr/bin"
+JENKINS_PATH="/opt/rh/devtoolset-6/root/usr/bin"
 JENKINS_ENV="JOBS={{ ansible_processor_vcpus }} \
   HOME=/home/{{ server_user }} \
   NODE_TEST_DIR=$HOME/tmp \

--- a/setup/centos6/resources/start.sh
+++ b/setup/centos6/resources/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 rm -f nohup.out
-NODE_COMMON_PIPE=/home/iojs/test.pipe OSTYPE=linux-gnu nohup scl enable devtoolset-2 'java -jar slave.jar -jnlpUrl https://ci.nodejs.org/computer/iojs-digitalocean-centos6-64-{{id}}/slave-agent.jnlp -secret {{secret}}' &
+NODE_COMMON_PIPE=/home/iojs/test.pipe OSTYPE=linux-gnu nohup scl enable devtoolset-6 'java -jar slave.jar -jnlpUrl https://ci.nodejs.org/computer/iojs-digitalocean-centos6-64-{{id}}/slave-agent.jnlp -secret {{secret}}' &
 OSTYPE=linux-gnu nohup scl enable git19 'java -jar slave.jar -jnlpUrl https://ci.nodejs.org/computer/iojs-digitalocean-centos6-64-gcc44-{{gcc44_id}}/slave-agent.jnlp -secret {{gcc44_secret}}' &


### PR DESCRIPTION
Currently CentOS 6 machines use gcc 4.8 while Node.js requires "gcc and g++ 4.9.4 or newer". See #762.

`devtoolset-3` has gcc 4.9.1, too old.
`devtoolset-5` has "gcc (GCC) 5.3.1 20160406", that's still older than gcc 4.9.4.
`devtoolset-6` has "gcc (GCC) 6.3.1 20170216", good enough.

The CERN repo doesn't have `devtoolset` newer than 2, so I replaced that with Software Collections.