### PR TITLE
www: enable fallback for French, Catalan, and Galitian locales

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -62,10 +62,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja|de)/) {
+        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja|de|fr|ca|gl)/) {
             set $lang $1;
         }
-        rewrite ^/(es|it|ko|zh-cn|uk|ja|de)/(.*)$ /en/$2;
+        rewrite ^/(es|it|ko|zh-cn|uk|ja|de|fr|ca|gl)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback
@@ -240,10 +240,10 @@ server {
 
     # instead of serving a 404 page when a page hasn't been translated
     location @english_fallback {
-        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja|de)/) {
+        if ($uri ~* ^/(es|it|ko|zh-cn|uk|ja|de|fr|ca|gl)/) {
             set $lang $1;
         }
-        rewrite ^/(es|it|ko|zh-cn|uk|ja|de)/(.*)$ /en/$2;
+        rewrite ^/(es|it|ko|zh-cn|uk|ja|de|fr|ca|gl)/(.*)$ /en/$2;
     }
 
     # serve a localized 404 page if we've got $lang set from @english_fallback


### PR DESCRIPTION
This enables English fallback for files not translated to French, Catalan, and Galitian.

Refs: https://github.com/nodejs/nodejs.org/issues/1318