### PR TITLE
win: update Git to 2.14.1

### DIFF
--- a/setup/ansible-inventory
+++ b/setup/ansible-inventory
@@ -175,6 +175,12 @@ node-win2008r2-x64-3.cloudapp.net
 node-win2012r2-x64-1.cloudapp.net
 node-win2012r2-x64-2.cloudapp.net
 node-win2012r2-x64-3.cloudapp.net
+node-win2016-15213.cloudapp.net
+node-win2016-26485.cloudapp.net
+node-win2016-39067.cloudapp.net
+node-win2016-41016.cloudapp.net
+node-win2016-51654.cloudapp.net
+node-win2016-62910.cloudapp.net
 104.130.225.148
 23.253.254.31
 104.130.8.178

--- a/setup/windows/common-ansible-playbook.yaml
+++ b/setup/windows/common-ansible-playbook.yaml
@@ -27,8 +27,22 @@
 
 - name: Git | Download Git
   win_get_url:
-    url: 'https://github.com/git-for-windows/git/releases/download/v2.6.0.windows.1/Git-2.6.0-64-bit.exe'
+    url: 'https://github.com/git-for-windows/git/releases/download/v2.14.1.windows.1/Git-2.14.1-64-bit.exe'
     dest: 'C:\TEMP\git.exe'
+  tags: [download, git]
+
+- name: Git | Stat Downloaded Git
+  win_stat:
+    path: 'C:\TEMP\git.exe'
+    get_checksum: yes
+    checksum_algorithm: sha256
+  register: git_stat
+  tags: [download, git]
+
+- name: Git | Fail if downloaded Git checksum is not correct
+  fail:
+    msg: "Downloaded Git checksum is not correct"
+  when: git_stat.stat.checksum != '0dc556503e3ce4699228fc910a8e4a8d81172635ac8e8e16a11be107254c4901'
   tags: [download, git]
 
 - name: Git | Copy Git Install Configuration
@@ -94,6 +108,6 @@
 - name: Automatic Logon | Setup Automatic Logon
   script: "./resources/Enable-Autologon.ps1 -UserName {{ ansible_ssh_user }} -Password {{ ansible_ssh_pass }}"
   tags: [setup, autologon]
-  
+
 - name: Reboot Machine
   win_reboot:


### PR DESCRIPTION
Updated Git to 2.14.1 in all Windows machines. This commit reflects that change.

This caused an issue where Git no longer works with ssh-agent (apparently, Windows only). So, `node-compile-windows` was no longer able to upload the binaries and I had to update the job to a different mechanism.

Ref: https://github.com/nodejs/build/issues/831

R?= @kunalspathak @piccoloaiutante @refack 