### PR TITLE
Add EPEL to centos7

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/centos5.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos5.yml
@@ -14,5 +14,5 @@
 
 - name: install epel
   yum:
-    name: "http://dl.fedoraproject.org/pub/epel/5/{{ ansible_architecture }}/epel-release-5-4.noarch.rpm"
+    name: "http://archives.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm"
     state: present

--- a/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
@@ -16,4 +16,7 @@
     gpgkey: http://ftp.scientificlinux.org/linux/scientific/5x/{{ ansible_architecture }}/RPM-GPG-KEYs/RPM-GPG-KEY-cern
     gpgcheck: yes
 
-# needs epel! https://fedoraproject.org/wiki/EPEL
+- name: install epel
+  yum:
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+    state: present

--- a/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
@@ -1,0 +1,6 @@
+---
+
+- name: install epel
+  yum:
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+    state: present

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
 init: {
-  centos:  ['centos5', 'centos6'],
+  centos:  ['centos5', 'centos6','centos7'],
   debian:  ['debian7', 'ubuntu1204'],
   freebsd: 'freebsd',
   openrc:  'alpine',


### PR DESCRIPTION
I just got caught by this setting up a replacement for test-packetnet-centos7-arm64-1 which has been borked a lot recently (seems to be some bad hardware problems because I tried to do a reboot again which has worked in the past but it's locked up and I've had to contact packet.net support about it—I've had more success in their non-CA datacenters so I switched to their NJ one for this).

I don't know what's changed but `ccache` isn't available for plain install on CentOS 7 on packet.net any more. Perhaps it's something new in CentOS 7.3 or perhaps packet.net used to bundle EPEL automatically but now doesn't. Anyway, it's now installing it manually in this PR and is confirmed working on the new test-packetnet-centos7-arm64-1.

btw there's a note in the CentOS 6 setup about adding EPEL, perhaps it's a TODO and should be added. It can be done in the same way as this but until I have another CentOS 6 box to provision I won't be bothering testing it, someone else can though.