### PR TITLE
Add subteams

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ missing please open an issue.
 
 
 
-## People
+## Build WG Members
 
 - Wyatt Preul [@geek](https://github.com/geek)
 - Gibson Fahnestock [@gibfahn](https://github.com/gibfahn)
@@ -38,9 +38,28 @@ missing please open an issue.
 - Kunal Pathak [@kunalspathak](https://github.com/kunalspathak)
 - Refael Ackermann [@refack](https://github.com/refack)
 
-Note that different groups within the build WG have different access. For more
-information see [access.md][].
+### Infra Admins
 
+- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
+- João Reis [@joaocgreis](https://github.com/joaocgreis)
+- Michael Dawson [@mhdawson](https://github.com/mhdawson)
+- Rod Vagg [@rvagg](https://github.com/rvagg)
+
+### Release Admins
+
+- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
+- João Reis [@joaocgreis](https://github.com/joaocgreis)
+- Rod Vagg [@rvagg](https://github.com/rvagg)
+
+### Github Bot Admins
+
+- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
+- João Reis [@joaocgreis](https://github.com/joaocgreis)
+- Rod Vagg [@rvagg](https://github.com/rvagg)
+- Phillip Johnsen [@phillipj](https://github.com/phillipj)
+- Hans Kristian Flaatten [@Starefossen](https://github.com/Starefossen)
+
+For more information about accesses and team roles see [access.md][].
 
 ## Infrastructure Providers
 
@@ -180,8 +199,6 @@ Build and test orchestration is performed by [Jenkins][21].
 
 
 
-[node]: https://nodejs.org/
-[ns]:   https://nodesource.com/
 [1]:    irc://irc.freenode.net/node-build
 [2]:    https://digitalocean.com/
 [3]:    https://www.rackspace.com/
@@ -203,6 +220,8 @@ Build and test orchestration is performed by [Jenkins][21].
 [19]:   http://techtribe.nl
 [20]:   https://tessel.io/
 [21]:   https://jenkins.io/
+[access.md]: ./doc/access.md
+[node]: https://nodejs.org/
+[ns]:   https://nodesource.com/
 [pivotal]: https://www.pivotalagency.com.au/
 [securo]: http://securogroup.com/
-[access.md]: ./doc/access.md

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ delivery of binaries and source code to end-users.
 This repository contains information used to set up and maintain the various
 pieces of Node.js Foundation infrastructure managed by the Build Working Group.
 It is intended to be open and transparent, if you see any relevant information
-missing please open an issue.
-
-
+missing please open an issue. If you are interested in joining check out
+[this][Joining the Build WG].
 
 ## Build WG Members
 
@@ -220,6 +219,7 @@ Build and test orchestration is performed by [Jenkins][21].
 [19]:   http://techtribe.nl
 [20]:   https://tessel.io/
 [21]:   https://jenkins.io/
+[Joining the Build WG]: /doc/process/joining_the_build_wg.md
 [access.md]: ./doc/access.md
 [node]: https://nodejs.org/
 [ns]:   https://nodesource.com/

--- a/doc/access.md
+++ b/doc/access.md
@@ -14,26 +14,18 @@ give access to any of the secrets within. For more info see the repo's README.
 
 ### Test machines
 
-[@nodejs/build][] have root access to the test CI machines (`test-*`).
+[@nodejs/build][] have root access to the test CI machines (`test-*`). The list
+of members is [here][Build WG Members].
 
 ### Infra machines
 
 A subsection of build members have access to infra machines
-(`infra-*`). The current list is:
-
-- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
-- João Reis [@joaocgreis](https://github.com/joaocgreis)
-- Michael Dawson [@mhdawson](https://github.com/mhdawson)
-- Rod Vagg [@rvagg](https://github.com/rvagg)
+(`infra-*`). The list of members is [here][Infra Admins].
 
 ### Release machines
 
-A subsection of build members have access to infra machines
-(`infra-*`). The current list is:
-
-- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
-- João Reis [@joaocgreis](https://github.com/joaocgreis)
-- Rod Vagg [@rvagg](https://github.com/rvagg)
+A subsection of build members have access to release machines
+(`release-*`). The list of members is [here][Release Admins].
 
 ## Infra Access
 
@@ -63,18 +55,11 @@ configure machines).
 
 - [@nodejs/jenkins-admins][] have admin access.
 
-### [github-bot][]
+### [Github Bot][]
 
 Those with `github-bot` access have access to the Github Bot's configuration,
-including Github and Jenkins secrets.
-
-The following have access:
-
-- Johan Bergström [@jbergstroem](https://github.com/jbergstroem)
-- João Reis [@joaocgreis](https://github.com/joaocgreis)
-- Rod Vagg [@rvagg](https://github.com/rvagg)
-- Phillip Johnsen [@phillipj](https://github.com/phillipj)
-- Hans Kristian Flaatten [@Starefossen](https://github.com/Starefossen)
+including Github and Jenkins secrets. The list of members is
+[here][Github Bot Admins].
 
 
 [@nodejs/build]: https://github.com/orgs/nodejs/teams/build/members
@@ -83,7 +68,11 @@ The following have access:
 [@nodejs/post-mortem-admins]: https://github.com/orgs/nodejs/teams/post-mortem-admins/members
 [@nodejs/post-mortem]: https://github.com/orgs/nodejs/teams/post-mortem/members
 [@nodejs/release]: https://github.com/orgs/nodejs/teams/release/members
+[Build WG Members]: /README.md#build-wg-members
+[Github Bot Admins]: /README.md#github-bot-admins
+[Infra Admins]: /README.md#infra-admins
 [Jenkins access doc]: /doc/process/jenkins_job_configuration_access.md
+[Release Admins]: /README.md#release-admins
 [github-bot]: https://github.com/nodejs/github-bot
 [inventory.yml]: /ansible/inventory.yml
 [org owners]: https://github.com/orgs/nodejs/people?utf8=%E2%9C%93&query=%20role%3Aowner

--- a/doc/access.md
+++ b/doc/access.md
@@ -55,11 +55,11 @@ configure machines).
 
 - [@nodejs/jenkins-admins][] have admin access.
 
-### [Github Bot][]
+### [GitHub Bot][]
 
-Those with `github-bot` access have access to the Github Bot's configuration,
-including Github and Jenkins secrets. The list of members is
-[here][Github Bot Admins].
+Those with `github-bot` access have access to the GitHub Bot's configuration,
+including GitHub and Jenkins secrets. The list of members is
+[here][GitHub Bot Admins].
 
 
 [@nodejs/build]: https://github.com/orgs/nodejs/teams/build/members
@@ -69,11 +69,11 @@ including Github and Jenkins secrets. The list of members is
 [@nodejs/post-mortem]: https://github.com/orgs/nodejs/teams/post-mortem/members
 [@nodejs/release]: https://github.com/orgs/nodejs/teams/release/members
 [Build WG Members]: /README.md#build-wg-members
-[Github Bot Admins]: /README.md#github-bot-admins
+[GitHub Bot Admins]: /README.md#github-bot-admins
 [Infra Admins]: /README.md#infra-admins
 [Jenkins access doc]: /doc/process/jenkins_job_configuration_access.md
 [Release Admins]: /README.md#release-admins
-[github-bot]: https://github.com/nodejs/github-bot
+[GitHub Bot]: https://github.com/nodejs/github-bot
 [inventory.yml]: /ansible/inventory.yml
 [org owners]: https://github.com/orgs/nodejs/people?utf8=%E2%9C%93&query=%20role%3Aowner
 [post-mortem jobs]: https://ci.nodejs.org/view/post-mortem/

--- a/doc/process/joining_the_build_wg.md
+++ b/doc/process/joining_the_build_wg.md
@@ -1,0 +1,26 @@
+# Joining the Build Working Group
+
+Anyone interested in helping out with the Build WG can reach out to existing
+members to let us know, for example via a Github Issue on this repo or through
+[IRC][].
+
+Membership of the Build WG involves granting infrastructure access, so full
+membership of the WG can be a gradual process. However we welcome anyone willing
+to contribute, and we're always working to make contributions easier.
+
+Once you're an established contributor, an existing Build WG member will invite
+you to join the WG. A PR adding your name can be raised by either you or them
+(e.g. [#524][]) and once that gains consensus and is landed you will be
+onboarded (see [the onboarding doc][] for more details).
+
+# Further access requests
+
+Existing members may require one of the additional accesses documented in
+[access.md][] by raising a PR adding their name to the relevant section of
+[the Readme][]. It will be reviewed and approved by the WG like any other
+request.
+
+[#524]: https://github.com/nodejs/build/pull/524
+[IRC]: /README.md#nodejs-build-working-group
+[the Readme]: /README.md
+[the onboarding doc]: /ONBOARDING.md


### PR DESCRIPTION
Also adds a quick intro to joining, and also notes that you can request additional access to things as necessary.

I considered adding another section for [`Jenkins Admins`](https://github.com/orgs/nodejs/teams/jenkins-admins/members), but haven't done that yet. Opinions welcome!

Fixes: https://github.com/nodejs/build/issues/826