### PR TITLE
move common `apt` task out of debian specific task

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/debian7.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian7.yml
@@ -1,8 +1,0 @@
----
-
-#
-# debian 7 -- some systems will 404 on sources unless updated
-#
-
-- name: update repositories
-  raw: apt-get update -y

--- a/ansible/roles/package-upgrade/tasks/partials/apt.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/apt.yml
@@ -4,6 +4,9 @@
 # Updates all packages for debian-based distributions
 #
 
+- name: update repositories
+  raw: apt-get update -y
+
 - name: upgrade installed packages
   apt: upgrade=dist update_cache=yes
 

--- a/ansible/roles/package-upgrade/tasks/partials/apt.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/apt.yml
@@ -4,9 +4,6 @@
 # Updates all packages for debian-based distributions
 #
 
-- name: update repositories
-  raw: apt-get update -y
-
 - name: upgrade installed packages
   apt: upgrade=dist update_cache=yes
 


### PR DESCRIPTION
I think this is right, PTAL.