### PR TITLE
ansible: add RHEL to the supported OS's

### DIFF
--- a/ansible/roles/package-upgrade/vars/main.yml
+++ b/ansible/roles/package-upgrade/vars/main.yml
@@ -6,7 +6,7 @@
 
   pm: {
     'apk': 'alpine',
-    'yum': 'centos',
+    'yum': ['centos', 'rhel'],
     'apt': ['debian', 'ubuntu'],
     'dnf': 'fedora',
     'pkg': 'freebsd',


### PR DESCRIPTION
First step in supporting RHEL.
I am not sure how much `centos` stuff should also be run on RHEL.