### PR TITLE
switch from global to per-process core dumps on SmartOS

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: change default coredump folder
   when: os|startswith("smartos")
-  shell: coreadm -g /home/iojs/cores/core.%f.%p -e global
+  shell: coreadm -i /home/iojs/cores/core.%f.%p -e process -d global
 
 - name: disable sftp
   when: not os|startswith("win")


### PR DESCRIPTION
This allows for controlling core files limits per process (e.g per
tests).

Ref: https://github.com/nodejs/node/pull/14013