### PR TITLE
win: updates for Ansible 2

### DIFF
--- a/setup/windows/README.md
+++ b/setup/windows/README.md
@@ -30,10 +30,11 @@ for each host and change the variables as necessary:
 ---
 server_id: node-msft-win10-1
 server_secret: SECRET
-ansible_ssh_user: node
-ansible_ssh_pass: PASSWORD
-ansible_ssh_port: 5986
+ansible_user: node
+ansible_password: PASSWORD
+ansible_port: 5986
 ansible_connection: winrm
+ansible_winrm_server_cert_validation: ignore
 ```
 
 To test the connection to the hosts, run:

--- a/setup/windows/vcbt2015-ansible-playbook.yaml
+++ b/setup/windows/vcbt2015-ansible-playbook.yaml
@@ -5,11 +5,11 @@
 
     - name: Download and Install Windows Updates
       win_updates:
-        register: update_result
+      register: update_result
 
     - name: Reboot machine if necessary
       win_reboot:
-        when: update_result.reboot_required
+      when: update_result.reboot_required
 
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
@@ -40,5 +40,5 @@
     - name: Reboot machine after Visual C++ Build Tools installation
       win_reboot:
 
-    - include: ./common-ansible-playbook.yaml
+    - import_tasks: ./common-ansible-playbook.yaml
       tags: common

--- a/setup/windows/vs2013-ansible-playbook.yaml
+++ b/setup/windows/vs2013-ansible-playbook.yaml
@@ -5,11 +5,11 @@
 
     - name: Download and Install Windows Updates
       win_updates:
-        register: update_result
+      register: update_result
 
     - name: Reboot machine if necessary
       win_reboot:
-        when: update_result.reboot_required
+      when: update_result.reboot_required
 
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
@@ -28,5 +28,5 @@
     - name: Reboot machine after Visual Studio installation
       win_reboot:
 
-    - include: ./common-ansible-playbook.yaml
+    - import_tasks: ./common-ansible-playbook.yaml
       tags: common

--- a/setup/windows/vs2015-ansible-playbook.yaml
+++ b/setup/windows/vs2015-ansible-playbook.yaml
@@ -5,11 +5,11 @@
 
     - name: Download and Install Windows Updates
       win_updates:
-        register: update_result
+      register: update_result
 
     - name: Reboot machine if necessary
       win_reboot:
-        when: update_result.reboot_required
+      when: update_result.reboot_required
 
     - name: Create C:\TEMP directory
       win_file: path='C:\TEMP' state=directory
@@ -29,5 +29,5 @@
     - name: Reboot machine after Visual Studio installation
       win_reboot:
 
-    - include: ./common-ansible-playbook.yaml
+    - import_tasks: ./common-ansible-playbook.yaml
       tags: common


### PR DESCRIPTION
A few small updates, tested when deploying `test-rackspace-win2012r2-x64-8`:

- Use the new key names in host_vars
- Ignore certificates, necessary with new version of pywinrm
- Reboot indentation fix
- Use static imports for common

cc @refack @kunalspathak @piccoloaiutante 