### PR TITLE
doc: update intel text in providers list (meta: negotiating wording for donor descriptions & contributions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ and speed in our CI system.
 - **[ARM][17]**: semiconductor intellectual property supplier, have donated
   ARMv8 hardware used by the Node.js CI system for build and testing Node.js.
 
-- **[Intel][22]**: provides hardware used for benchmarking in the
+- **[Intel][22]**: "the world leader in silicon innovation," contributes
+  hardware used for benchmarking in the Node.js project's CI system to advance
+  and accelerate Node.js performance.
+
   Node.js project's CI system.
 
 - **[MacStadium][23]**: Managed hosting provider for Mac. Provides Mac


### PR DESCRIPTION
@nodejs/build we've been having private discussions with Intel about their hardware contributions and how best to acknowledge it—they have donated two physical boxes now hosted at nearForm, for benchmarking/perf work, which we are immensely thankful for of course. It raises some interesting questions about how far we go with putting marketing content into our README that I think we should discuss together. @mhdawson and I have been doing so privately in the context of this, and he has taken the lead primarily on updating this list and the associated graphic as well as our promotion of our providers across our various channels (this repo, twitter and in conference talks).

Keeping in mind that we entirely use donated resources and provide (soft) commitments to co-promote with our donors to make it worth their while being involved. This has been very helpful in attracting and retaining donors, most recently MacStadium signed up with some amazing resources and they don't have a direct connection to Node.js like a lot of our other providers do so the benefits to them are almost entirely marketing-related.

In this PR is the latest iteration of some wording we've been discussing with Intel, slightly modified by me (I've put their tag-line in quotes). If you look over our existing list you'll see a mix of simple "they've donated X" and "they are a Y company and have donated X" (see ARM just above this one for the most obvious comparison to Intel).

So my proposal (consider it a strawman for discussion) is that we allow donors to provide tag-lines like this but we keep them in quotes. Also, the text about their contribution should fit into a single, non-awkward sentence. Aside from that I don't have any suggestions for rules when negotiating wording here other than on a case-by-case basis to keep it _reasonable_.