### PR TITLE
jenkins: add http-parser.jenkinsfile

### DIFF
--- a/jenkins/http-parser.jenkinsfile
+++ b/jenkins/http-parser.jenkinsfile
@@ -7,8 +7,8 @@ pipeline {
 
     parameters {
         booleanParam(name: 'CERTIFY_SAFE', defaultValue: false, description: 'I have reviewed *the latest version of* these changes and I am sure that they don’t contain any code that could compromise the security of the CI infrastructure.')
-        string(defaultValue: "", description: 'The numeric ID of the pull request (from GitHub URL)', name: 'PR_ID')
-        string(defaultValue: 'master', description: 'Git branch to use for testing (ignore this value for PRs)', name: 'BRANCH')
+        string(name: 'PR_ID', defaultValue: "", description: 'The numeric ID of the pull request (from GitHub URL)')
+        string(name: 'BRANCH', defaultValue: 'master', description: 'Git branch to use for testing (ignore this value for PRs)')
     }
 
     stages {

--- a/jenkins/http-parser.jenkinsfile
+++ b/jenkins/http-parser.jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                 echo "Testing: ${sh(returnStdout: true, script: 'git log -1 --oneline').trim()}"
 
                 sh 'gcc --version'
-                sendBuildStatus("pending", env.PR_ID, env.BUILD_URL)
+                sendBuildStatus("pending", env.PR_ID, env.BUILD_URL, env.GIT_COMMIT)
             }
         }
 
@@ -45,40 +45,23 @@ pipeline {
 
     post {
         success {
-            sendBuildStatus("success", env.PR_ID, env.BUILD_URL)
+            sendBuildStatus("success", env.PR_ID, env.BUILD_URL, env.GIT_COMMIT)
         }
 
         failure {
-            sendBuildStatus("failure", env.PR_ID, env.BUILD_URL)
+            sendBuildStatus("failure", env.PR_ID, env.BUILD_URL, env.GIT_COMMIT)
         }
     }
 }
 
-def sendBuildStatus(status, prId, buildUrl) {
+def sendBuildStatus(status, prId, buildUrl, commit) {
     if (!prId) { return }
 
-    def path = ""
-    def message = ""
-
-    if (status == "success") {
-        message = "tests passed"
-        path = "end"
-    } else if (status == "failure") {
-        message = "tests failed"
-        path = "end"
-    } else if (status == "pending") {
-        message = "checking for errors"
-        path = "start"
-    }
-
-    def buildPayload = JsonOutput.toJson([
-        'identifier': 'test',
-        'status': status,
-        'message': message,
-        'commit': sh(returnStdout: true, script: 'git rev-parse HEAD').trim(),
-        'url': buildUrl,
-        'ref': "refs/pull/${env.PR_ID}/head"
-        ])
-
-    sh(returnStdout: true, script: "curl -H 'Content-Type: application/json' -X POST -d '${buildPayload}' http://9d7d96c6.ngrok.io/http-parser/jenkins/${path}")
+    build job: 'post-build-status-update', parameters: [
+              string(name: 'REPO', value: 'http-parser'),
+              string(name: 'IDENTIFIER', value: 'test'),
+              string(name: 'URL', value: buildUrl),
+              string(name: 'COMMIT', value: commit),
+              string(name: 'REF', value: "refs/pull/${env.PR_ID}/head"),
+          ]
 }

--- a/jenkins/http-parser.jenkinsfile
+++ b/jenkins/http-parser.jenkinsfile
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+import groovy.json.JsonOutput
+
+pipeline {
+    agent any
+
+    parameters {
+        booleanParam(name: 'CERTIFY_SAFE', defaultValue: false, description: 'I have reviewed *the latest version of* these changes and I am sure that they don’t contain any code that could compromise the security of the CI infrastructure.')
+        string(defaultValue: "", description: 'The numeric ID of the pull request (from GitHub URL)', name: 'PR_ID')
+    }
+
+    stages {
+        stage('Clone repository') {
+            steps {
+                git 'https://github.com/nodejs/http-parser.git'
+            }
+        }
+
+        stage('Setup Git repository') {
+            when {
+                expression {
+                    return !!env.PR_ID
+                }
+            }
+
+            steps {
+                sh "git fetch origin pull/${env.PR_ID}/head:totest"
+                sh 'git checkout totest'
+            }
+        }
+
+        stage('Setup build dependencies') {
+            steps {
+                echo "Testing: ${sh(returnStdout: true, script: 'git log -1 --oneline').trim()}"
+
+                sh 'gcc --version'
+                sendBuildStatus("pending", env.PR_ID, env.BUILD_URL)
+            }
+        }
+
+        stage('Run tests') {
+            steps {
+                sh 'make'
+            }
+        }
+    }
+
+    post {
+        success {
+            sendBuildStatus("success", env.PR_ID, env.BUILD_URL)
+        }
+
+        failure {
+            sendBuildStatus("failure", env.PR_ID, env.BUILD_URL)
+        }
+    }
+}
+
+def sendBuildStatus(status, prId, buildUrl) {
+    if (!prId) { return }
+
+    def path = ""
+    def message = ""
+
+    if (status == "success") {
+        message = "tests passed"
+        path = "end"
+    } else if (status == "failure") {
+        message = "tests failed"
+        path = "end"
+    } else if (status == "pending") {
+        message = "checking for errors"
+        path = "start"
+    }
+
+    def buildPayload = JsonOutput.toJson([
+        'identifier': 'test',
+        'status': status,
+        'message': message,
+        'commit': sh(returnStdout: true, script: 'git rev-parse HEAD').trim(),
+        'url': buildUrl,
+        'ref': "refs/pull/${env.PR_ID}/head"
+        ])
+
+    sh(returnStdout: true, script: "curl -H 'Content-Type: application/json' -X POST -d '${buildPayload}' http://9d7d96c6.ngrok.io/http-parser/jenkins/${path}")
+}

--- a/jenkins/http-parser.jenkinsfile
+++ b/jenkins/http-parser.jenkinsfile
@@ -3,30 +3,27 @@
 import groovy.json.JsonOutput
 
 pipeline {
-    agent any
+    agent { label 'jenkins-workspace' }
 
     parameters {
         booleanParam(name: 'CERTIFY_SAFE', defaultValue: false, description: 'I have reviewed *the latest version of* these changes and I am sure that they don’t contain any code that could compromise the security of the CI infrastructure.')
         string(defaultValue: "", description: 'The numeric ID of the pull request (from GitHub URL)', name: 'PR_ID')
+        string(defaultValue: 'master', description: 'Git branch to use for testing (ignore this value for PRs)', name: 'BRANCH')
     }
 
     stages {
-        stage('Clone repository') {
+        stage("Setup repository") {
             steps {
-                git 'https://github.com/nodejs/http-parser.git'
-            }
-        }
-
-        stage('Setup Git repository') {
-            when {
-                expression {
-                    return !!env.PR_ID
-                }
-            }
-
-            steps {
-                sh "git fetch origin pull/${env.PR_ID}/head:totest"
-                sh 'git checkout totest'
+                checkout(poll: false, scm: [
+                    $class: 'GitSCM',
+                    branches: [[
+                        name: (params.PR_ID ? "pr/${params.PR_ID}/head" : params.BRANCH)
+                    ]],
+                    userRemoteConfigs: [[
+                        url: "https://github.com/nodejs/http-parser",
+                        refspec: '+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*',
+                    ]]
+                ])
             }
         }
 


### PR DESCRIPTION
This is a simple prototype to try out Jenkins pipelines (ref #838) in a low-ish risk way. This commit introduces `jenkins/http-parser.jenkinsfile`, a pipeline to run tests for [nodejs/http-parser](https://github.com/nodejs/http-parser) -- http-parser is not part of ci.nodejs.org as of right now. I setup a Jenkins instance locally and was using it to test drive out the pipeline file. I can confirm it works correctly for PR 388 as well as master (if you leave PR_ID blank).

Before this can go out, there are a few things (and probably more that I didn't think of) that will be need to tested/done:

- [x] finish setting up integration with nodejs/github-bot
  - get the hostname, and replace ngrok.io with that
  - add http-parser to [this list](https://github.com/nodejs/github-bot/blob/master/scripts/jenkins-status.js#L4)
- [ ] target specific platforms
  - right now, http-parser's Travis CI configuration only targets linux, so we should either stick with that or add more platforms via the [`agent` / `label`](https://jenkins.io/doc/book/pipeline/syntax/#agent) config options.
- [ ]  backfill current open PRs
  - I think a good test for this would be to backfill all current open PRs with a CI run, to make sure it fails / succeeds as appropriate

Some pipelines stuff is a little quirky, but I think this is a decent POC -- please let me know your thoughts :)

cc @refack @gibfahn 