### PR TITLE
add ARMv7 Wheezy extra setup notes for gcc 4.9

### DIFF
--- a/doc/deb-control-armv7.patch
+++ b/doc/deb-control-armv7.patch
@@ -1,0 +1,707 @@
+--- control	2017-10-17 11:59:02.000000000 +0000
++++ _control	2016-01-05 06:32:28.197515500 +0000
+@@ -4,20 +4,20 @@
+ Maintainer: Debian GCC Maintainers <debian-gcc@lists.debian.org>
+ Uploaders: Matthias Klose <doko@debian.org>
+ Standards-Version: 3.9.6
+-Build-Depends: debhelper (>= 5.0.62), dpkg-dev (>= 1.17.11), 
++Build-Depends: debhelper (>= 5.0.62), dpkg-dev (>= 1.16.0~ubuntu4), 
+   g++-multilib [amd64 i386 kfreebsd-amd64 mips mips64 mips64el mipsel mipsn32 mipsn32el powerpc ppc64 s390 s390x sparc sparc64 x32], 
+-  libc6.1-dev (>= 2.13-5) [alpha ia64] | libc0.3-dev (>= 2.13-5) [hurd-i386] | libc0.1-dev (>= 2.13-5) [kfreebsd-i386 kfreebsd-amd64] | libc6-dev (>= 2.13-5), libc6-dev (>= 2.13-31) [armel armhf], libc6-dev-amd64 [i386 x32], libc6-dev-sparc64 [sparc], libc6-dev-sparc [sparc64], libc6-dev-s390 [s390x], libc6-dev-s390x [s390], libc6-dev-i386 [amd64 x32], libc6-dev-powerpc [ppc64], libc6-dev-ppc64 [powerpc], libc0.1-dev-i386 [kfreebsd-amd64], lib32gcc1 [amd64 ppc64 kfreebsd-amd64 mipsn32 mipsn32el mips64 mips64el s390x sparc64 x32], libn32gcc1 [mips mipsel mips64 mips64el], lib64gcc1 [i386 mips mipsel mipsn32 mipsn32el powerpc sparc s390 x32], libc6-dev-mips64 [mips mipsel mipsn32 mipsn32el], libc6-dev-mipsn32 [mips mipsel mips64 mips64el], libc6-dev-mips32 [mipsn32 mipsn32el mips64 mips64el], libc6-dev-x32 [amd64 i386], libx32gcc1 [amd64 i386], libc6.1-dbg [alpha ia64] | libc0.3-dbg [hurd-i386] | libc0.1-dbg [kfreebsd-i386 kfreebsd-amd64] | libc6-dbg, 
++  libc6.1-dev (>= 2.13-5) [alpha ia64] | libc0.3-dev (>= 2.13-5) [hurd-i386] | libc0.1-dev (>= 2.13-5) [kfreebsd-i386 kfreebsd-amd64] | libc6-dev (>= 2.13-5), libc6-dev (>= 2.13-31) [armel armhf], libc6-dev-amd64 [i386 x32], libc6-dev-sparc64 [sparc], libc6-dev-sparc [sparc64], libc6-dev-s390 [s390x], libc6-dev-s390x [s390], libc6-dev-i386 [amd64 x32], libc6-dev-powerpc [ppc64], libc6-dev-ppc64 [powerpc], libc0.1-dev-i386 [kfreebsd-amd64], lib32gcc1 [amd64 ppc64 kfreebsd-amd64 mipsn32 mipsn32el mips64 mips64el s390x sparc64 x32], libn32gcc1 [mips mipsel mips64 mips64el], lib64gcc1 [i386 mips mipsel mipsn32 mipsn32el powerpc sparc s390 x32], libc6-dev-mips64 [mips mipsel mipsn32 mipsn32el], libc6-dev-mipsn32 [mips mipsel mips64 mips64el], libc6-dev-mips32 [mipsn32 mipsn32el mips64 mips64el], libc6.1-dbg [alpha ia64] | libc0.3-dbg [hurd-i386] | libc0.1-dbg [kfreebsd-i386 kfreebsd-amd64] | libc6-dbg, 
+   kfreebsd-kernel-headers (>= 0.84) [kfreebsd-any], 
+   m4, libtool, autoconf2.64, 
+   libunwind7-dev (>= 0.98.5-6) [ia64], libatomic-ops-dev [ia64], 
+   autogen, gawk, lzma, xz-utils, patchutils, 
+-  zlib1g-dev, systemtap-sdt-dev [linux-any kfreebsd-any hurd-any], 
+-  binutils (>= 2.25-3~) | binutils-multiarch (>= 2.25-3~), binutils-hppa64 (>= 2.25-3~) [hppa], 
++  zlib1g-dev, 
++  binutils (>= 2.22) | binutils-multiarch (>= 2.22), binutils-hppa64 (>= 2.22) [hppa], 
+   gperf (>= 3.0.1), bison (>= 1:2.3), flex, gettext, 
+   gdb, 
+   texinfo (>= 4.3), locales, sharutils, 
+   procps, zlib1g-dev, libantlr-java, python, libffi-dev, fastjar, libmagic-dev, libecj-java (>= 3.3.0-2), zip, libasound2-dev [ !hurd-any !kfreebsd-any], libxtst-dev, libxt-dev, libgtk2.0-dev (>= 2.4.4-2), libart-2.0-dev, libcairo2-dev, netbase, 
+-  libcloog-isl-dev (>= 0.18), libmpc-dev (>= 1.0), libmpfr-dev (>= 3.0.0-9~), libgmp-dev (>= 2:5.0.1~), 
++  libcloog-isl-dev (>= 0.18), libmpc-dev, libmpfr-dev (>= 3.0.0-9~), libgmp-dev (>= 2:5.0.1~), 
+   dejagnu [!m68k], realpath (>= 1.9.12), chrpath, lsb-release, quilt
+ Build-Depends-Indep: doxygen (>= 1.7.2), graphviz (>= 2.2), ghostscript, texlive-latex-base, xsltproc, libxml2-utils, docbook-xsl-ns, 
+ Homepage: http://gcc.gnu.org/
+@@ -221,39 +221,6 @@
+  This package contains the headers and static library files necessary for
+  building C programs which use libgcc, libgomp, libquadmath, libssp or libitm.
+ 
+-Package: libx32gcc1
+-Architecture: amd64 i386
+-Section: libs
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${misc:Depends}
+-Description: GCC support library (x32)
+- Shared version of the support library, a library of internal subroutines
+- that GCC uses to overcome shortcomings of particular machines, or
+- special needs for some languages.
+-
+-Package: libx32gcc1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc1 (= ${gcc:EpochVersion}), ${misc:Depends}
+-Description: GCC support library (debug symbols)
+- Debug symbols for the GCC support library.
+-
+-Package: libx32gcc-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Recommends: ${dep:libcdev}
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libgccbiarch}, ${dep:libsspbiarch},
+- ${dep:libgompbiarch}, ${dep:libitmbiarch}, ${dep:libatomicbiarch},
+- ${dep:libbtracebiarch}, ${dep:libasanbiarch}, ${dep:liblsanbiarch},
+- ${dep:libtsanbiarch}, ${dep:libubsanbiarch},
+- ${dep:libvtvbiarch}, ${dep:libcilkrtsbiarch},
+- ${dep:libqmathbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC support library (x32 development files)
+- This package contains the headers and static library files necessary for
+- building C programs which use libgcc, libgomp, libquadmath, libssp or libitm.
+-
+ Package: gcc-4.9
+ Architecture: any
+ Section: devel
+@@ -274,7 +241,7 @@
+  libtsan0-dbg (>= ${gcc:Version}),
+  libubsan0-dbg (>= ${gcc:Version}),
+  libcilkrts5-dbg (>= ${gcc:Version}),
+- libquadmath0-dbg (>= ${gcc:Version}), ${dep:libcloog}
++ libquadmath-dbg (>= ${gcc:Version}), ${dep:libcloog}
+ Provides: c-compiler
+ Description: GNU C compiler
+  This is the GNU C compiler, a fairly portable optimizing compiler for C.
+@@ -436,131 +403,6 @@
+ Description: GCC OpenMP (GOMP) support library (n32 debug symbols)
+  GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+ 
+-Package: libx32gomp1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC OpenMP (GOMP) support library (x32)
+- GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+- in the GNU Compiler Collection.
+-
+-Package: libx32gomp1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gomp1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC OpenMP (GOMP) support library (x32 debug symbols)
+- GOMP is an implementation of OpenMP for the C, C++, and Fortran compilers
+-
+-Package: libitm1
+-Section: libs
+-Architecture: any
+-Provides: libitm1-armel [armel], libitm1-armhf [armhf]
+-Multi-Arch: same
+-Pre-Depends: multiarch-support
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Transactional Memory Library
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-Package: libitm1-dbg
+-Architecture: any
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libitm1 (= ${gcc:Version}), ${misc:Depends}
+-Provides: libitm1-dbg-armel [armel], libitm1-dbg-armhf [armhf]
+-Multi-Arch: same
+-Description: GNU Transactional Memory Library (debug symbols)
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-Package: lib32itm1
+-Section: libs
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: ${confl:lib32}
+-Description: GNU Transactional Memory Library (32bit)
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-Package: lib32itm1-dbg
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib32itm1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Transactional Memory Library (32 bit debug symbols)
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-Package: lib64itm1
+-Section: libs
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Transactional Memory Library (64bit)
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-Package: lib64itm1-dbg
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib64itm1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Transactional Memory Library (64bit debug symbols)
+- GNU Transactional Memory Library (libitm) provides transaction support for
+- accesses to the memory of a process, enabling easy-to-use synchronization of
+- accesses to shared memory by several threads.
+-
+-#Package: libn32itm`'ITM_SO`'LS
+-#Section: ifdef(`TARGET',`devel',`libs')
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Priority: ifdef(`TARGET',`extra',`PRI(optional)')
+-#Depends: BASEDEP, ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: GNU Transactional Memory Library (n32)
+-# GNU Transactional Memory Library (libitm) provides transaction support for
+-# accesses to the memory of a process, enabling easy-to-use synchronization of
+-# accesses to shared memory by several threads.
+-
+-#Package: libn32itm`'ITM_SO-dbg`'LS
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Section: debug
+-#Priority: extra
+-#Depends: BASEDEP, libdep(itm`'ITM_SO,n32,=), ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: GNU Transactional Memory Library (n32 debug symbols)
+-# GNU Transactional Memory Library (libitm) provides transaction support for
+-# accesses to the memory of a process, enabling easy-to-use synchronization of
+-# accesses to shared memory by several threads.
+-
+-Package: libx32itm1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Transactional Memory Library (x32)
+- This manual documents the usage and internals of libitm. It provides
+- transaction support for accesses to the memory of a process, enabling
+- easy-to-use synchronization of accesses to shared memory by several threads.
+-
+-Package: libx32itm1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32itm1 (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Transactional Memory Library (x32 debug symbols)
+- This manual documents the usage and internals of libitm. It provides
+- transaction support for accesses to the memory of a process, enabling
+- easy-to-use synchronization of accesses to shared memory by several threads.
+-
+ Package: libatomic1
+ Section: libs
+ Architecture: any
+@@ -639,24 +481,6 @@
+  library providing __atomic built-in functions. When an atomic call cannot
+  be turned into lock-free instructions, GCC will make calls into this library.
+ 
+-Package: libx32atomic1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: support library providing __atomic built-in functions (x32)
+- library providing __atomic built-in functions. When an atomic call cannot
+- be turned into lock-free instructions, GCC will make calls into this library.
+-
+-Package: libx32atomic1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32atomic1 (= ${gcc:Version}), ${misc:Depends}
+-Description: support library providing __atomic built-in functions (x32 debug symbols)
+- library providing __atomic built-in functions. When an atomic call cannot
+- be turned into lock-free instructions, GCC will make calls into this library.
+-
+ Package: libasan1
+ Section: libs
+ Architecture: any
+@@ -737,122 +561,6 @@
+ # AddressSanitizer (ASan) is a fast memory error detector.  It finds
+ # use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+ 
+-Package: libx32asan1
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: AddressSanitizer -- a fast memory error detector (x32)
+- AddressSanitizer (ASan) is a fast memory error detector.  It finds
+- use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+-
+-Package: libx32asan1-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32asan1 (= ${gcc:Version}), ${misc:Depends}
+-Description: AddressSanitizer -- a fast memory error detector (x32 debug symbols)
+- AddressSanitizer (ASan) is a fast memory error detector.  It finds
+- use-after-free and {heap,stack,global}-buffer overflow bugs in C/C++ programs.
+-
+-Package: liblsan0
+-Section: libs
+-Architecture: any
+-Multi-Arch: same
+-Pre-Depends: multiarch-support
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (runtime)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-Package: liblsan0-dbg
+-Architecture: any
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), liblsan0 (= ${gcc:Version}), ${misc:Depends}
+-Multi-Arch: same
+-Description: LeakSanitizer -- a memory leak detector (debug symbols)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-Package: lib32lsan0
+-Section: libs
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: ${confl:lib32}
+-Description: LeakSanitizer -- a memory leak detector (32bit)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-Package: lib32lsan0-dbg
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib32lsan0 (= ${gcc:Version}), ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (32 bit debug symbols)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-#Package: lib64lsan`'LSAN_SO`'LS
+-#Section: ifdef(`TARGET',`devel',`libs')
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarch64_archs')
+-#Priority: ifdef(`TARGET',`extra',`PRI(optional)')
+-#Depends: BASEDEP, ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: LeakSanitizer -- a memory leak detector (64bit)
+-# LeakSanitizer (Lsan) is a memory leak detector which is integrated
+-# into AddressSanitizer.
+-
+-#Package: lib64lsan`'LSAN_SO-dbg`'LS
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarch64_archs')
+-#Section: debug
+-#Priority: extra
+-#Depends: BASEDEP, libdep(lsan`'LSAN_SO,64,=), ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: LeakSanitizer -- a memory leak detector (64bit debug symbols)
+-# LeakSanitizer (Lsan) is a memory leak detector which is integrated
+-# into AddressSanitizer.
+-
+-#Package: libn32lsan`'LSAN_SO`'LS
+-#Section: ifdef(`TARGET',`devel',`libs')
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Priority: ifdef(`TARGET',`extra',`PRI(optional)')
+-#Depends: BASEDEP, ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: LeakSanitizer -- a memory leak detector (n32)
+-# LeakSanitizer (Lsan) is a memory leak detector which is integrated
+-# into AddressSanitizer.
+-
+-#Package: libn32lsan`'LSAN_SO-dbg`'LS
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Section: debug
+-#Priority: extra
+-#Depends: BASEDEP, libdep(lsan`'LSAN_SO,n32,=), ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: LeakSanitizer -- a memory leak detector (n32 debug symbols)
+-# LeakSanitizer (Lsan) is a memory leak detector which is integrated
+-# into AddressSanitizer.
+-
+-Package: libx32lsan0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (x32)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+-Package: libx32lsan0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32lsan0 (= ${gcc:Version}), ${misc:Depends}
+-Description: LeakSanitizer -- a memory leak detector (x32 debug symbols)
+- LeakSanitizer (Lsan) is a memory leak detector which is integrated
+- into AddressSanitizer.
+-
+ Package: libtsan0
+ Section: libs
+ Architecture: any
+@@ -964,26 +672,6 @@
+ # Various computations will be instrumented to detect undefined behavior
+ # at runtime. Available for C and C++.
+ 
+-Package: libx32ubsan0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: UBSan -- undefined behaviour sanitizer (x32)
+- UndefinedBehaviorSanitizer can be enabled via -fsanitize=undefined.
+- Various computations will be instrumented to detect undefined behavior
+- at runtime. Available for C and C++.
+-
+-Package: libx32ubsan0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32ubsan0 (= ${gcc:Version}), ${misc:Depends}
+-Description: UBSan -- undefined behaviour sanitizer (x32 debug symbols)
+- UndefinedBehaviorSanitizer can be enabled via -fsanitize=undefined.
+- Various computations will be instrumented to detect undefined behavior
+- at runtime. Available for C and C++.
+-
+ Package: libcilkrts5
+ Section: libs
+ Architecture: any
+@@ -1007,162 +695,6 @@
+  Intel Cilk Plus is an extension to the C and C++ languages to support
+  data and task parallelism.
+ 
+-Package: lib32cilkrts5
+-Section: libs
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: ${confl:lib32}
+-Description: Intel Cilk Plus language extensions (32bit)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: lib32cilkrts5-dbg
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib32cilkrts5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (32 bit debug symbols)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: lib64cilkrts5
+-Section: libs
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (64bit)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: lib64cilkrts5-dbg
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib64cilkrts5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (64bit debug symbols)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: libx32cilkrts5
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (x32)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: libx32cilkrts5-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32cilkrts5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Intel Cilk Plus language extensions (x32 debug symbols)
+- Intel Cilk Plus is an extension to the C and C++ languages to support
+- data and task parallelism.
+-
+-Package: libquadmath0
+-Section: libs
+-Architecture: any
+-Multi-Arch: same
+-Pre-Depends: multiarch-support
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC Quad-Precision Math Library
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype. The library is used to provide on such
+- targets the REAL(16) type in the GNU Fortran compiler.
+-
+-Package: libquadmath0-dbg
+-Architecture: any
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libquadmath0 (= ${gcc:Version}), ${misc:Depends}
+-Multi-Arch: same
+-Description: GCC Quad-Precision Math Library (debug symbols)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype.
+-
+-Package: lib32quadmath0
+-Section: libs
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: ${confl:lib32}
+-Description: GCC Quad-Precision Math Library (32bit)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype. The library is used to provide on such
+- targets the REAL(16) type in the GNU Fortran compiler.
+-
+-Package: lib32quadmath0-dbg
+-Architecture: amd64 ppc64 kfreebsd-amd64 s390x sparc64 x32 mipsn32 mipsn32el mips64 mips64el
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib32quadmath0 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC Quad-Precision Math Library (32 bit debug symbols)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype.
+-
+-Package: lib64quadmath0
+-Section: libs
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC Quad-Precision Math Library  (64bit)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype. The library is used to provide on such
+- targets the REAL(16) type in the GNU Fortran compiler.
+-
+-Package: lib64quadmath0-dbg
+-Architecture: i386 powerpc sparc s390 mips mipsel mipsn32 mipsn32el x32
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), lib64quadmath0 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC Quad-Precision Math Library  (64bit debug symbols)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype.
+-
+-#Package: libn32quadmath`'QMATH_SO`'LS
+-#Section: ifdef(`TARGET',`devel',`libs')
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Priority: ifdef(`TARGET',`extra',`PRI(optional)')
+-#Depends: BASEDEP, ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: GCC Quad-Precision Math Library (n32)
+-# A library, which provides quad-precision mathematical functions on targets
+-# supporting the __float128 datatype. The library is used to provide on such
+-# targets the REAL(16) type in the GNU Fortran compiler.
+-
+-#Package: libn32quadmath`'QMATH_SO-dbg`'LS
+-#Architecture: ifdef(`TARGET',`CROSS_ARCH',`biarchn32_archs')
+-#Section: debug
+-#Priority: extra
+-#Depends: BASEDEP, libdep(quadmath`'QMATH_SO,n32,=), ${misc:Depends}
+-#BUILT_USING`'dnl
+-#Description: GCC Quad-Precision Math Library (n32 debug symbols)
+-# A library, which provides quad-precision mathematical functions on targets
+-# supporting the __float128 datatype.
+-
+-Package: libx32quadmath0
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: GCC Quad-Precision Math Library (x32)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype. The library is used to provide on such
+- targets the REAL(16) type in the GNU Fortran compiler.
+-
+-Package: libx32quadmath0-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32quadmath0 (= ${gcc:Version}), ${misc:Depends}
+-Description: GCC Quad-Precision Math Library (x32 debug symbols)
+- A library, which provides quad-precision mathematical functions on targets
+- supporting the __float128 datatype.
+-
+ Package: gobjc++-4.9
+ Architecture: any
+ Priority: optional
+@@ -1246,15 +778,6 @@
+  This package contains the headers and static library files needed to build
+  GNU ObjC applications.
+ 
+-Package: libx32objc-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32objc4 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32 development files)
+- This package contains the headers and static library files needed to build
+- GNU ObjC applications.
+-
+ Package: libobjc4
+ Section: libs
+ Architecture: any
+@@ -1325,22 +848,6 @@
+ Description: Runtime library for GNU Objective-C applications (n32 debug symbols)
+  Library needed for GNU ObjC applications linked against the shared library.
+ 
+-Package: libx32objc4
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32)
+- Library needed for GNU ObjC applications linked against the shared library.
+-
+-Package: libx32objc4-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32objc4 (= ${gcc:Version}), libx32gcc1-dbg (>= ${gcc:EpochVersion}), ${misc:Depends}
+-Description: Runtime library for GNU Objective-C applications (x32 debug symbols)
+- Library needed for GNU ObjC applications linked against the shared library.
+-
+ Package: gfortran-4.9
+ Architecture: any
+ Priority: optional
+@@ -1401,15 +908,6 @@
+  This package contains the headers and static library files needed to build
+  GNU Fortran applications.
+ 
+-Package: libx32gfortran-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32gfortran3 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32 development files)
+- This package contains the headers and static library files needed to build
+- GNU Fortran applications.
+-
+ Package: libgfortran3
+ Section: libs
+ Architecture: any
+@@ -1489,24 +987,6 @@
+  Library needed for GNU Fortran applications linked against the
+  shared library.
+ 
+-Package: libx32gfortran3
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32)
+- Library needed for GNU Fortran applications linked against the
+- shared library.
+-
+-Package: libx32gfortran3-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gfortran3 (= ${gcc:Version}), ${misc:Depends}
+-Description: Runtime library for GNU Fortran applications (x32 debug symbols)
+- Library needed for GNU Fortran applications linked against the
+- shared library.
+-
+ Package: gccgo-4.9
+ Architecture: any
+ Priority: optional
+@@ -1612,25 +1092,6 @@
+  Library needed for GNU Go applications linked against the
+  shared library.
+ 
+-Package: libx32go5
+-Section: libs
+-Architecture: amd64 i386
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), ${dep:libcbiarch}, ${shlibs:Depends}, ${misc:Depends}
+-Replaces: libx32go3
+-Description: Runtime library for GNU Go applications (x32)
+- Library needed for GNU Go applications linked against the
+- shared library.
+-
+-Package: libx32go5-dbg
+-Section: debug
+-Architecture: amd64 i386
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32go5 (= ${gcc:Version}), ${misc:Depends}
+-Description: Runtime library for GNU Go applications (x32 debug symbols)
+- Library needed for GNU Go applications linked against the
+- shared library.
+-
+ Package: gcj-4.9
+ Section: java
+ Architecture: any
+@@ -1832,19 +1293,6 @@
+  was included up to g++-2.95. The first version of libstdc++-v3 appeared
+  in g++-3.0.
+ 
+-Package: libx32stdc++6
+-Architecture: amd64 i386
+-Section: libs
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc1 (>= ${gcc:Version}), ${shlibs:Depends}, ${misc:Depends}
+-Description: GNU Standard C++ Library v3 (x32)
+- This package contains an additional runtime library for C++ programs
+- built with the GNU compiler.
+- .
+- libstdc++-v3 is a complete rewrite from the previous libstdc++-v2, which
+- was included up to g++-2.95. The first version of libstdc++-v3 appeared
+- in g++-3.0.
+-
+ Package: libstdc++-4.9-dev
+ Architecture: any
+ Multi-Arch: same
+@@ -1981,33 +1429,6 @@
+ Description: GNU Standard C++ Library v3 (debugging files)
+  This package contains the shared library of libstdc++ compiled with
+  debugging symbols.
+-
+-Package: libx32stdc++-4.9-dev
+-Architecture: amd64 i386
+-Section: libdevel
+-Priority: optional
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32gcc-4.9-dev (= ${gcc:Version}), libx32stdc++6 (>= ${gcc:Version}),
+- libstdc++-4.9-dev (= ${gcc:Version}), ${misc:Depends}
+-Description: GNU Standard C++ Library v3 (development files)
+- This package contains the headers and static library files necessary for
+- building C++ programs which use libstdc++.
+- .
+- libstdc++-v3 is a complete rewrite from the previous libstdc++-v2, which
+- was included up to g++-2.95. The first version of libstdc++-v3 appeared
+- in g++-3.0.
+-
+-Package: libx32stdc++6-4.9-dbg
+-Architecture: amd64 i386
+-Section: debug
+-Priority: extra
+-Depends: gcc-4.9-base (= ${gcc:Version}), libx32stdc++6 (>= ${gcc:Version}),
+- libstdc++-4.9-dev (= ${gcc:Version}), libx32gcc1-dbg (>= ${gcc:EpochVersion}),
+- ${shlibs:Depends}, ${misc:Depends}
+-Conflicts: libx32stdc++6-dbg, libx32stdc++6-4.6-dbg,
+- libx32stdc++6-4.7-dbg, libx32stdc++6-4.8-dbg
+-Description: GNU Standard C++ Library v3 (debugging files)
+- This package contains the shared library of libstdc++ compiled with
+- debugging symbols.
+ 
+ Package: libstdc++-4.9-doc
+ Architecture: all


### PR DESCRIPTION
Fixes #829 & https://github.com/nodejs/node/issues/4531 & https://github.com/nodejs/node/issues/15157 & https://github.com/nodejs/build/issues/897

Also added debian/control patch for making Jessie GCC 4.9 source packages compile on ARMv7 Wheezy, adapted from setup/debian-wheezy-gcc/deb-control.patch (tediously adapted I might add ...). I've put this patch file in doc/ rather than setup/debian-wheezy-gcc assuming that the whole setup/ directory will eventually be nuked (well, that's the hope but it's probably a pipe dream). Does it make sense to put a .patch in here?