### PR TITLE
libfontconfig, java 8, other minor ansible fixes for fedora, debian, ubuntu

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -90,8 +90,8 @@ hosts:
         freebsd10-x64-1: {ip: 159.203.59.134, user: freebsd}
         freebsd11-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd11-x64-2: {ip: 107.170.28.213, user: freebsd}
-        ubuntu12-x64-1: {ip: 104.236.234.182}
-        ubuntu12-x64-2: {ip: 107.170.104.83}
+        ubuntu1204-x64-1: {ip: 104.236.234.182}
+        ubuntu1204-x64-2: {ip: 107.170.104.83}
         ubuntu1404-x64-1: {ip: 45.55.252.223}
         ubuntu1404-x86-1: {ip: 159.203.115.220}
         ubuntu1604-x86-1: {ip: 159.203.77.233}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -16,21 +16,22 @@ ssh_config: /etc/ssh/sshd_config
 
 sshd_service_map: {
   'ubuntu1404': 'ssh',
-  }
+  'ubuntu1204': 'ssh',
+}
 
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
   systemd: ['debian8', 'ubuntu1604', 'ubuntu1610'],
   ntp_package: ['ubuntu1404']
-  }
+}
 
 common_packages: [
   'automake',
   'bash',
   'libtool',
   'sudo',
-  ]
+]
 
 # you can either add os family or os to this list (see smartos)
 # but the playbook chooses os over family - not both
@@ -51,26 +52,28 @@ packages: {
   centos: [
     'ccache',
     'git',
-    ],
+  ],
 
   centos7: [
     'gcc-c++',
-    ],
+  ],
 
   debian7: [
     'gcc-4.8',
     'g++-4.8',
-    ],
+  ],
 
   debian8: [
     'ccache',
     'git',
-    ],
+    'libfontconfig1',
+  ],
 
   fedora: [
     'ccache',
     'gcc-c++',
     'git',
+    'fontconfig',
   ],
 
   freebsd: [
@@ -86,7 +89,7 @@ packages: {
     'git',
     'gmake',
     'xz'
-    ],
+  ],
 
   smartos15: [
     'gcc49',
@@ -95,7 +98,7 @@ packages: {
     'git',
     'gmake',
     'xz'
-    ],
+  ],
 
   smartos16: [
     'gcc49',
@@ -104,16 +107,17 @@ packages: {
     'git',
     'gmake',
     'xz'
-    ],
+  ],
 
   ubuntu: [
     'ccache',
     'g++',
     'gcc',
     'git',
-    ],
+    'libfontconfig1',
+  ],
 
   ubuntu1404: [
     'ntp',
-    ]
-  }
+  ]
+}

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -4,8 +4,38 @@
 # installs java
 #
 
+- name: install add-apt-repostory
+  when: os in ("ubuntu1204", "ubuntu1404")
+  package: name=software-properties-common state=present
+
+- name: add webupd8 oracle java repository
+  when: os in ("ubuntu1204", "ubuntu1404")
+  apt_repository: repo='ppa:webupd8team/java'
+
+- name: add webupd8team oracle java repository
+  when: os == "debian8"
+  lineinfile:
+    dest: /etc/apt/sources.list
+    state: present
+    line: deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main
+
+- name: add webupd8team oracle java repository key
+  when: os == "debian8"
+  shell: apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
+
+- name: accept webupd8 oracle java 8 license
+  when: os in ("ubuntu1204", "ubuntu1404") or os == "debian8"
+  debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.
 - name: install java
   when: not os|startswith("zos")
   package: name="{{ java_package_name }}" state=present
+
+- name: install webupd8 oracle java 8 extras
+  when: os in ("ubuntu1204", "ubuntu1404")
+  package: name="{{item}}" state=present
+  with_items:
+    - ca-certificates
+    - oracle-java8-set-default

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -9,12 +9,13 @@ packages: {
   'centos5': 'java-1.7.0-openjdk',
   'centos': 'java-1.8.0-openjdk-headless',
   'debian7': 'openjdk-7-jre-headless',
-  'debian8': 'openjdk-8-jre-headless',
+  'debian8': 'oracle-java8-installer',
   'fedora': 'java-1.8.0-openjdk-headless',
   'freebsd': 'openjdk8-jre',
   'smartos': 'openjdk8',
   'ubuntu': 'openjdk-8-jre-headless',
-  'ubuntu1404': 'openjdk-7-jre-headless',
+  'ubuntu1404': 'oracle-java8-installer',
+  'ubuntu1204': 'oracle-java8-installer',
   }
 
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"


### PR DESCRIPTION
There's some stuff in here for ubuntu1204 and we may be removing that (see https://github.com/nodejs/build/issues/961)

fedora 22->24 are having some problems with fetching updates cause they are EOL, seem to be OK on DigitalOcean because I guess they have a local mirror.

Java updates as per notes in #775, this formalises the debian and ubuntu items in that list, the rest still need doing.

The fontconfig stuff in here should fix #937

Also worth noting that I've run these scripts across all the machines multiple times now, and unless something fails in CI, that means our scripts are idempotent! `ansible-playbook playbooks/jenkins/worker/create.yml --limit test-*ubuntu*-x*,test-*fedora*,test-*debian8-x*`