### PR TITLE
www: sync w/ current nodejs.org config

### DIFF
--- a/setup/www/resources/scripts/sync-benchmarking.sh
+++ b/setup/www/resources/scripts/sync-benchmarking.sh
@@ -3,7 +3,8 @@
 pidfile=/var/run/nodejs/sync-benchmarking.pid
 cmd="
   rsync -aqz --delete benchmark:charts/ /home/www/benchmarking/charts/ &&
-  rsync -aqz --delete benchmark:coverage-out/out/ /home/www/coverage/
+  rsync -aqz --delete benchmark:coverage-out/out/ /home/www/coverage/ &&
+  scp benchmark:benchmarking/www/index.html /home/www/benchmarking/
 "
 
 if [ -a "$pidfile" -a -r "$pidfile" ]; then

--- a/setup/www/tasks/base.yaml
+++ b/setup/www/tasks/base.yaml
@@ -1,5 +1,5 @@
 - name: Base | Add the NodeSource Node.js repo
-  command: "bash -c 'curl -sL https://deb.nodesource.com/setup_6.x | bash -'"
+  command: "bash -c 'curl -sL https://deb.nodesource.com/setup_8.x | bash -'"
   tags: base
 
 - name: Base | APT Update

--- a/setup/www/tasks/tools.yaml
+++ b/setup/www/tasks/tools.yaml
@@ -30,10 +30,9 @@
     dest: /etc/crontab
     line: "{{ item }}"
   with_items:
-    - '0 20    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/v6.x --config /etc/nightly-builder.json'
-    - '0 19    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/v7.x --config /etc/nightly-builder.json'
+    - '0 20    * * *   dist    /usr/bin/nodejs-nightly-builder --type v8-canary --ref heads/canary --config /etc/nightly-builder-v8-canary.json'
+    - '0 19    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/v9.x-staging --config /etc/nightly-builder.json'
     - '0 18    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/master --config /etc/nightly-builder.json'
-    - '0 11    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/v8.x --config /etc/nightly-builder-chakracore.json'
+    - '0 11    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/v9.x --config /etc/nightly-builder-chakracore.json'
     - '0 10    * * *   dist    /usr/bin/nodejs-nightly-builder --type nightly --ref heads/master --config /etc/nightly-builder-chakracore.json'
-    - '1 0     * * *   root    npm update -g nodejs-latest-linker nodejs-dist-indexer nodejs-nightly-builder >& /dev/null'
   tags: tools


### PR DESCRIPTION
Addresses #200 and a few other minor things that are on the server but are not reflected in the scripts for it.

Adds the log-collect stuff that's on there collecting logs for us from cloudflare and doing some basic filtering. There's also some stuff in there to convert the json format to nginx format but it's not being used for anything currently. The log-collect work is only partially complete since we're collecting but not using it for metrics generation yet. We still need to (a) confirm that we're successfully collecting everything with this procedure (logshare isn't the most robust tool unfortunately, or maybe it's their API, hence the sanity-check script in here), and (b) either do the json->nginx conversion for metrics, or make metrics scripts able to read the json files as they are. Either way, this PR reflects current state so is good to merge IMO.

I haven't tested this .. a bit of a stab in the dark, I'm not willing to run this against the live server.