### PR TITLE
github-bot: add IPs of Jenkins workers

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -197,6 +197,8 @@ Unsorted stuff of things we need to do/think about
 - [ ] add explicit ARCH and DESTCPU for release machines (RV: I'm adding
       "arm64" manually for both to force the right thing, from memory I've
       needed to do this on x86 and x64, best be explicit to be sure)
+- [ ] github-bot: automate list of whitelisted Jenkins worker IPs with
+      python
 
 [callback]: plugins/inventory/nodejs_yaml.py
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -232,6 +232,8 @@ hosts:
         centos7-arm64-2: {ip: 147.75.74.254}
         ubuntu1604-arm64-1: {ip: 147.75.77.130}
         ubuntu1604-arm64-2: {ip: 147.75.74.174}
+# when adding, removing or changing the IPs below,
+# remember to update Jenkins worker IP whitelist in github-bot
         ubuntu1604-x64-1: {ip: 147.75.69.113, alias: jenkins-workspace-1}
         ubuntu1604-x64-2: {ip: 147.75.73.189, alias: jenkins-workspace-2}
 

--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -9,3 +9,4 @@ LOGS_DIR=/home/{{server_user}}/logs
 JENKINS_API_CREDENTIALS={{envs.jenkins_api_credentials}}
 JENKINS_JOB_URL_CITGM={{envs.jenkins_job_url_citgm}}
 JENKINS_BUILD_TOKEN_CITGM={{envs.jenkins_build_token_citgm}}
+JENKINS_WORKER_IPS=147.75.69.113,147.75.73.189


### PR DESCRIPTION
Providing `$JENKINS_WORKER_IPS` environment variable at startup will activate the whitelist implemented in the bot, validating who's allowed to pushed Jenkins job updates as inline PR statuses on github.com.

Refs https://github.com/nodejs/github-bot/pull/142

/cc @nodejs/github-bot 