### PR TITLE
WIP alpine: support alpine 3.5

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -104,12 +104,13 @@ For more information refer to other hosts in `inventory.yml` or the
 
 Each host needs a bit of metadata:
 
-  - (required) `ip`: used both by ansible and placed in your ssh config.
-  - `user`: only provide if ssh requires a non-root login. Passing this
+  - (required) `ip`: used both by ansible and placed in your ssh config
+  - `user`: only provide if ssh requires a non-root login—passing this
              will additionally make ansible try to become root for all
-             commands executed.
-  - `alias`: creates shorthand names for ssh convenience.
-  - `labels`: Each host can also labels. More on that below.
+             commands executed
+  - `alias`: creates shorthand names for ssh convenience
+  - `labels`: each host can also labels, more on that below
+  - `server_jobs`: fix the number of parallel compile and test processes
 
 ### Adding extra options to a host
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -104,6 +104,8 @@ hosts:
     - joyent:
         alpine34-x64-1: {ip: 72.2.114.80}
         alpine34-x64-2: {ip: 72.2.115.165}
+        alpine35-x64-1: {ip: }
+        alpine35-x64-2: {ip: }
         freebsd10-x64-1: {ip: 72.2.115.15}
         freebsd10-x64-2: {ip: 72.2.114.23}
         smartos14-x64-1: {ip: 72.2.114.47}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -102,10 +102,10 @@ hosts:
         aix61-ppc64-1: {ip: 50.200.166.131, port: 18822}
 
     - joyent:
-        alpine34-x64-1: {ip: 72.2.114.80}
-        alpine34-x64-2: {ip: 72.2.115.165}
-        alpine35-x64-1: {ip: }
-        alpine35-x64-2: {ip: }
+        alpine34-x64-1: {ip: 72.2.114.80, server_jobs: 2}
+        alpine34-x64-2: {ip: 72.2.115.165, server_jobs: 2}
+        alpine35-x64-1: {ip: 72.2.119.198, server_jobs: 2}
+        alpine35-x64-2: {ip: 72.2.118.27, server_jobs: 2}
         freebsd10-x64-1: {ip: 72.2.115.15}
         freebsd10-x64-2: {ip: 72.2.114.23}
         smartos14-x64-1: {ip: 72.2.114.47}

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -57,6 +57,7 @@ valid = {
 # - ip [string] (required): ip address of host
 # - alias [string]: 'nickname', will be used in ssh config
 # - labels [sequence]: passed to jenkins
+# - server_jobs [cpus]: passed as JOBS to jenkins
 #
 # parsing done on host naming:
 #
@@ -134,6 +135,9 @@ def main():
 
                         if 'alias' in metadata:
                             c.update({'alias': metadata['alias']})
+
+                        if 'server_jobs' in metadata:
+                            c.update({'server_jobs': metadata['server_jobs']})
 
                         if 'win' in hostname:
                             c.update({'is_win': True})

--- a/ansible/roles/baselayout/tasks/partials/repo/alpine.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/alpine.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-# alpine34 repos - these are required in bootstrap so they're probably in place
+# alpine3 repos - these are required in bootstrap so they're probably in place
 #
 
 - name: "repos : add alpine edge package repos"

--- a/ansible/roles/bootstrap/tasks/partials/alpine.yml
+++ b/ansible/roles/bootstrap/tasks/partials/alpine.yml
@@ -35,3 +35,9 @@
 - name: install shadow
   when: has_shadow.rc == 1
   raw: apk add shadow
+
+# required for bug on Joyent for Alpine 3.4 using OpenSSL 7.5+
+# discussio @ https://github.com/nodejs/build/pull/989
+- name: fix openssl to < 7.5
+  raw: apk add 'openssh<7.5'
+

--- a/ansible/roles/bootstrap/tasks/partials/alpine.yml
+++ b/ansible/roles/bootstrap/tasks/partials/alpine.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-#  alpine 3.4
+#  alpine 3.x
 #
 
 - name: check for python
@@ -24,11 +24,11 @@
     create: yes
     line: "{{ item }}"
     state: present
-  with_items: "{{ alpine34_repos }}"
+  with_items: "{{ alpine3_repos }}"
   register: has_added_package_repo
 
 - name: check for shadow
-  raw: apk info -q shadow
+  raw: apk info | grep shadow
   failed_when: has_shadow.rc > 1
   register: has_shadow
 

--- a/ansible/roles/bootstrap/vars/main.yml
+++ b/ansible/roles/bootstrap/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
 
-alpine34_repos: [
+alpine3_repos: [
   'https://dl-3.alpinelinux.org/alpine/edge/main',
   'https://dl-3.alpinelinux.org/alpine/edge/community' # java lives here
   ]

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -6,6 +6,7 @@
 
 packages: {
   'alpine34': 'openjdk8-jre-base',
+  'alpine35': 'openjdk8-jre-base',
   'centos5': 'java-1.7.0-openjdk',
   'centos': 'java-1.8.0-openjdk-headless',
   'debian7': 'openjdk-7-jre-headless',

--- a/ansible/roles/jenkins-worker/tasks/monit.yml
+++ b/ansible/roles/jenkins-worker/tasks/monit.yml
@@ -12,7 +12,7 @@
   args:
     src: "{{ monitrc }}"
     dest: "/etc/monitrc"
-    mode: 0440
+    mode: 0400
   loop_control:
     loop_var: monitrc
   with_first_found:

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -63,6 +63,7 @@ jenkins: "{{ jenkins_init[init_type] }}"
 
 needs_monit: [
   'alpine34',
+  'alpine35',
   'centos5',
   'centos6',
   'debian7',


### PR DESCRIPTION
This should work in theory but there's a problem with the containers on Joyent once you upgrade the packages. It pulls in a new sshd that doesn't like the `UsePrivilegeSeparation` option (deprecated) but sandbox setup appears to be why any additional ssh connections fail. i.e. once the ansible script updates the packages on the host, you can no longer establish new ssh connections. I've tried a bunch of things with sshd config to make it work with no success. Googling doesn't help much either although the one interesting result is this https://smartos.org/bugview/OS-4407 which looks connected, although old. The `Resource temporarily unavailable [preauth]` message is the same, and the `DEBUG3` output is very similar, but `UsePrivilegeSeparation` deprecation seems to be the problem. My guess is that since openssh [7.5](https://www.openssh.com/txt/release-7.5), privilege separation is mandatory so you can't turn it off but the underlying platform doesn't support what it's trying to do (smartos?).

@misterdjules any thoughts on who we could ping for support on this?