### PR TITLE
add `bzip2` to fedora baselayout

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -70,6 +70,7 @@ packages: {
   ],
 
   fedora: [
+    'bzip2',
     'ccache',
     'gcc-c++',
     'git',


### PR DESCRIPTION
Used by CitGM:

```
 > phantomjs-prebuilt@2.1.16 install /home/iojs/build/workspace/citgm-smoker/nodes/fedora-latest-x64/citgm_tmp/4ad209ec-9e2f-4cc4-9d0f-772b05fb6f59/eslint/node_modules/phantomjs-prebuilt
 > node install.js
 PhantomJS not found on PATH
 Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
 Saving to /home/iojs/build/workspace/citgm-smoker/nodes/fedora-latest-x64/citgm_tmp/4ad209ec-9e2f-4cc4-9d0f-772b05fb6f59/npm_config_tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
 Receiving...
 Received 22866K total.
 Extracting tar contents (via spawned process)
 Error extracting archive
 Phantom installation failed { Error: Command failed: tar jxf /home/iojs/build/workspace/citgm-smoker/nodes/fedora-latest-x64/citgm_tmp/4ad209ec-9e2f-4cc4-9d0f-772b05fb6f59/npm_config_tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
 tar (child): bzip2: Cannot exec: No such file or directory

```