### PR TITLE
jenkins: make curl use ipv4

### DIFF
--- a/jenkins/pipelines/post-build-status-update.jenkinsfile
+++ b/jenkins/pipelines/post-build-status-update.jenkinsfile
@@ -56,7 +56,7 @@ def sendBuildStatus(repo, identifier, status, url, commit, ref) {
         'message': message
         ])
 
-    def script = "curl -s -o /dev/null --connect-timeout 5 -X POST " +
+    def script = "curl --ipv4 -s -o /dev/null --connect-timeout 5 -X POST " +
         "-H 'Content-Type: application/json' -d '${buildPayload}' " +
         "http://github-bot.nodejs.org:3333/${repo}/jenkins/${path}"
 


### PR DESCRIPTION
Having errors with github-bot currently...

16:19:08.251  INFO bot: request finish (req_id=7ada38f2-de42-47b9-8746-e582ad53a907, duration=1, req.query={}, req.remoteAddress=::ffff:147.75.69.113, req.remotePort=44716)

... because curl is trying to use IPv6.

cc @refack @phillipj 