### PR TITLE
docker: add openssl 1.0.2 and zlib

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -113,7 +113,7 @@ hosts:
         smartos15-x64-2: {ip: 165.225.139.77}
         smartos16-x64-1: {ip: 72.2.115.252}
         smartos16-x64-2: {ip: 72.2.113.74}
-        ubuntu1604_docker-x64-1: {ip: 72.2.118.27, user: ubuntu}
+        ubuntu1604_docker-x64-1: {ip: 165.225.138.30, user: ubuntu}
         ubuntu1710-x64-1: {ip: 37.153.110.33, user: ubuntu}
         ubuntu1710-x64-2: {ip: 8.19.32.121, user: ubuntu}
 

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -97,6 +97,22 @@
   with_items:
     - "{{ containers }}"
 
+- name: create worker ccache directory
+  file:
+    path: "/home/{{ server_user }}/.ccache/"
+    state: directory
+    owner: "{{ server_user }}"
+    group: "{{ server_user }}"
+    mode: 0755
+
+- name: generate ccache config
+  template:
+    src: "{{ role_path }}/templates/ccache_config.j2"
+    dest: "/home/{{ server_user }}/.ccache/ccache.conf"
+    owner: "{{ server_user }}"
+    group: "{{ server_user }}"
+    mode: "0644"
+
 - name: register {{ server_user }} GID
   raw: "grep ^{{ server_user }} /etc/passwd | awk -F: '{print $4}'"
   register: server_user_gid

--- a/ansible/roles/docker/templates/alpine34.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine34.Dockerfile.j2
@@ -44,7 +44,7 @@ RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
 
-VOLUME [ "/home/{{ server_user }}/" ]
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/alpine34.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine34.Dockerfile.j2
@@ -48,6 +48,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \

--- a/ansible/roles/docker/templates/alpine35.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine35.Dockerfile.j2
@@ -49,6 +49,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \

--- a/ansible/roles/docker/templates/alpine35.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine35.Dockerfile.j2
@@ -45,7 +45,7 @@ RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
 
-VOLUME [ "/home/{{ server_user }}/" ]
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/alpine36.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine36.Dockerfile.j2
@@ -45,7 +45,7 @@ RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
 
-VOLUME [ "/home/{{ server_user }}/" ]
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/alpine36.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine36.Dockerfile.j2
@@ -48,6 +48,7 @@ RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \

--- a/ansible/roles/docker/templates/alpine37.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine37.Dockerfile.j2
@@ -48,6 +48,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \

--- a/ansible/roles/docker/templates/ccache_config.j2
+++ b/ansible/roles/docker/templates/ccache_config.j2
@@ -1,0 +1,1 @@
+max_size = 20G

--- a/ansible/roles/docker/templates/ccache_config.j2
+++ b/ansible/roles/docker/templates/ccache_config.j2
@@ -1,1 +1,1 @@
-max_size = 20G
+max_size = 25G

--- a/ansible/roles/docker/templates/jenkins.service.j2
+++ b/ansible/roles/docker/templates/jenkins.service.j2
@@ -9,7 +9,7 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} --name node-ci-{{ item.name }} node-ci:{{ item.name }}
+ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} -v /home/{{ server_user }}/.ccache/:/home/{{ server_user }}/.ccache --name node-ci-{{ item.name }} node-ci:{{ item.name }}
 ExecStop=/usr/bin/docker stop -t 5 node-ci-{{ item.name }}
 Restart=always
 RestartSec=30

--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -29,7 +29,7 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
-VOLUME [ "/home/{{ server_user }}/" ]
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -33,6 +33,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -41,6 +41,16 @@ RUN mkdir -p /tmp/openssl_1.1.0g && \
     make install && \
     rm -rf /tmp/openssl_1.1.0g
 
+ENV OPENSSL102DIR /opt/openssl-1.0.2m
+
+RUN mkdir -p /tmp/openssl_1.0.2m && \
+    cd /tmp/openssl_1.0.2m && \
+    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2m.tar.gz | tar zxv --strip=1 && \
+    ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
+    make -j 6 && \
+    make install && \
+    rm -rf /tmp/openssl_1.0.2m
+
 ENV FIPS20DIR /opt/openssl-fips_2.0.16
 
 RUN FIPSDIR=$FIPS20DIR mkdir -p /tmp/openssl-fips_2.0.16 && \
@@ -50,6 +60,16 @@ RUN FIPSDIR=$FIPS20DIR mkdir -p /tmp/openssl-fips_2.0.16 && \
     make && \
     make install && \
     rm -rf /tmp/openssl-fips_2.0.16
+
+ENV ZLIB12DIR /opt/zlib_1.2.11
+
+RUN mkdir -p /tmp/zlib_1.2.11 && \
+    cd /tmp/zlib_1.2.11 && \
+    curl -sL https://zlib.net/zlib-1.2.11.tar.gz | tar zxv --strip=1 && \
+    ./configure --prefix=$ZLIB12DIR && \
+    make -j 6 && \
+    make install && \
+    rm -rf /tmp/zlib_1.2.11
 
 VOLUME [ "/home/{{ server_user }}/" ]
 

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -41,15 +41,15 @@ RUN mkdir -p /tmp/openssl_1.1.0g && \
     make install && \
     rm -rf /tmp/openssl_1.1.0g
 
-ENV OPENSSL102DIR /opt/openssl-1.0.2m
+ENV OPENSSL102DIR /opt/openssl-1.0.2n
 
-RUN mkdir -p /tmp/openssl_1.0.2m && \
-    cd /tmp/openssl_1.0.2m && \
-    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2m.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.0.2n && \
+    cd /tmp/openssl_1.0.2n && \
+    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2n.tar.gz | tar zxv --strip=1 && \
     ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.0.2m
+    rm -rf /tmp/openssl_1.0.2n
 
 ENV FIPS20DIR /opt/openssl-fips_2.0.16
 

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -75,6 +75,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -71,7 +71,7 @@ RUN mkdir -p /tmp/zlib_1.2.11 && \
     make install && \
     rm -rf /tmp/zlib_1.2.11
 
-VOLUME [ "/home/{{ server_user }}/" ]
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -31,6 +31,16 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
+ENV OPENSSL102DIR /opt/openssl-1.0.2n
+
+RUN mkdir -p /tmp/openssl_1.0.2n && \
+    cd /tmp/openssl_1.0.2n && \
+    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2n.tar.gz | tar zxv --strip=1 && \
+    ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
+    make -j 6 && \
+    make install && \
+    rm -rf /tmp/openssl_1.0.2n
+
 ENV OPENSSL110DIR /opt/openssl-1.1.0g
 
 RUN mkdir -p /tmp/openssl_1.1.0g && \
@@ -41,15 +51,15 @@ RUN mkdir -p /tmp/openssl_1.1.0g && \
     make install && \
     rm -rf /tmp/openssl_1.1.0g
 
-ENV OPENSSL102DIR /opt/openssl-1.0.2n
+ENV OPENSSL111DIR /opt/openssl-1.1.1-pre1
 
-RUN mkdir -p /tmp/openssl_1.0.2n && \
-    cd /tmp/openssl_1.0.2n && \
-    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2n.tar.gz | tar zxv --strip=1 && \
-    ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
+RUN mkdir -p /tmp/openssl_1.1.1-pre1 && \
+    cd /tmp/openssl_1.1.1-pre1 && \
+    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-pre1.tar.gz | tar zxv --strip=1 && \
+    ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.0.2n
+    rm -rf /tmp/openssl_1.1.1-pre1
 
 ENV FIPS20DIR /opt/openssl-fips_2.0.16
 

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM ubuntu:18.04
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
@@ -13,36 +13,21 @@ ENV OSVARIANT docker
 ENV DESTCPU x64
 ENV ARCH x64
 
-RUN apk add --no-cache --upgrade apk-tools
-
-RUN apk add --no-cache libstdc++
-
-RUN apk add --no-cache --virtual .build-deps \
-        shadow \
-        binutils-gold \
-        curl \
-        g++ \
-        gcc \
-        gnupg \
-        libgcc \
-        linux-headers \
-        make \
-        paxctl \
-        python \
-        tar \
-        ccache \
-        openjdk8 \
-        git \
-        procps \
-        openssh-client \
-        py2-pip \
-        bash
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
+    ccache \
+    g++ \
+    gcc \
+    git \
+    openjdk-8-jre-headless \
+    curl \
+    python-pip \
+    libfontconfig1
 
 RUN pip install tap2junit
 
-RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
+RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
-RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
+RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -33,6 +33,8 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
 
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
 CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \


### PR DESCRIPTION
These are operational in CI now, see https://ci.nodejs.org/job/node-test-commit-linux-linked/1131/ for master and https://ci.nodejs.org/job/node-test-commit-linux-linked/1133/ for v4.x.

Next up libuv, cares and nghttp2 .. maybe http-parser, but I'm not sure anyone's actually using that shared functionality.