### PR TITLE
doc: add maclover7 to github bot admin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ missing please open an issue. If you are interested in joining check out
 - [@jbergstroem](https://github.com/jbergstroem) - Johan Bergström
 - [@joaocgreis](https://github.com/joaocgreis) - João Reis
 - [@joyeecheung](https://github.com/joyeecheung) - Joyee Cheung
+- [@maclover7](https://github.com/maclover7) - Jon Moss
 - [@phillipj](https://github.com/phillipj) - Phillip Johnsen
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 


### PR DESCRIPTION
Been doing a bunch of work on the bot related to pull request status
lights, and would be helpful to have elevated permissions. For example,
Ansible permissions were needed to roll out
https://github.com/nodejs/build/pull/1054.

cc @phillipj 