### PR TITLE
ansible: introduce create-github-bot playbook

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -41,6 +41,9 @@ These playbooks are available to you:
 
   - **jenkins/linter.yml**: Sets up the code linters (flavour of a worker).
 
+  - **create-github-bot.yml**: Configures the server that hosts the
+    [github-bot][].
+
   - **create-webhost.yml**: Configures the server(s) that host nodejs.org,
                             iojs.org and dist.libuv.org among other things
                             (only works on Ubuntu boxes).
@@ -192,4 +195,4 @@ Unsorted stuff of things we need to do/think about
       python
 
 [callback]: plugins/inventory/nodejs_yaml.py
-
+[github-bot]: https://github.com/nodejs/github-bot

--- a/ansible/playbooks/create-github-bot.yml
+++ b/ansible/playbooks/create-github-bot.yml
@@ -1,0 +1,33 @@
+---
+
+#
+# sets up the host that runs the github-bot
+#
+# To properly run with secrets, copy and paste the YAML from
+# `build/github-bot/deployment_secrets.md` in the `nodejs/secrets` repo into
+# `ansible/host_vars/infra-rackspace-debian8-x64-1` in this repo (nodejs/build)
+#
+
+- hosts: infra-rackspace-debian8-x64-1
+  roles:
+    - bootstrap
+    - package-upgrade
+    - github-bot
+  pre_tasks:
+    - name: check if secrets are properly set
+      fail:
+      failed_when: not {{ secret }}
+      loop_control:
+        loop_var: secret
+      with_items:
+        - envs.port
+        - envs.travis_token
+        - envs.github_token
+        - envs.github_webhook_secret
+        - envs.login_credentials
+        - envs.jenkins_api_credentials
+        - envs.jenkins_job_citgm
+        - envs.jenkins_build_token_citgm
+        - envs.jenkins_job_node
+        - envs.jenkins_build_token_node
+        - conf.github_deploy_webhook_secret

--- a/ansible/roles/github-bot/tasks/main.yml
+++ b/ansible/roles/github-bot/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+
+- name: Bootstrap | Install baseline packages
+  package:
+    name: "{{ package }}"
+    state: present
+  loop_control:
+    loop_var: package
+  with_items: "{{ base_packages }}"
+
+- name: Bootstrap | Add nodesource signing key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Bootstrap | Add nodesource repo
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_6.x jessie main
+    state: present
+
+- name: Bootstrap | APT Update and upgrade
+  apt:
+    update_cache: yes
+    upgrade: full
+
+- name: Bootstrap | Install packages
+  package:
+    name: "{{ package }}"
+    state: present
+  loop_control:
+    loop_var: package
+  with_items: "{{ packages }}"
+
+- name: Bootstrap | Enable time syncing
+  service:
+    name: systemd-timesyncd
+    state: started
+    enabled: yes
+
+- name: Boostrap | Add {{ server_user }} user
+  user:
+    name: "{{ server_user }}"
+
+- name: Init | Create required directories
+  file:
+    path: "/home/{{ server_user }}/{{ item }}"
+    state: directory
+    mode: 0755
+    owner: "{{ server_user }}"
+  with_items: "{{ required_directories }}"
+
+- name: Init | Generate and copy init script
+  template:
+    src: "{{ role_path }}/templates/github-bot.service.j2"
+    dest: /lib/systemd/system/github-bot.service
+
+- name: Init | Generate and copy systemd EnvironmentFile
+  template:
+    src: "{{ role_path }}/templates/environment-file.j2"
+    dest: "/home/{{ server_user }}/environment/github-bot"
+
+- name: Init | Clone github-bot repo
+  become: yes
+  become_user: "{{ server_user }}"
+  git:
+    repo: https://github.com/nodejs/github-bot.git
+    dest: "/home/{{ server_user }}/github-bot"
+
+- name: Init | Install npm dependencies
+  become: yes
+  become_user: "{{ server_user }}"
+  npm:
+    path: "/home/{{ server_user }}/github-bot"
+    production: yes
+
+- name: Init | Start github-bot
+  service:
+    name: github-bot
+    state: started
+    enabled: yes
+
+- name: Deploy Webhook | Install github-webhook
+  npm:
+    name: github-webhook
+    global: yes
+
+- name: Deploy Webhook | Copy config
+  template:
+    src: "{{ role_path }}/templates/github-bot-deploy-webhook.json.j2"
+    dest: "/home/{{ server_user }}/config/github-bot-deploy-webhook.json"
+
+- name: Deploy Webhook | Copy deploy script
+  template:
+    src: "{{ role_path }}/templates/deploy-github-bot.sh.j2"
+    dest: "/home/{{ server_user }}/bin/deploy-github-bot.sh"
+    mode: 0755
+    owner: "{{ server_user }}"
+
+- name: Deploy Webhook | Generate and copy service script
+  template:
+    src: "{{ role_path }}/templates/github-bot-deploy-webhook.service.j2"
+    dest: /lib/systemd/system/github-bot-deploy-webhook.service
+
+- name: Deploy Webhook | Start service
+  service:
+    name: github-bot-deploy-webhook
+    state: started
+    enabled: yes
+
+- name: Deploy Webhook | Allow user to restart github-bot
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: "^{{ server_user }}"
+    line: "'{{ server_user }} ALL=(ALL) NOPASSWD: /bin/systemctl restart github-bot'"
+
+- name: Runtime dependencies | Clone node repo
+  become: yes
+  become_user: "{{ server_user }}"
+  git:
+    repo: https://github.com/nodejs/node.git
+    dest: "/home/{{ server_user }}/repos/node"
+    update: no
+
+- name: Runtime dependencies | Config node repo author email
+  become: yes
+  become_user: "{{ server_user }}"
+  git_config:
+    name: user.email
+    value: "github-bot@nodejs.org"
+    scope: local
+    repo: "/home/{{ server_user }}/repos/node"
+
+- name: Runtime dependencies | Config node repo author name
+  become: yes
+  become_user: "{{ server_user }}"
+  git_config:
+    name: user.name
+    value: "nodejs-github-bot"
+    scope: local
+    repo: "/home/{{ server_user }}/repos/node"

--- a/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
+++ b/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+pidof -s -o '%PPID' -x $(basename $0) > /dev/null 2>&1 && \
+  echo "$(basename $0) already running" && \
+  exit 1
+
+cd /home/{{ server_user }}/github-bot
+git reset --hard
+git clean -fdx
+git fetch origin
+git checkout origin/master
+
+npm install --cache-min 1440 --production
+sudo systemctl restart github-bot

--- a/ansible/roles/github-bot/templates/environment-file.j2
+++ b/ansible/roles/github-bot/templates/environment-file.j2
@@ -1,0 +1,14 @@
+NODE_ENV=production
+PORT={{ envs.port }}
+TRAVIS_TOKEN={{ envs.travis_token }}
+GITHUB_TOKEN={{ envs.github_token }}
+GITHUB_WEBHOOK_SECRET={{ envs.github_webhook_secret }}
+LOGIN_CREDENTIALS={{ envs.login_credentials }}
+NODE_REPO_DIR=/home/{{ server_user }}/repos/node
+LOGS_DIR=/home/{{ server_user }}/logs
+JENKINS_API_CREDENTIALS={{ envs.jenkins_api_credentials }}
+JENKINS_JOB_CITGM={{ envs.jenkins_job_citgm }}
+JENKINS_BUILD_TOKEN_CITGM={{ envs.jenkins_build_token_citgm }}
+JENKINS_JOB_NODE={{ envs.jenkins_job_node }}
+JENKINS_BUILD_TOKEN_NODE={{ envs.jenkins_build_token_node }}
+JENKINS_WORKER_IPS=147.75.70.237,147.75.73.189,169.60.150.88,51.15.200.62,51.15.218.201,147.75.74.174,147.75.193.230,163.172.186.154

--- a/ansible/roles/github-bot/templates/github-bot-deploy-webhook.json.j2
+++ b/ansible/roles/github-bot/templates/github-bot-deploy-webhook.json.j2
@@ -1,0 +1,13 @@
+{
+  "port": 9999,
+  "path": "/deploy-webhook",
+  "secret": "{{ conf.github_deploy_webhook_secret }}",
+  "log": "/home/{{ server_user }}/logs/github-bot-webhook.log",
+  "rules": [
+    {
+      "event": "push",
+      "match": "ref == \"refs/heads/master\"",
+      "exec": "/home/{{ server_user }}/bin/deploy-github-bot.sh"
+    }
+  ]
+}

--- a/ansible/roles/github-bot/templates/github-bot-deploy-webhook.service.j2
+++ b/ansible/roles/github-bot/templates/github-bot-deploy-webhook.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=github-bot-deploy-webhook
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/github-webhook --config config/github-bot-deploy-webhook.json
+WorkingDirectory=/home/{{ server_user }}
+Restart=always
+RestartSec=10
+User={{ server_user }}

--- a/ansible/roles/github-bot/templates/github-bot.service.j2
+++ b/ansible/roles/github-bot/templates/github-bot.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=github-bot
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/node server.js
+EnvironmentFile=/home/{{ server_user }}/environment/github-bot
+WorkingDirectory=/home/{{ server_user }}/github-bot
+Restart=always
+RestartSec=10
+User={{ server_user }}

--- a/ansible/roles/github-bot/vars/main.yml
+++ b/ansible/roles/github-bot/vars/main.yml
@@ -1,0 +1,15 @@
+---
+base_packages:
+  - aptitude
+  - python-apt
+
+packages:
+  - nodejs
+  - git
+
+required_directories:
+  - bin
+  - config
+  - environment
+  - logs
+  - repos


### PR DESCRIPTION
This is a migrated version of the playbook that lives in `setup/github-bot`.

I have tested this on the production server, and works good.

I will be removing the `setup/github-bot` directory in a later PR, to avoid a smaller diff.

cc infra admins: @gibfahn @jbergstroem @joaocgreis @mhdawson @rvagg 
cc @phillipj 