### PR TITLE
ansible: run package-upgrade after adding new sources

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -27,6 +27,10 @@
   when: os in ("ubuntu1204", "ubuntu1404") or os == "debian8"
   debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 
+- name: update packages
+  include_role:
+    name: package-upgrade
+
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.
 - name: install java


### PR DESCRIPTION
Practiced setting up a Debian 8 machine via Vagrant, and
`package-upgrade` needs to be run after adding new sources. After this
update, I think `setup/debian8` can be removed -- I have a Ansible-ized
Vagrant box running a Jenkins worker based on the
`jenkins/worker/create.yml` playbook.