### PR TITLE
doc: initial supported systems release data doc

### DIFF
--- a/doc/supported_systems_release_data.md
+++ b/doc/supported_systems_release_data.md
@@ -1,0 +1,19 @@
+
+# Release data for supported operating systems / distributions
+
+## Linux
+
+* [RHEL](https://access.redhat.com/support/policy/updates/errata/) _(versions & dates mirrored by CentOS)_
+* [Debian](https://wiki.debian.org/LTS)
+* [Ubuntu](https://www.ubuntu.com/info/release-end-of-life) _(18.04 versions pending final 18.04 final release)_
+
+| Distro                | glibc | gcc | Linux kernel | Support EOL |
+|-----------------------|-------|-----|--------------|-------------|
+| RHEL 6                | 2.12  | 4.4 | 2.6          | Nov-2020    |
+| RHEL 7                | 2.17  | 4.8 | 3.10         | Jun-2024    |
+| Debian 7 (Wheezy)     | 2.13  | 4.7 | 3.2          | May-2018    |
+| Debian 8 (Jessie)     | 2.19  | 4.9 | 3.16         | Apr-2020    |
+| Debian 9 (Stretch)    | 2.24  | 6.3 | 4.9          | Jun-2022    |
+| Ubuntu 14.04 (Trusty) | 2.19  | 4.8 | 3.13         | Apr-2019    |
+| Ubuntu 16.04 (Xenial) | 2.23  | 5.3 | 4.4          | Apr-2021    |
+| Ubuntu 18.04 (Bionic) | 2.26  | 7.2 | 4.15         | Apr-2023    |


### PR DESCRIPTION
First pass at a data sheet of support dates, libc, kernel and gcc versions of our major supported systems. Only RHEL (CentOS), Debian, Ubuntu here. I'm going to skip Fedora and Alpine in the Linuxes since they are short-lived.

Need to add info on SmartOS (I couldn't find a good resource on that), FreeBSD, Windows and the IBM systems.

I'd like to land this with just these initial systems and let others fill in the rest (or I could return to this later). For now I'd like to get discussion on Node 10 supported systems going and these are the key pieces as far as Linux is concerned to start that discussion.