### PR TITLE
ansible: install gcc-c++ on centos6 so ccache picks it up properly

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -52,10 +52,7 @@ packages: {
   centos: [
     'ccache',
     'git',
-  ],
-
-  centos7: [
-    'gcc-c++',
+    'gcc-c++', # even need this on centos6 so ccache has symlinks
   ],
 
   debian7: [


### PR DESCRIPTION
otherwise there's no symlinks for `g++` and `c++` in /usr/lib64/ccache and it gets bypassed even when using devtoolset-2 binaries

fixed on the hosts that need it