### PR TITLE
Update diagnostics script to handle FreeBSD and macOS

### DIFF
--- a/jenkins/scripts/node-test-commit-diagnostics.sh
+++ b/jenkins/scripts/node-test-commit-diagnostics.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+
+# Diagnostics
+
+# $1: Set to before to print "Before building", otherwise prints "After building"
+
+set +x
+DIAGFILE=${HOME}/jenkins_diagnostics.txt
+echo >> ${DIAGFILE}
+echo >> ${DIAGFILE}
+echo >> ${DIAGFILE}
+TS="`date`"
+echo $TS
+echo $TS >> ${DIAGFILE}
+
+[ "$1" = before ] && whenFlag=Before || whenFlag=After
+echo "$whenFlag building" >> ${DIAGFILE}
+
+echo $BUILD_TAG >> ${DIAGFILE}
+echo $BUILD_URL >> ${DIAGFILE}
+echo $NODE_NAME >> ${DIAGFILE}
+echo >> ${DIAGFILE}
+
+case "$(uname)" in
+  Darwin|FreeBSD) flag=p ;;
+  *)              flag=  ;;
+esac
+echo "netstat -an$flag" >> ${DIAGFILE}
+netstat -an$flag >> ${DIAGFILE} 2>&1 || true
+unset flag
+
+echo >> ${DIAGFILE}
+echo "netstat -gn" >> ${DIAGFILE}
+netstat -gn >> ${DIAGFILE} 2>&1 || true
+echo >> ${DIAGFILE}
+echo "ps auxww" >> ${DIAGFILE}
+ps auxww >> ${DIAGFILE} 2>&1 || true
+mv ${DIAGFILE} ${DIAGFILE}-OLD || true
+tail -c 20000000 ${DIAGFILE}-OLD > ${DIAGFILE} || true
+rm ${DIAGFILE}-OLD || true
+set -x
+pgrep node || true

--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -53,8 +53,15 @@ echo $BUILD_TAG >> ${DIAGFILE}
 echo $BUILD_URL >> ${DIAGFILE}
 echo $NODE_NAME >> ${DIAGFILE}
 echo >> ${DIAGFILE}
-echo "netstat -anp" >> ${DIAGFILE}
-netstat -anp >> ${DIAGFILE} 2>&1 || true
+
+case "$(uname)" in
+  Darwin|FreeBSD) FLAG=p ;;
+  *)              FLAG=  ;;
+esac
+echo "netstat -an$FLAG" >> ${DIAGFILE}
+netstat -an$FLAG >> ${DIAGFILE} 2>&1 || true
+unset FLAG
+
 echo >> ${DIAGFILE}
 echo "netstat -gn" >> ${DIAGFILE}
 netstat -gn >> ${DIAGFILE} 2>&1 || true

--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -39,37 +39,5 @@ if [ -n "${POST_REBASE_SHA1_CHECK}" ]; then
   fi
 fi
 
-# Diagnostics
-set +x
-DIAGFILE=${HOME}/jenkins_diagnostics.txt
-echo >> ${DIAGFILE}
-echo >> ${DIAGFILE}
-echo >> ${DIAGFILE}
-TS="`date`"
-echo $TS
-echo $TS >> ${DIAGFILE}
-echo "Before building" >> ${DIAGFILE}
-echo $BUILD_TAG >> ${DIAGFILE}
-echo $BUILD_URL >> ${DIAGFILE}
-echo $NODE_NAME >> ${DIAGFILE}
-echo >> ${DIAGFILE}
-
-case "$(uname)" in
-  Darwin|FreeBSD) FLAG=p ;;
-  *)              FLAG=  ;;
-esac
-echo "netstat -an$FLAG" >> ${DIAGFILE}
-netstat -an$FLAG >> ${DIAGFILE} 2>&1 || true
-unset FLAG
-
-echo >> ${DIAGFILE}
-echo "netstat -gn" >> ${DIAGFILE}
-netstat -gn >> ${DIAGFILE} 2>&1 || true
-echo >> ${DIAGFILE}
-echo "ps auxww" >> ${DIAGFILE}
-ps auxww >> ${DIAGFILE} 2>&1 || true
-mv ${DIAGFILE} ${DIAGFILE}-OLD || true
-tail -c 20000000 ${DIAGFILE}-OLD > ${DIAGFILE} || true
-rm ${DIAGFILE}-OLD || true
-set -x
-pgrep node || true
+# TODO(gib): Run locally once we're cloning the whole git repo.
+curl https://raw.githubusercontent.com/nodejs/build/master/jenkins/scripts/node-test-commit-diagnostics.sh | bash -ex -s before


### PR DESCRIPTION
They can't handle the -p option, and give the following error:

```console
$ netstat -anp
netstat: option requires an argument -- p
Usage:  netstat [-AaLlnW] [-f address_family | -p protocol]
        netstat [-gilns] [-f address_family]
        netstat -i | -I interface [-w wait] [-abdgRtS]
        netstat -s [-s] [-f address_family | -p protocol] [-w wait]
        netstat -i | -I interface -s [-f address_family | -p protocol]
        netstat -m [-m]
        netstat -r [-Aaln] [-f address_family]
        netstat -rs [-s]
```