### PR TITLE
build and install gcc 4.9.4 on rhel72

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -125,6 +125,7 @@ hosts:
     - linuxonecc:
         rhel72-s390x-1: {ip: 148.100.110.63}
         rhel72-s390x-2: {ip: 148.100.110.64}
+        rhel72-s390x-3: {ip: 148.100.110.12}
 
     - mininodes:
         ubuntu1604-arm64_odroid_c2-1: {ip: 70.167.220.147}

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -44,7 +44,7 @@
       skip: true
 
 - name: check for a recent enough ccache
-  when: os in ccache_no_binpkg
+  when: os in ccache_no_binpkg or 'rhel72-s390x' in inventory_hostname
   stat: path="{{ binary_dest }}"
   register: has_ccache
 
@@ -97,6 +97,13 @@
     state: present
     regexp: '^127\.0\.1\.1\s+\w.+$'
     line: '127.0.1.1        {{safe_hostname}}'
+
+- name: run ccache installer
+  when: os == "rhel72" and arch == "s390x" and not has_ccache.stat.exists
+  include: ccache.yml
+  static: false
+  vars:
+    - version: 3.3.3
 
 - name: run ccache installer
   when: os in ccache_no_binpkg and not has_ccache.stat.exists

--- a/ansible/roles/gcc/tasks/main.yml
+++ b/ansible/roles/gcc/tasks/main.yml
@@ -1,0 +1,292 @@
+---
+
+#
+# installs gcc 4.9 @ /data/gcc-4.9 on rhel7.x
+#
+
+- stat: path=/data/gcc-4.9/bin/gcc-4.9
+  register: build_gcc_49
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create working directory
+  file:
+    path: /data/tmp
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: download gmp 6.1.0
+  get_url:
+    url: http://ftp.gnu.org/gnu/gmp/gmp-6.1.0.tar.xz
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: unarchive gmp 6.1.0
+  unarchive:
+    src: /data/tmp/gmp-6.1.0.tar.xz
+    remote_src: yes
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create build directory
+  file:
+    path: /data/tmp/build
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: configure gmp 6.1.0
+  shell: /data/tmp/gmp-6.1.0/configure --prefix=/data/gcc-4.9
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build gmp 6.1.0
+  shell: make -j{{ ansible_processor_cores }} install
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create working directory
+  file:
+    path: /data/tmp
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: download mprf 3.1.4 
+  get_url:
+    url: http://ftp.gnu.org/gnu/mpfr/mpfr-3.1.4.tar.gz
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: unarchive mprf 3.1.4
+  unarchive:
+    src: /data/tmp/mpfr-3.1.4.tar.gz
+    remote_src: yes
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create build directory
+  file:
+    path: /data/tmp/build
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build mprf 3.1.4
+  shell: /data/tmp/mpfr-3.1.4/configure --with-gmp=/data/gcc-4.9 --prefix=/data/gcc-4.9
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build mprf 3.1.4
+  shell: make -j{{ ansible_processor_cores }} install
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create working directory
+  file:
+    path: /data/tmp
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: download mpc 1.0.3
+  get_url:
+    url: http://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: unarchive mpc 1.0.3
+  unarchive:
+    src: /data/tmp/mpc-1.0.3.tar.gz
+    remote_src: yes
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create build directory
+  file:
+    path: /data/tmp/build
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: configure mpc 1.0.3
+  shell: /data/tmp/mpc-1.0.3/configure --with-mpfr=/data/gcc-4.9 --with-gmp=/data/gcc-4.9 --prefix=/data/gcc-4.9
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build mpc 1.0.3
+  shell: make -j{{ ansible_processor_cores }} install
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create working directory
+  file:
+    path: /data/tmp
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: download binutils 2.28.1
+  get_url:
+    url: https://ftp.gnu.org/gnu/binutils/binutils-2.28.1.tar.gz
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: unarchive binutils 2.28.1
+  unarchive:
+    src: /data/tmp/binutils-2.28.1.tar.gz
+    remote_src: yes
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create build directory
+  file:
+    path: /data/tmp/build
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: configure binutils 2.28.1
+  shell: /data/tmp/binutils-2.28.1/configure --with-mpfr=/data/gcc-4.9 --with-gmp=/data/gcc-4.9 --prefix=/data/gcc-4.9
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build binutils 2.28.1
+  shell: make -j{{ ansible_processor_cores }}
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: install binutils 2.28.1
+  shell: make install
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create working directory
+  file:
+    path: /data/tmp
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: download gcc 4.9.4
+  get_url:
+    url: http://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.gz
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: unarchive gcc 4.9.4
+  unarchive:
+    src: /data/tmp/gcc-4.9.4.tar.gz
+    remote_src: yes
+    dest: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Create build directory
+  file:
+    path: /data/tmp/build
+    state: directory
+    mode: 0755
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: configure gcc4.9
+  shell: /data/tmp/gcc-4.9.4/configure --with-mpfr=/data/gcc-4.9 --with-gmp=/data/gcc-4.9 --prefix=/data/gcc-4.9 --program-suffix=-4.9 --disable-multilib
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: build gcc49
+  shell: make -j{{ ansible_processor_cores }}
+  async: 3600
+  poll: 10
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: install gcc49
+  shell: make install
+  args:
+    chdir: /data/tmp/build
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: build_gcc_49.stat.exists == False
+  tags: gcc49

--- a/ansible/roles/jenkins-worker/meta/main.yml
+++ b/ansible/roles/jenkins-worker/meta/main.yml
@@ -6,3 +6,4 @@
 
 dependencies:
 - { 'role': 'java-base' }
+- { 'role': 'gcc', when: os|startswith("rhel7") }

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -33,11 +33,26 @@
   when: "'rhel72-s390x' in inventory_hostname"
 
 - name: create user
-  when: not os|startswith("zos")
+  when: not os|startswith("zos") and not "'rhel72-s390x' in inventory_hostname"
   user:
     name: "{{ server_user }}"
     group: "{{ server_user }}"
     shell: "{{ bash_path[os|stripversion]|default('/bin/bash') }}"
+
+- name: create user for rhel72-s390x
+  user:
+    name: "{{ server_user }}"
+    group: "{{ server_user }}"
+    home: "/data/{{server_user }}"
+    shell: "{{ bash_path[os|stripversion]|default('/bin/bash') }}"
+  when: "'rhel72-s390x' in inventory_hostname"
+
+- name: create symbolic link for home directory on rhel72-s390x
+  file:
+    src: "/data/{{ server_user }}"
+    dest: "/home/{{ server_user }}"
+    state: link
+  when: "'rhel72-s390x' in inventory_hostname"
 
 - name: add ::1 to /etc/hosts for ipv6 compat
   when: not os|startswith("zos")


### PR DESCRIPTION
Builds and installs gcc 4.9 which isn't officially supported.
The install could take up to 30 mins.
Must use the following

export PATH=/data/gcc-4.9/bin:$PATH
export LDFLAGS="-Wl,-rpath,$(dirname $(/data/gcc-4.9/bin/gcc --print-file-name libgcc_s.so))"