### PR TITLE
ansible : replacing slave.jar to agent.jar

### DIFF
--- a/ansible/group_vars/release
+++ b/ansible/group_vars/release
@@ -1,6 +1,6 @@
 jenkins_url: "https://ci-release.nodejs.org"
-# intentionally fetching `slave.jar` from ci.nodejs.org to avoid auth problems
-jenkins_worker_jar: "https://ci.nodejs.org/jnlpJars/slave.jar"
+# intentionally fetching `agent.jar` from ci.nodejs.org to avoid auth problems
+jenkins_worker_jar: "https://ci.nodejs.org/jnlpJars/agent.jar"
 server_user: "iojs"
 home: "/home"
 remote_env: {}

--- a/ansible/group_vars/test
+++ b/ansible/group_vars/test
@@ -1,5 +1,5 @@
 jenkins_url: "https://ci.nodejs.org"
-jenkins_worker_jar: "{{ jenkins_url }}/jnlpJars/slave.jar"
+jenkins_worker_jar: "{{ jenkins_url }}/jnlpJars/agent.jar"
 server_user: iojs
 home: "/home"
 remote_env: {}

--- a/ansible/playbooks/jenkins/worker/upgrade-jar.yml
+++ b/ansible/playbooks/jenkins/worker/upgrade-jar.yml
@@ -1,16 +1,16 @@
 ---
 
 #
-# upgrade `slave.jar` at jenkins workers
+# upgrade `agent.jar` at jenkins workers
 #
 
 -  hosts: test
 
    tasks:
-    - name: download slave.jar
+    - name: download agent.jar
       get_url:
         url: "{{ jenkins_worker_jar }}"
-        dest: /home/{{ server_user }}/slave.jar
+        dest: /home/{{ server_user }}/agent.jar
         mode: 0644
 
     - name: restart jenkins

--- a/ansible/roles/docker/templates/alpine34.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine34.Dockerfile.j2
@@ -51,8 +51,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/alpine35.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine35.Dockerfile.j2
@@ -52,8 +52,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/alpine36.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine36.Dockerfile.j2
@@ -51,8 +51,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/alpine37.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine37.Dockerfile.j2
@@ -51,8 +51,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -36,8 +36,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -88,8 +88,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -36,8 +36,8 @@ USER iojs:iojs
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \
-  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
           -secret {{ item.secret }}

--- a/ansible/roles/jenkins-worker/files/alpine.monitrc
+++ b/ansible/roles/jenkins-worker/files/alpine.monitrc
@@ -2,6 +2,6 @@ set logfile syslog
 set daemon 30
 
 check process jenkins
-  matching slave.jar
+  matching agent.jar
   start program = "/sbin/rc-service -q jenkins zap && /sbin/rc-service -q jenkins start"
   stop program  = "/sbin/rc-service -q jenkins stop"

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -77,20 +77,20 @@
   command: systemctl restart iptables
   when: "'rhel72-s390x' in inventory_hostname"
 
-- name: download slave.jar
+- name: download agent.jar
   when: not os|startswith("zos")
   get_url:
     url: "{{ jenkins_worker_jar }}"
-    dest: '{{ home }}/{{ server_user }}/slave.jar'
+    dest: '{{ home }}/{{ server_user }}/agent.jar'
     mode: 0644
     timeout: 60
 
 # temporary until we get the righ cert bundles
-- name: download slave.jar -zos
+- name: download agent.jar -zos
   when: os|startswith("zos")
   get_url:
     url: "{{ jenkins_worker_jar }}"
-    dest: '{{ home }}/{{ server_user }}/slave.jar'
+    dest: '{{ home }}/{{ server_user }}/agent.jar'
     mode: 0644
     timeout: 60
     validate_certs: no

--- a/ansible/roles/jenkins-worker/templates/centos.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/centos.initd.j2
@@ -15,7 +15,7 @@ JAVA=/usr/bin/java
 PIDFILE=/var/run/jenkins/$NAME.pid
 
 JENKINS_SLAVE_USER="iojs"
-JENKINS_SLAVE_JAR="/home/{{ server_user }}/slave.jar"
+JENKINS_SLAVE_JAR="/home/{{ server_user }}/agent.jar"
 JENKINS_SLAVE_LOG="/home/{{ server_user }}/$NAME.log"
 JENKINS_SLAVE_ARGS="-Xmx{{ server_ram|default('128m') }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp -secret {{ secret }}"
 JENKINS_ENV="JOBS={{ ansible_processor_vcpus }} \

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -31,7 +31,7 @@ jenkins_env=" \
   CC=cc \
   CXX=c++"
 
-jenkins_jar="/home/{{ server_user }}/slave.jar"
+jenkins_jar="/home/{{ server_user }}/agent.jar"
 jenkins_log_file="/home/{{ server_user }}/${name}_console.log"
 jenkins_args="-Xmx{{ server_ram|default('128m') }} -jar ${jenkins_jar} \
   -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp \

--- a/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
+++ b/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
@@ -28,7 +28,7 @@
 
       <exec_method type='method'
                    name='start'
-                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/slave.jar -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp -secret {{ secret }}'
+                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/agent.jar -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp -secret {{ secret }}'
                    timeout_seconds='30' />
 
       <exec_method type="method"

--- a/ansible/roles/jenkins-worker/templates/openrc.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/openrc.initd.j2
@@ -5,7 +5,7 @@ description="Start a Jenkins slave"
 name="java"
 command="/usr/bin/java"
 command_args="-Xmx{{ server_ram|default('128m') }} \
-  -jar /home/{{ server_user }}/slave.jar -secret {{ secret }} \
+  -jar /home/{{ server_user }}/agent.jar -secret {{ secret }} \
   -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp \
   -slaveLog /home/{{ server_user }}/slave.log"
 

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -21,6 +21,6 @@ export CFLAGS="-q64"
 export LDFLAGS="-q64"
 
 {{ java_path[os] }} -Dfile.encoding=ISO8859_1 -Xmx{{ server_ram|default('128m') }} \
-    -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
+    -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1  &
 EOF

--- a/ansible/roles/jenkins-worker/templates/systemd.service.j2
+++ b/ansible/roles/jenkins-worker/templates/systemd.service.j2
@@ -24,6 +24,6 @@ Environment="NODE_TEST_DIR=/home/{{ server_user }}/tmp"
 Environment="OSTYPE=linux-gnu"
 
 ExecStart=/usr/bin/java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp \
           -secret {{ secret }}

--- a/ansible/roles/jenkins-worker/templates/upstart.j2
+++ b/ansible/roles/jenkins-worker/templates/upstart.j2
@@ -29,6 +29,6 @@ script
   fi
 
   exec java -Xmx{{ server_ram|default('128m') }} \
-        -jar /home/{{ server_user }}/slave.jar -secret {{ secret }} \
+        -jar /home/{{ server_user }}/agent.jar -secret {{ secret }} \
         -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp
 end script


### PR DESCRIPTION
replacing `slave.jar` to `agent.jar` in `ansible` for implementing
worker machine terminology

Fixes : https://github.com/nodejs/build/issues/1060