### PR TITLE
github-bot: update jenkins worker IP

### DIFF
--- a/setup/github-bot/resources/environment-file
+++ b/setup/github-bot/resources/environment-file
@@ -9,4 +9,4 @@ LOGS_DIR=/home/{{server_user}}/logs
 JENKINS_API_CREDENTIALS={{envs.jenkins_api_credentials}}
 JENKINS_JOB_URL_CITGM={{envs.jenkins_job_url_citgm}}
 JENKINS_BUILD_TOKEN_CITGM={{envs.jenkins_build_token_citgm}}
-JENKINS_WORKER_IPS=147.75.69.113,147.75.73.189,169.60.150.88
+JENKINS_WORKER_IPS=147.75.70.237,147.75.73.189,169.60.150.88


### PR DESCRIPTION
Updating one of the jenkins worker IPs has it has changed.

Seeing quite a lot of these in the bot logs:

```bash
WARN bot: Ignoring, not allowed to push Jenkins updates (req_id=4d597e22-8cf3-47ed-915d-a2c35116dd78, ip=147.75.70.237)
```

Refs https://github.com/nodejs/build/commit/78bdb8596ef2c336d54d0ee180247488e6722c6f

/cc @rvagg 