### PR TITLE
coverage: add gcovr version specific diff

### DIFF
--- a/jenkins/scripts/coverage/gcovr-patches-3.4.diff
+++ b/jenkins/scripts/coverage/gcovr-patches-3.4.diff
@@ -1,0 +1,23 @@
+diff --git a/scripts/gcovr b/scripts/gcovr
+index 034779c86d29..e68b239c424f 100755
+--- a/scripts/gcovr
++++ b/scripts/gcovr
+@@ -496,7 +496,7 @@ def process_gcov_data(data_fname, covdata, options):
+     if filtered_fname is None:
+         if options.verbose:
+             sys.stdout.write("  Filtering coverage data for file %s\n" % fname)
+-        return
++        #return
+     #
+     # Return if the filename matches the exclude pattern
+     #
+@@ -2141,6 +2141,9 @@ if options.objdir:
+ for i in range(0, len(options.exclude)):
+     options.exclude[i] = re.compile(options.exclude[i])
+
++if options.output is not None:
++    options.output = os.path.abspath(options.output)
++
+ if options.root is not None:
+     if not options.root:
+         sys.stderr.write(


### PR DESCRIPTION
Add diff specific to the 3.4 version of gcovr.  This will
allow us to avoid breaking coverage in older node versions
when we chose to update the version of gcovr that we are
using.