### PR TITLE
Serve security.txt file from the static directory

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -301,11 +301,6 @@ server {
         default_type text/plain;
     }
 
-    location /security.txt {
-        alias /home/www/nodejs/static/security.txt;
-        default_type text/plain;
-    }
-
     location /.well-known/security.txt {
         alias /home/www/nodejs/static/security.txt;
         default_type text/plain;
@@ -317,6 +312,7 @@ server {
         default_type text/plain;
     }
 
+    rewrite ^/security.txt$                                       https://$server_name/.well-known/security.txt permanent;
     rewrite ^/about/security/?$                                   https://$server_name/en/security/ permanent;
     rewrite ^/contribute/?$                                       https://$server_name/en/get-involved/ permanent;
     rewrite ^/contribute/accepting_contributions.html$            https://github.com/nodejs/dev-policy permanent;

--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -301,6 +301,16 @@ server {
         default_type text/plain;
     }
 
+    location /security.txt {
+        alias /home/www/nodejs/static/security.txt;
+        default_type text/plain;
+    }
+
+    location /.well-known/security.txt {
+        alias /home/www/nodejs/static/security.txt;
+        default_type text/plain;
+    }
+
     location /metrics {
         alias /home/dist/metrics/;
         autoindex on;


### PR DESCRIPTION
The URLs are recommended by the security.txt spec available at https://securitytxt.org.

The security.txt file was added to the static directory in a separate PR: nodejs/nodejs.org#1589.