### PR TITLE
jenkins: change compiler level for 8.X

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -14,7 +14,7 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
   NODE_MAJOR_VERSION="$(echo "$NODE_VERSION" | cut -d . -f 1)"
   echo "Setting compiler for Node version $NODE_MAJOR_VERSION on ppc64le"
 
-  if [ "$NODE_MAJOR_VERSION" -gt "7" ]; then
+  if [ "$NODE_MAJOR_VERSION" -gt "8" ]; then
     export COMPILER_LEVEL="4.9"
   fi
 


### PR DESCRIPTION
Moving compiler level to 4.9 was a breaking change so
only make the change for versions > 8 for now to avoid
affecting LTS releases.

Needed to help fix: https://github.com/nodejs/node/issues/19530