### PR TITLE
ansible: use gcc 4.9.4 or newer on CentOS 6

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
@@ -4,18 +4,6 @@
 # centos6 - almost getting there
 #
 
-- name: "repo : add scl devtoolset"
-  yum_repository:
-    baseurl: http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
-    gpgkey: http://ftp.scientificlinux.org/linux/scientific/5x/{{ ansible_architecture }}/RPM-GPG-KEYs/RPM-GPG-KEY-cern
-    gpgcheck: yes
-
-- name: "repo : add scl"
-  yum_repository:
-    baseurl: http://linuxsoft.cern.ch/cern/scl/slc6-scl.repo
-    gpgkey: http://ftp.scientificlinux.org/linux/scientific/5x/{{ ansible_architecture }}/RPM-GPG-KEYs/RPM-GPG-KEY-cern
-    gpgcheck: yes
-
 - name: install epel
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -42,6 +42,11 @@ packages: {
     'gcc-c++', # even need this on centos6 so ccache has symlinks
   ],
 
+  centos6: [
+    'centos-release-scl',
+    'devtoolset-6'
+  ],
+
   debian7: [
     'gcc-4.8,g++-4.8',
   ],

--- a/ansible/roles/jenkins-worker/templates/centos.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/centos.initd.j2
@@ -32,7 +32,7 @@ JENKINS_ENV="JOBS={{ ansible_processor_vcpus }} \
 . /etc/rc.d/init.d/functions
 
 # Add python/ccache path as well as regular path
-JENKINS_PATH="/usr/lib64/ccache:/opt/rh/devtoolset-2/root/usr/bin:$PATH"
+JENKINS_PATH="/usr/lib64/ccache:/opt/rh/devtoolset-6/root/usr/bin:$PATH"
 
 # Replace potentially double colons since they add cwd
 JENKINS_PATH="${JENKINS_PATH//::/:}"


### PR DESCRIPTION
Currently CentOS 6 machines use gcc 4.8 while Node.js requires "gcc and g++ 4.9.4 or newer". See #762.

`devtoolset-3` has gcc 4.9.1, too old.
`devtoolset-5` has "gcc (GCC) 5.3.1 20160406", that's still older than gcc 4.9.4.
`devtoolset-6` has "gcc (GCC) 6.3.1 20170216", good enough.

The CERN repo doesn't have `devtoolset` newer than 2, so I replaced that with Software Collections, just like in https://github.com/nodejs/build/pull/809.