### PR TITLE
added VersionSelectorScript.groovy to select builders for Node version

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -1,10 +1,17 @@
+// Helper closures to make our buildExclusions DSL terse and readable
 def gte = { v -> { nodeVersion -> nodeVersion >= v} }
 def lt = { v -> { nodeVersion -> nodeVersion < v} }
 def releaseType = { buildType -> buildType == 'release' }
 def anyType = { buildType -> true }
 
 def buildExclusions = [
-  // Linux
+  // Given a machine label, build type (release or !release) and a Node.js
+  // major version number, determine which ones to _exclude_ from a build
+
+  // -------------------------------------------------------
+  // Machine Label,                   Build Type,  Node Version
+
+  // Linux -------------------------------------------------
   [ /^centos5/,                       anyType,     gte(8)  ],
   [ /^centos6/,                       releaseType, lt(8)   ],
   [ /centos[67]-(arm)?(64|32)-gcc48/, anyType,     gte(10) ],
@@ -13,38 +20,42 @@ def buildExclusions = [
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],
 
-  // Windows
+  // ARM  --------------------------------------------------
+  [ /^debian7-docker-armv7$/,         anyType,     gte(10) ],
+  [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
+  [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
+
+  // Windows -----------------------------------------------
   [ /^vs2013-/,                       anyType,     gte(6)  ],
   [ /^vs2015-/,                       anyType,     lt(6)   ],
   [ /^vs2015-/,                       anyType,     gte(10) ],
   [ /^vs2017-/,                       anyType,     lt(10)  ],
 
-  // SmartOS
+  // SmartOS -----------------------------------------------
   [ /^smartos14/,                     anyType,     gte(8)  ],
   [ /^smartos15/,                     anyType,     lt(8)   ],
   [ /^smartos15/,                     releaseType, gte(10) ],
   [ /^smartos16/,                     anyType,     lt(8)   ],
   [ /^smartos17/,                     anyType,     lt(10)  ],
 
-  [ /^debian7-docker-armv7$/,         anyType,     gte(10) ],
-  [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
-  [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
-
-  // PPC BE
+  // PPC BE ------------------------------------------------
   [ /^ppcbe-ubuntu/,                  anyType,     gte(8)  ],
 
-  // s390x
+  // s390x -------------------------------------------------
   [ /s390x/,                          anyType,     lt(6)   ],
 
-  // AIX61
+  // AIX61 -------------------------------------------------
   [ /aix61/,                          anyType,     lt(6)   ],
 
-  // sharedlibs containered
+  // Shared libs docker containers -------------------------
   [ /sharedlibs_openssl111/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl102/,          anyType,     gte(10) ],
   [ /sharedlibs_fips20/,              anyType,     gte(10) ],
   [ /sharedlibs_withoutintl/,         anyType,     lt(9)   ],
+
+  // -------------------------------------------------------
+
 ]
 
 def canBuild = { nodeVersion, builderLabel, buildType ->
@@ -67,8 +78,13 @@ if (parameters['NODEJS_MAJOR_VERSION'])
 println "Node.js major version: $nodeMajorVersion"
 println "Node.js version: ${parameters['NODEJS_VERSION']}"
 
+// NOTE: this assumes that the default "Slaves"->"Name" in the Configuration
+// Matrix is left as "nodes", if it's changed then `it.nodes` below won't work
+// and returning a result with a "nodes" property won't work.
 result['nodes'] = []
 
+// Before running this script, `def buildType = 'release'` or some other value
+// to be able to use the appropriate `buildType` in the exclusions
 def _buildType
 try {
   _buildType = buildType
@@ -78,6 +94,8 @@ try {
 
 combinations.each{
   def builderLabel = it.nodes
+  // Default to running all builders if nodeMajorVersion is still -1
+  // (i.e. the version check failed)
   if (nodeMajorVersion >= 4) {
     if (!canBuild(nodeMajorVersion, builderLabel, _buildType)) {
       println "Skipping $builderLabel for Node.js $nodeMajorVersion"
@@ -86,4 +104,3 @@ combinations.each{
   }
   result['nodes'].add(it)
 }
-

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -5,9 +5,9 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
     return false
-  if (buildType != 'release' && builderLabel == "centos6-64-gcc48" && nodeMajorVersion >= 10)
+  if (buildType != 'release' && builderLabel =~ /centos[67]-(arm)?64-gcc48/ && nodeMajorVersion >= 10)
     return false
-  if (buildType != 'release' && builderLabel == "centos6-64-gcc6" && nodeMajorVersion < 10)
+  if (buildType != 'release' && builderLabel =~ /centos[67]-(arm)?64-gcc6/ && nodeMajorVersion < 10)
     return false
 
   // Windows

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -22,6 +22,11 @@ def canBuild(nodeMajorVersion, builderLabel) {
   if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
     return false
 
+  // ARMv7
+  if (builderLabel.equals('armv7-wheezy-release') && nodeMajorVersion >= 10)
+    return false
+  if (builderLabel.equals('armv7-jessie-release') && nodeMajorVersion < 10)
+    return false
 
   // PPC BE
   if (builderLabel.indexOf('ppcbe-ubuntu') == 0 && nodeMajorVersion >= 8)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -5,6 +5,10 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
     return false
+  if (buildType != 'release' && builderLabel == "centos6-64-gcc48" && nodeMajorVersion >= 10)
+    return false
+  if (buildType != 'release' && builderLabel == "centos6-64-gcc6" && nodeMajorVersion < 10)
+    return false
 
   // Windows
   if (builderLabel.indexOf('vs2013-') == 0 && nodeMajorVersion >= 6)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -73,7 +73,7 @@ def _buildType
 try {
   _buildType = buildType
 } catch (groovy.lang.MissingPropertyException e) {
-  _buildType = 'release'
+  _buildType = 'test'
 }
 
 combinations.each{

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -1,9 +1,9 @@
-def canBuild(nodeMajorVersion, builderLabel) {
+def canBuild(nodeMajorVersion, builderLabel, buildType='release') {
 
   // Linux
   if (builderLabel.indexOf('centos5') == 0 && nodeMajorVersion >= 8)
     return false
-  if (builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
+  if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
     return false
 
   // Windows
@@ -42,6 +42,18 @@ def canBuild(nodeMajorVersion, builderLabel) {
 
   // AIX61
   if (builderLabel.indexOf('aix61') > -1 && nodeMajorVersion < 6)
+    return false
+
+  // sharedlibs containered
+  if (builderLabel.indexOf('sharedlibs_openssl111') > -1 && nodeMajorVersion < 9)
+    return false
+  if (builderLabel.indexOf('sharedlibs_openssl110') > -1 && nodeMajorVersion < 9)
+    return false
+  if (builderLabel.indexOf('sharedlibs_openssl102') > -1 && nodeMajorVersion > 9)
+    return false
+  if (builderLabel.indexOf('sharedlibs_fips20') > -1 && nodeMajorVersion > 9)
+    return false
+  if (builderLabel.indexOf('sharedlibs_withoutintl') > -1 && nodeMajorVersion < 9)
     return false
 
   return true

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -31,6 +31,8 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (buildType == 'release' && builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion >= 10)
     return false
+  if (builderLabel.indexOf('smartos16') == 0 && nodeMajorVersion < 8)
+    return false
   if (builderLabel.indexOf('smartos17') == 0 && nodeMajorVersion < 10)
     return false
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -5,9 +5,9 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
     return false
-  if (buildType != 'release' && builderLabel =~ /centos[67]-(arm)?64-gcc48/ && nodeMajorVersion >= 10)
+  if (builderLabel =~ /centos[67]-(arm)?64-gcc48/ && nodeMajorVersion >= 10)
     return false
-  if (buildType != 'release' && builderLabel =~ /centos[67]-(arm)?64-gcc6/ && nodeMajorVersion < 10)
+  if (builderLabel =~ /centos[67]-(arm)?64-gcc6/ && nodeMajorVersion < 10)
     return false
 
   // Windows

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -1,0 +1,61 @@
+def canBuild(nodeMajorVersion, builderLabel) {
+
+  // Linux
+  if (builderLabel.indexOf('centos5') == 0 && nodeMajorVersion >= 8)
+    return false
+  if (builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
+    return false
+
+  // Windows
+  if (builderLabel.indexOf('vs2013-') == 0 && nodeMajorVersion >= 6)
+    return false
+  if (builderLabel.indexOf('vs2015-') == 0 && (nodeMajorVersion < 6 || nodeMajorVersion >= 10))
+    return false
+  if (builderLabel.indexOf('vs2017-') == 0 && nodeMajorVersion < 10)
+    return false
+
+  // SmartOS
+  if (builderLabel.indexOf('smartos13') == 0) // Node.js 0.x
+    return false
+  if (builderLabel.indexOf('smartos14') == 0 && nodeMajorVersion >= 8)
+    return false
+  if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
+    return false
+
+
+  // PPC BE
+  if (builderLabel.indexOf('ppcbe-ubuntu') == 0 && nodeMajorVersion >= 8)
+    return false
+
+  // s390x
+  if (builderLabel.indexOf('s390x') > -1 && nodeMajorVersion < 6)
+    return false
+
+  // AIX61
+  if (builderLabel.indexOf('aix61') > -1 && nodeMajorVersion < 6)
+    return false
+
+  return true
+}
+
+// setup for execution of the above rules
+
+int nodeMajorVersion = -1
+if (parameters['NODEJS_MAJOR_VERSION'])
+  nodeMajorVersion = parameters['NODEJS_MAJOR_VERSION'].toString().toInteger()
+println 'Node.js major version: ' + nodeMajorVersion
+println 'Node.js version: ' + parameters['NODEJS_VERSION']
+
+result['nodes'] = []
+
+combinations.each{
+  def builderLabel = it.nodes
+  if (nodeMajorVersion >= 4) {
+    if (!canBuild(nodeMajorVersion, builderLabel)) {
+      println 'Skipping ' + builderLabel + ' for Node.js ' + nodeMajorVersion
+      return
+    }
+  }
+  result['nodes'] << it
+}
+

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -5,9 +5,9 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
     return false
-  if (builderLabel =~ /centos[67]-(arm)?64-gcc48/ && nodeMajorVersion >= 10)
+  if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc48/ && nodeMajorVersion >= 10)
     return false
-  if (builderLabel =~ /centos[67]-(arm)?64-gcc6/ && nodeMajorVersion < 10)
+  if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc6/ && nodeMajorVersion < 10)
     return false
 
   // Windows

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -26,8 +26,8 @@ def buildExclusions = [
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
-  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10) ],
-  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
+  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
 
   // Windows -----------------------------------------------
   [ /^vs2013-/,                       anyType,     gte(6)  ],
@@ -57,6 +57,7 @@ def buildExclusions = [
   [ /sharedlibs_openssl102/,          anyType,     gte(10) ],
   [ /sharedlibs_fips20/,              anyType,     gte(10) ],
   [ /sharedlibs_withoutintl/,         anyType,     lt(9)   ],
+  [ /sharedlibs_withoutssl/,          anyType,     lt(10)  ],
 
   // -------------------------------------------------------
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -11,6 +11,8 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (builderLabel.indexOf('ubuntu1804') == 0 && nodeMajorVersion < 10) // probably temporary
     return false
+  if (builderLabel.indexOf('ubuntu1204') == 0 && nodeMajorVersion >= 10)
+    return false
 
   // Windows
   if (builderLabel.indexOf('vs2013-') == 0 && nodeMajorVersion >= 6)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -38,7 +38,7 @@ def buildExclusions = [
   // SmartOS -----------------------------------------------
   [ /^smartos14/,                     anyType,     gte(8)  ],
   [ /^smartos15/,                     anyType,     lt(8)   ],
-  [ /^smartos15/,                     releaseType, gte(10) ],
+  [ /^smartos15/,                     anyType,     gte(10) ],
   [ /^smartos16/,                     anyType,     lt(8)   ],
   [ /^smartos17/,                     anyType,     lt(10)  ],
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -26,8 +26,8 @@ def buildExclusions = [
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
-  [ /^cross-compiler-armv[67]-gcc-4.9$/, anyType,  lt(10) ],
-  [ /^cross-compiler-armv[67]-gcc-4.9$/, anyType,  lt(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10) ],
 
   // Windows -----------------------------------------------
   [ /^vs2013-/,                       anyType,     gte(6)  ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -9,7 +9,7 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc6/ && nodeMajorVersion < 10)
     return false
-  if (builtType == 'release' && builderLabel =~ /centos6-32-gcc6/ && nodeMajorVersion >= 10) // 32-bit linux for <10 only
+  if (buildType == 'release' && builderLabel =~ /centos6-32-gcc6/ && nodeMajorVersion >= 10) // 32-bit linux for <10 only
     return false
   if (builderLabel.indexOf('ubuntu1804') == 0 && nodeMajorVersion < 10) // probably temporary
     return false

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -9,6 +9,8 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc6/ && nodeMajorVersion < 10)
     return false
+  if (builderLabel.indexOf('ubuntu1804') == 0 && nodeMajorVersion < 10) // probably temporary
+    return false
 
   // Windows
   if (builderLabel.indexOf('vs2013-') == 0 && nodeMajorVersion >= 6)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -58,6 +58,7 @@ def buildExclusions = [
   [ /sharedlibs_fips20/,              anyType,     gte(10) ],
   [ /sharedlibs_withoutintl/,         anyType,     lt(9)   ],
   [ /sharedlibs_withoutssl/,          anyType,     lt(10)  ],
+  [ /sharedlibs_shared/,              anyType,     lt(9)   ],
 
   // -------------------------------------------------------
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -9,6 +9,8 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc6/ && nodeMajorVersion < 10)
     return false
+  if (builtType == 'release' && builderLabel =~ /centos6-32-gcc6/ && nodeMajorVersion >= 10) // 32-bit linux for <10 only
+    return false
   if (builderLabel.indexOf('ubuntu1804') == 0 && nodeMajorVersion < 10) // probably temporary
     return false
   if (builderLabel.indexOf('ubuntu1204') == 0 && nodeMajorVersion >= 10)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -1,72 +1,72 @@
-def canBuild(nodeMajorVersion, builderLabel, buildType) {
+def canBuild(nodeVersion, builderLabel, buildType) {
+  def isRelease = buildType == 'release'
+  def matches = { match -> builderLabel =~ match }
 
   // Linux
-  if (builderLabel.indexOf('centos5') == 0 && nodeMajorVersion >= 8)
+  if (matches(/^centos5/) && nodeVersion >= 8)
     return false
-  if (buildType == 'release' && builderLabel.indexOf('centos6') == 0 && nodeMajorVersion < 8)
+  if (isRelease && matches(/^centos6/) && nodeVersion < 8)
     return false
-  if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc48/ && nodeMajorVersion >= 10)
+  if (matches(/centos[67]-(arm)?(64|32)-gcc48/) && nodeVersion >= 10)
     return false
-  if (builderLabel =~ /centos[67]-(arm)?(64|32)-gcc6/ && nodeMajorVersion < 10)
+  if (matches(/centos[67]-(arm)?(64|32)-gcc6/) && nodeVersion < 10)
     return false
-  if (buildType == 'release' && builderLabel =~ /centos6-32-gcc6/ && nodeMajorVersion >= 10) // 32-bit linux for <10 only
+  if (isRelease && matches(/centos6-32-gcc6/) && nodeVersion >= 10) // 32-bit linux for <10 only
     return false
-  if (builderLabel.indexOf('ubuntu1804') == 0 && nodeMajorVersion < 10) // probably temporary
+  if (matches(/^ubuntu1804/) && nodeVersion < 10) // probably temporary
     return false
-  if (builderLabel.indexOf('ubuntu1204') == 0 && nodeMajorVersion >= 10)
+  if (matches(/^ubuntu1204/) && nodeVersion >= 10)
     return false
 
   // Windows
-  if (builderLabel.indexOf('vs2013-') == 0 && nodeMajorVersion >= 6)
+  if (matches(/^vs2013-/) && nodeVersion >= 6)
     return false
-  if (builderLabel.indexOf('vs2015-') == 0 && (nodeMajorVersion < 6 || nodeMajorVersion >= 10))
+  if (matches(/^vs2015-/) && (nodeVersion < 6 || nodeVersion >= 10))
     return false
-  if (builderLabel.indexOf('vs2017-') == 0 && nodeMajorVersion < 10)
+  if (matches(/^vs2017-/) && nodeVersion < 10)
     return false
 
   // SmartOS
-  if (builderLabel.indexOf('smartos13') == 0) // Node.js 0.x
+  if (matches(/^smartos14/) && nodeVersion >= 8)
     return false
-  if (builderLabel.indexOf('smartos14') == 0 && nodeMajorVersion >= 8)
+  if (matches(/^smartos15/) && nodeVersion < 8)
     return false
-  if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
+  if (isRelease && matches(/^smartos15/) && nodeVersion >= 10)
     return false
-  if (buildType == 'release' && builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion >= 10)
+  if (matches(/^smartos16/) && nodeVersion < 8)
     return false
-  if (builderLabel.indexOf('smartos16') == 0 && nodeMajorVersion < 8)
-    return false
-  if (builderLabel.indexOf('smartos17') == 0 && nodeMajorVersion < 10)
+  if (matches(/^smartos17/) && nodeVersion < 10)
     return false
 
-  if (builderLabel.equals('debian7-docker-armv7') && nodeMajorVersion >= 10)
+  if (matches(/^debian7-docker-armv7$/) && nodeVersion >= 10)
     return false
-  if (buildType == 'release' && builderLabel.equals('debian8-docker-armv7') && nodeMajorVersion < 10)
+  if (isRelease && matches(/^debian8-docker-armv7$/) && nodeVersion < 10)
     return false
-  if (builderLabel.equals('debian9-docker-armv7') && nodeMajorVersion < 10)
+  if (matches(/^debian9-docker-armv7$/) && nodeVersion < 10)
     return false
 
   // PPC BE
-  if (builderLabel.indexOf('ppcbe-ubuntu') == 0 && nodeMajorVersion >= 8)
+  if (matches(/^ppcbe-ubuntu/) && nodeVersion >= 8)
     return false
 
   // s390x
-  if (builderLabel.indexOf('s390x') > -1 && nodeMajorVersion < 6)
+  if (matches(/s390x/) && nodeVersion < 6)
     return false
 
   // AIX61
-  if (builderLabel.indexOf('aix61') > -1 && nodeMajorVersion < 6)
+  if (matches(/aix61/) && nodeVersion < 6)
     return false
 
   // sharedlibs containered
-  if (builderLabel.indexOf('sharedlibs_openssl111') > -1 && nodeMajorVersion < 9)
+  if (matches(/sharedlibs_openssl111/) && nodeVersion < 9)
     return false
-  if (builderLabel.indexOf('sharedlibs_openssl110') > -1 && nodeMajorVersion < 9)
+  if (matches(/sharedlibs_openssl110/) && nodeVersion < 9)
     return false
-  if (builderLabel.indexOf('sharedlibs_openssl102') > -1 && nodeMajorVersion > 9)
+  if (matches(/sharedlibs_openssl102/) && nodeVersion > 9)
     return false
-  if (builderLabel.indexOf('sharedlibs_fips20') > -1 && nodeMajorVersion > 9)
+  if (matches(/sharedlibs_fips20/) && nodeVersion > 9)
     return false
-  if (builderLabel.indexOf('sharedlibs_withoutintl') > -1 && nodeMajorVersion < 9)
+  if (matches(/sharedlibs_withoutintl/) && nodeVersion < 9)
     return false
 
   return true
@@ -77,8 +77,8 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
 int nodeMajorVersion = -1
 if (parameters['NODEJS_MAJOR_VERSION'])
   nodeMajorVersion = parameters['NODEJS_MAJOR_VERSION'].toString().toInteger()
-println 'Node.js major version: ' + nodeMajorVersion
-println 'Node.js version: ' + parameters['NODEJS_VERSION']
+println "Node.js major version: $nodeMajorVersion"
+println "Node.js version: ${parameters['NODEJS_VERSION']}"
 
 result['nodes'] = []
 
@@ -93,10 +93,10 @@ combinations.each{
   def builderLabel = it.nodes
   if (nodeMajorVersion >= 4) {
     if (!canBuild(nodeMajorVersion, builderLabel, _buildType)) {
-      println 'Skipping ' + builderLabel + ' for Node.js ' + nodeMajorVersion
+      println "Skipping $builderLabel for Node.js $nodeMajorVersion"
       return
     }
   }
-  result['nodes'] << it
+  result['nodes'].add(it)
 }
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -1,4 +1,4 @@
-def canBuild(nodeMajorVersion, builderLabel, buildType='release') {
+def canBuild(nodeMajorVersion, builderLabel, buildType) {
 
   // Linux
   if (builderLabel.indexOf('centos5') == 0 && nodeMajorVersion >= 8)
@@ -69,10 +69,17 @@ println 'Node.js version: ' + parameters['NODEJS_VERSION']
 
 result['nodes'] = []
 
+def _buildType
+try {
+  _buildType = buildType
+} catch (groovy.lang.MissingPropertyException e) {
+  _buildType = 'release'
+}
+
 combinations.each{
   def builderLabel = it.nodes
   if (nodeMajorVersion >= 4) {
-    if (!canBuild(nodeMajorVersion, builderLabel)) {
+    if (!canBuild(nodeMajorVersion, builderLabel, _buildType)) {
       println 'Skipping ' + builderLabel + ' for Node.js ' + nodeMajorVersion
       return
     }

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -29,6 +29,10 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
     return false
   if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
     return false
+  if (buildType == 'release' && builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion >= 10)
+    return false
+  if (builderLabel.indexOf('smartos17') == 0 && nodeMajorVersion < 10)
+    return false
 
   if (builderLabel.equals('debian7-docker-armv7') && nodeMajorVersion >= 10)
     return false

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -27,6 +27,10 @@ def canBuild(nodeMajorVersion, builderLabel) {
     return false
   if (builderLabel.equals('armv7-jessie-release') && nodeMajorVersion < 10)
     return false
+  if (builderLabel.equals('debian7-docker-armv7') && nodeMajorVersion >= 10)
+    return false
+  if (builderLabel.equals('debian9-docker-armv7') && nodeMajorVersion < 10)
+    return false
 
   // PPC BE
   if (builderLabel.indexOf('ppcbe-ubuntu') == 0 && nodeMajorVersion >= 8)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -26,12 +26,9 @@ def canBuild(nodeMajorVersion, builderLabel, buildType) {
   if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
     return false
 
-  // ARMv7
-  if (builderLabel.equals('armv7-wheezy-release') && nodeMajorVersion >= 10)
-    return false
-  if (builderLabel.equals('armv7-jessie-release') && nodeMajorVersion < 10)
-    return false
   if (builderLabel.equals('debian7-docker-armv7') && nodeMajorVersion >= 10)
+    return false
+  if (buildType == 'release' && builderLabel.equals('debian8-docker-armv7') && nodeMajorVersion < 10)
     return false
   if (builderLabel.equals('debian9-docker-armv7') && nodeMajorVersion < 10)
     return false

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -24,6 +24,10 @@ def buildExclusions = [
   [ /^debian7-docker-armv7$/,         anyType,     gte(10) ],
   [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
+  [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.9$/, anyType,  lt(10) ],
+  [ /^cross-compiler-armv[67]-gcc-4.9$/, anyType,  lt(10) ],
 
   // Windows -----------------------------------------------
   [ /^vs2013-/,                       anyType,     gte(6)  ],


### PR DESCRIPTION
Following on from https://github.com/nodejs/build/issues/1153

node-version-jenkins-plugin is now installed on ci.nodejs.org and is being used in node-test-commit-linux-arm, node-test-commit-linux-containered and node-test-commit-linux to select the right builders to run. So we have some ARM and containered specific options in here. The script also has a "buildType"  so that it can do slightly different things for release as for test (and other), e.g. centos6 shouldn't be used for Node 4 in release but it should be used for everything for test.