### PR TITLE
nginx: Redirect old inspector docs (node executable)

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -423,4 +423,6 @@ server {
 
     rewrite ^/static/documents/casestudies/(.*)$                                    https://foundation.nodejs.org/wp-content/uploads/sites/50/2017/09/$1 permanent;
     rewrite ^/static/documents/minutes/nodejs-foundation-board-meeting-(.*).pdf$    https://github.com/nodejs/board/blob/master/minutes/$1.md permanent;
+
+    rewrite ^/en/docs/inspector/$                                 https://$server_name/en/docs/guides/debugging-getting-started/ permanent;
 }

--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -424,5 +424,5 @@ server {
     rewrite ^/static/documents/casestudies/(.*)$                                    https://foundation.nodejs.org/wp-content/uploads/sites/50/2017/09/$1 permanent;
     rewrite ^/static/documents/minutes/nodejs-foundation-board-meeting-(.*).pdf$    https://github.com/nodejs/board/blob/master/minutes/$1.md permanent;
 
-    rewrite ^/en/docs/inspector/$                                 https://$server_name/en/docs/guides/debugging-getting-started/ permanent;
+    rewrite ^/en/docs/inspector/?$                                https://$server_name/en/docs/guides/debugging-getting-started/ permanent;
 }


### PR DESCRIPTION
Turns out node was linking to nodejs.org/en/docs/inspector.
This fixes the redirect as well.

Ref: nodejs/nodejs.org#1619