### PR TITLE
updated git for debian8, ubuntu 14.04 and ubuntu 16.06

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
@@ -1,10 +1,5 @@
 ---
 
-#
-# add backports for systemd-coredump
-#
-
-
 - name: "repo : add debian-backports"
   apt_repository:
     repo: 'deb http://ftp.debian.org/debian jessie-backports main'
@@ -19,4 +14,3 @@
     state: present
     update_cache: yes
   register: has_updated_package_repo
-

--- a/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
@@ -1,0 +1,22 @@
+---
+
+#
+# add backports for systemd-coredump
+#
+
+
+- name: "repo : add debian-backports"
+  apt_repository:
+    repo: 'deb http://ftp.debian.org/debian jessie-backports main'
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo
+
+- name: "repo : add git-core trusty ppa"
+  apt_repository:
+    repo: ppa:git-core/ppa
+    codename: trusty
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo
+

--- a/ansible/roles/baselayout/tasks/partials/repo/ubuntu1404.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/ubuntu1404.yml
@@ -1,12 +1,15 @@
 ---
 
-#
-# add PPA for gcc 4.9
-#
-
-- name: "repo : add Ubuntu Toolchain PPA"
+- name: "repo : add ubuntu toolchain ppa"
   apt_repository:
     repo: 'ppa:ubuntu-toolchain-r/test'
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo
+
+- name: "repo : add git-core ppa"
+  apt_repository:
+    repo: ppa:git-core/ppa
     state: present
     update_cache: yes
   register: has_updated_package_repo

--- a/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
@@ -1,0 +1,8 @@
+---
+
+- name: "repo : add git-core ppa"
+  apt_repository:
+    repo: ppa:git-core/ppa
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo

--- a/ansible/roles/jenkins-worker/templates/systemd.service.j2
+++ b/ansible/roles/jenkins-worker/templates/systemd.service.j2
@@ -13,7 +13,6 @@ Restart=always
 RestartSec=30
 StartLimitInterval=0
 WorkingDirectory=/home/{{ server_user }}
-LimitCORE=unlimited
 
 Environment="USER={{ server_user }}"
 Environment="JOBS={{ jobs_env }}"


### PR DESCRIPTION
they now all have 2.17, including the jenkins-workspace machines. I'm hoping this will clear up some of the git errors we've been seeing in Jenkins.