### PR TITLE
ansible: smartos17

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,6 +36,7 @@ hosts:
         smartos13-x64-1: {ip: 72.2.114.225}
         smartos14-x64-1: {ip: 72.2.113.193}
         smartos15-x64-1: {ip: 165.225.131.14}
+        smartos17-x64-1: {ip: 72.2.114.225}
 
     - requireio:
         rvagg-debian9-armv6l_pi1p-1: {ip: 192.168.2.40, user: pi}
@@ -112,6 +113,8 @@ hosts:
         smartos15-x64-2: {ip: 165.225.139.77}
         smartos16-x64-1: {ip: 72.2.115.252}
         smartos16-x64-2: {ip: 72.2.113.74}
+        smartos17-x64-1: {ip: 72.2.112.228}
+        smartos17-x64-2: {ip: 72.2.115.11}
         ubuntu1604_docker-x64-1: {ip: 165.225.138.30, user: ubuntu}
         ubuntu1710-x64-1: {ip: 37.153.110.33, user: ubuntu}
         ubuntu1710-x64-2: {ip: 8.19.32.121, user: ubuntu}

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -64,7 +64,7 @@
     - "{{ packages[os|stripversion]|default('[]') }}"
     - "{{ common_packages|default('[]') }}"
 
-- name: update package alternatives
+- name: ubuntu1404 | update package alternatives
   when: os == "ubuntu1404"
   alternatives: link=/usr/bin/{{ gcc }} name={{ gcc }} path=/usr/bin/{{ gcc }}-4.9
   loop_control:
@@ -72,6 +72,21 @@
   with_items:
     - gcc
     - g++
+
+- name: smartos17 | update gcc symlinks
+  when: os == "smartos17"
+  file:
+    src: "/opt/local/gcc7/bin/{{ gcc }}"
+    dest: "/opt/local/bin/{{ gcc }}"
+    state: link
+  loop_control:
+    loop_var: gcc
+  with_items:
+    - gcc
+    - cc
+    - g++
+    - cpp
+    - c++
 
 - name: remove fortune from login shells
   when: os|stripversion == 'freebsd'
@@ -102,8 +117,6 @@
   when: os in ccache_no_binpkg and not has_ccache.stat.exists
   include: ccache.yml
   static: false
-  vars:
-    - version: 3.3.3
 
 - name: set up ntp
   include: "{{ ntp_include }}"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -6,7 +6,7 @@
 
 binary_dest: '/usr/local/bin/ccache'
 
-ccache_no_binpkg: ['smartos14', 'smartos15', 'smartos16']
+ccache_no_binpkg: ['smartos14', 'smartos15', 'smartos16', 'smartos17']
 ccache_version: 3.3.2
 
 git_no_binpkg: ['debian7']
@@ -72,31 +72,30 @@ packages: {
     'gcc-c++',
   ],
 
-  smartos14: [
-    'gcc48',
-    'gcc48-libs',
+  smartos: [
     'gccmakedep',
     'git',
     'gmake',
     'xz'
+  ],
+
+  smartos14: [
+    'gcc48',
+    'gcc48-libs'
   ],
 
   smartos15: [
     'gcc49',
-    'gcc49-libs',
-    'gccmakedep',
-    'git',
-    'gmake',
-    'xz'
+    'gcc49-libs'
   ],
 
   smartos16: [
     'gcc49',
-    'gcc49-libs',
-    'gccmakedep',
-    'git',
-    'gmake',
-    'xz'
+    'gcc49-libs'
+  ],
+
+  smartos17: [
+    'gcc7'
   ],
 
   ubuntu: [

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -9,6 +9,11 @@
     jobs_env: "{{ jobs_variants[arch] }}"
   when: jobs_env is undefined and server_jobs is undefined and arch in jobs_variants
 
+- name: set jobs_env from jobs_variants.{{ os|stripversion }}
+  set_fact:
+    jobs_env: "{{ jobs_variants[os|stripversion] }}"
+  when: jobs_env is undefined and server_jobs is undefined and os|stripversion in jobs_variants
+
 - name: set jobs_env from server_jobs or ansible_processor_vcpus
   set_fact:
     jobs_env: "{{ server_jobs|default(ansible_processor_vcpus) }}"

--- a/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
+++ b/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
@@ -21,7 +21,7 @@
           <envvar name='NODE_TEST_DIR' value='/home/{{ server_user }}/tmp' />
           <envvar name='OSTYPE' value='solaris' />
           <envvar name='HOME' value='/home/{{ server_user }}' />
-          <envvar name='JOBS' value='{{ jobs_env|default("4")) }}' />
+          <envvar name='JOBS' value='{{ jobs_env|default("2") }}' />
           <envvar name='PATH' value='/usr/local/bin:/usr/local/sbin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />
         </method_environment>
       </method_context>

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -76,6 +76,7 @@ java_path: {
   'smartos14': '/opt/local/java/openjdk8/bin/java',
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
+  'smartos17': '/opt/local/java/openjdk8/bin/java',
   'zos13': '/usr/lpp/java/J8.0_64/bin/java'
   }
 
@@ -118,5 +119,6 @@ scaleway_armv7: {
 jobs_variants: {
   armv6l: '1',
   armv7l: '2',
-  arm64: '3'
+  arm64: '3',
+  smartos: '2'
 }


### PR DESCRIPTION
I've provisioned 2 test and 1 release smartos 17 machines and this is the required changes for ansible to get it set up. The only iffy bit that I bet there's a better answer for is the gcc7 links into /opt/local/bin, it's strange that there aren't links by default and there must be some kind of equivalent to debian style "alternatives". It works at least.

I've got rules in place to make Node >=10 binaries build on smartos 17, 64-bit only from 10 onward like for linux.

[VersionSelectorScript.groovy](https://github.com/nodejs/build/blob/rvagg/VersionSelectorScript.groovy/jenkins/scripts/VersionSelectorScript.groovy) now has the following:

```groovy
  if (builderLabel.indexOf('smartos14') == 0 && nodeMajorVersion >= 8)
    return false
  if (builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion < 8)
    return false
  if (buildType == 'release' && builderLabel.indexOf('smartos15') == 0 && nodeMajorVersion >= 10)
    return false
  if (builderLabel.indexOf('smartos16') == 0 && nodeMajorVersion < 8)
    return false
  if (builderLabel.indexOf('smartos17') == 0 && nodeMajorVersion < 10)
    return false
```

Roughly translated as:
* releases:
  - Node 4 & 6: smartos14
  - Node 8: smartos15
  - Node 10+: smartos17
* testing:
  - Node 4 & 6: smartos14
  - Node 8: smartos15, smartos16
  - Node 10+: smartos15, smartos16, smartos17

Builds from today onward (nightlies and the Node 10 test builds most notably) are using this configuration. Also including the absence of sunos-x86 binaries.

@geek 

/ref https://github.com/nodejs/build/issues/885
/ref https://github.com/nodejs/build/pull/1149