### PR TITLE
install binutils-2.26 on ubuntu

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -100,6 +100,6 @@ packages: {
   ],
 
   ubuntu1404: [
-    'ntp,g++-4.8,gcc-4.8,g++-4.9,gcc-4.9',
+    'ntp,g++-4.8,gcc-4.8,g++-4.9,gcc-4.9,binutils-2.26',
   ]
 }


### PR DESCRIPTION
Certain versions of node require binutils version 2.26 (https://github.com/nodejs/build/issues/1229)
This won't affect the default installation of binutils.

To use it, add the following to PATH.
/usr/lib/binutils-2.26/bin/

fyi, @mhdawson 