### PR TITLE
ansible: binutils-2.26 for debian8 using trusty-updates

### DIFF
--- a/ansible/roles/baselayout/files/debian8-ubuntu-trusty-apt-preferences
+++ b/ansible/roles/baselayout/files/debian8-ubuntu-trusty-apt-preferences
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=trusty-updates
+Pin-Priority: 50

--- a/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
@@ -1,18 +1,13 @@
 ---
 
-#
-# add backports for systemd-coredump
-#
-
-
-- name: "repo : add debian-backports"
+- name: "debian8 | add debian-backports" # has systemd-coredump if needed
   apt_repository:
     repo: 'deb http://ftp.debian.org/debian jessie-backports main'
     state: present
     update_cache: yes
   register: has_updated_package_repo
 
-- name: "repo : add git-core trusty ppa"
+- name: "debian8 | add git-core trusty ppa"
   apt_repository:
     repo: ppa:git-core/ppa
     codename: trusty
@@ -20,3 +15,23 @@
     update_cache: yes
   register: has_updated_package_repo
 
+- name: "debian8 | add trusty-updates gpg keys"
+  shell: "apt-key adv --recv-keys --keyserver keyserver.ubuntu.com {{ item }}"
+  with_items:
+    - 40976EAF437D05B5
+    - 3B4FE6ACC0B21F32
+  register: has_updated_package_repo
+
+- name: "debian8 | install lower trusty-updates package priority"
+  copy:
+    src: "{{ role_path }}/files/debian8-ubuntu-trusty-apt-preferences"
+    dest: "/etc/apt/preferences.d/trusty-updates"
+    mode: 0644
+  register: has_updated_package_repo
+
+- name: "debian8 | add trusty-updates"
+  apt_repository:
+    repo: 'deb http://us.archive.ubuntu.com/ubuntu trusty-updates main universe'
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -50,7 +50,7 @@ packages: {
   ],
 
   debian8: [
-    'ccache,git,gcc-4.9,g++-4.9,libfontconfig1',
+    'ccache,git,gcc-4.9,g++-4.9,libfontconfig1,binutils-2.26',
   ],
 
   debian9: [


### PR DESCRIPTION
Same as https://github.com/nodejs/build/pull/1235 but for Debian 8, unfortunately I have to pull in trusty-updates for jessie but set the priority low for all of the packages from there so we only pull in binutils-2.26 and nothing else.