### PR TITLE
Release Candidate support for Node-ChakraCore

### DIFF
--- a/setup/www/tasks/user.yaml
+++ b/setup/www/tasks/user.yaml
@@ -56,9 +56,9 @@
     - nodejs/release
     - nodejs/test
     - nodejs/v8-canary
-    - nodejs/chakracore-nightly
     - nodejs/docs
     - nodejs/chakracore-nightly
+    - nodejs/chakracore-rc
     - nodejs/chakracore-release
     - iojs/next-nightly
     - iojs/nightly
@@ -99,6 +99,7 @@
     - nodejs/release
     - nodejs/v8-canary
     - nodejs/chakracore-nightly
+    - nodejs/chakracore-rc
     - nodejs/chakracore-release
     - iojs/custom
     - iojs/next-nightly

--- a/setup/www/tools/promote/promote_nightly.sh
+++ b/setup/www/tools/promote/promote_nightly.sh
@@ -43,6 +43,12 @@ dirmatch=$chakracore_nightly_dirmatch
 
 . ${__dirname}/_promote.sh $site
 
+srcdir=$chakracore_rc_srcdir
+dstdir=$chakracore_rc_dstdir
+dirmatch=$chakracore_rc_dirmatch
+
+. ${__dirname}/_promote.sh $site
+
 srcdir=$chakracore_release_srcdir
 dstdir=$chakracore_release_dstdir
 dirmatch=$chakracore_release_dirmatch
@@ -52,11 +58,5 @@ dirmatch=$chakracore_release_dirmatch
 srcdir=$v8_canary_srcdir
 dstdir=$v8_canary_dstdir
 dirmatch=$v8_canary_dirmatch
-
-. ${__dirname}/_promote.sh $site
-
-srcdir=$chakracore_nightly_srcdir
-dstdir=$chakracore_nightly_dstdir
-dirmatch=$chakracore_nightly_dirmatch
 
 . ${__dirname}/_promote.sh $site

--- a/setup/www/tools/promote/settings
+++ b/setup/www/tools/promote/settings
@@ -29,6 +29,10 @@ chakracore_nightly_srcdir=${staging_rootdir}chakracore-nightly
 chakracore_nightly_dstdir=${dist_rootdir}chakracore-nightly
 chakracore_nightly_dirmatch=.*
 
+chakracore_rc_srcdir=${staging_rootdir}chakracore-rc
+chakracore_rc_dstdir=${dist_rootdir}chakracore-rc
+chakracore_rc_dirmatch=.*
+
 chakracore_release_srcdir=${staging_rootdir}chakracore-release
 chakracore_release_dstdir=${dist_rootdir}chakracore-release
 chakracore_release_dirmatch=.*


### PR DESCRIPTION
Node-ChakraCore will release its version 10 tomorrow simultaneously with Node-V8, hence RC builds are necessary for testing. This adds the necessary changes to `www`.

This is already in the server and the first build is available at https://nodejs.org/download/chakracore-rc/v10.0.0-rc.0/ .

This PR also removes two duplicate entries for `chakracore-nightly`.