### PR TITLE
ansible: rpi updates, completed conversions to new format

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -195,8 +195,8 @@ hosts:
         mhdawson-debian9-armv6l_pi1p-1:         {ip: 192.168.2.49, user: pi}
         securogroup-debian9-armv6l_pi1p-1:      {ip: 192.168.2.50, user: pi}
         securogroup-debian9-armv6l_pi1p-2:      {ip: 192.168.2.51, user: pi}
-        chrislea-debian7-armv6l_pi1p-1:         {ip: 192.168.2.52, user: pi}
-        davglass-debian7-armv6l_pi1p-1:         {ip: 192.168.2.53, user: pi}
+        chrislea-debian9-armv6l_pi1p-1:         {ip: 192.168.2.52, user: pi}
+        davglass-debian9-armv6l_pi1p-1:         {ip: 192.168.2.53, user: pi}
 
         rvagg-debian9-armv7l_pi2-1:        {ip: 192.168.2.60, user: pi}
         joeyvandijk-debian9-armv7l_pi2-1:  {ip: 192.168.2.61, user: pi}
@@ -208,8 +208,8 @@ hosts:
         sambthompson-debian9-armv7l_pi2-1: {ip: 192.168.2.67, user: pi}
         louiscntr-debian9-armv7l_pi2-1:    {ip: 192.168.2.68, user: pi}
         svincent-debian9-armv7l_pi2-2:     {ip: 192.168.2.69, user: pi}
-        svincent-debian7-armv7l_pi2-3:     {ip: 192.168.2.70, user: pi}
-        jasnell-debian7-armv7l_pi2-1:      {ip: 192.168.2.71, user: pi}
+        svincent-debian9-armv7l_pi2-3:     {ip: 192.168.2.70, user: pi}
+        jasnell-debian9-armv7l_pi2-1:      {ip: 192.168.2.71, user: pi}
 
         williamkapke-debian9-arm64_pi3-1:      {ip: 192.168.2.80, user: pi}
         williamkapke-debian9-arm64_pi3-2:      {ip: 192.168.2.81, user: pi}
@@ -221,7 +221,7 @@ hosts:
         securogroup-debian9-arm64_pi3-2:       {ip: 192.168.2.87, user: pi}
         notthetup_sayanee-debian9-arm64_pi3-1: {ip: 192.168.2.88, user: pi}
         piccoloaiutante-debian9-arm64_pi3-1:   {ip: 192.168.2.89, user: pi}
-        kahwee-debian8-arm64_pi3-1:            {ip: 192.168.2.90, user: pi}
+        kahwee-debian9-arm64_pi3-1:            {ip: 192.168.2.90, user: pi}
 
         rvagg-ubuntu1404-arm64_odroidxu3-1: {ip: 192.168.2.10, user: odroid}
         rvagg-ubuntu1404-arm64_odroidxu-1: {ip: 192.168.2.15}

--- a/ansible/roles/bootstrap/tasks/partials/raspberry-pi.yml
+++ b/ansible/roles/bootstrap/tasks/partials/raspberry-pi.yml
@@ -81,7 +81,7 @@
     - name: pi | test if nfs-root and sd card available
       shell: |
         test \
-          -n "$(sudo fdisk -l /dev/mmcblk0 | grep '^/dev/mmcblk0p1.*W95 FAT32$')" -a \
+          -n "$(sudo fdisk -l /dev/mmcblk0 | grep '^/dev/mmcblk0p1.*W95 FAT32')" -a \
           -n "$(grep ' / ' /proc/mounts | grep -E '^[0-9\.]+:/')"
       register: nfs_root_check_result
       ignore_errors: true

--- a/ansible/roles/jenkins-worker/tasks/partials/raspberry-pi.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/raspberry-pi.yml
@@ -6,7 +6,23 @@
   service: name=rpcbind state=started enabled=yes
   tags: init
 
-- name: pi | make nfs mounted directories
+- name: pi | test if nfs-root
+  shell: |
+    test -n "$(grep ' / ' /proc/mounts | grep -E '^[0-9\.]+:/')"
+  register: nfs_root_check_result
+  ignore_errors: true
+
+- name: pi | mount /boot/ via nfs
+  mount:
+    name: "/boot"
+    src: "{{ raspberry_pi.nfs_boot_server }}:{{ raspberry_pi.nfs_boot_share_root }}/{{ inventory_hostname }}"
+    fstype: nfs4
+    opts: nfsvers=3,rw,noexec,async,noauto
+    state: mounted
+  when: nfs_root_check_result.rc == 0
+  tags: nfs
+
+- name: pi | make .ccache
   file:
     path: "/home/{{ server_user }}/.ccache"
     state: directory
@@ -15,29 +31,27 @@
   ignore_errors: True
   tags: nfs
 
-- name: pi | configure mount options
+- name: pi | mount .ccache via nfs
   mount:
     name: "/home/{{ server_user }}/.ccache"
-    src: "{{ raspberry_pi.nfs_server }}:{{ raspberry_pi.nfs_share_root }}/.ccache"
+    src: "{{ raspberry_pi.nfs_root_server }}:{{ raspberry_pi.nfs_root_share_root }}/.ccache"
     fstype: nfs4
     opts: rw,exec,async,noauto
     state: mounted
   tags: nfs
 
-- name: pi | mount at end of boot sequence
-  lineinfile:
-    path: /etc/rc.local
-    insertbefore: '^exit 0'
-    line: '{{ item }}'
-  with_items:
-    - '/etc/init.d/rpcbind start'
-    - '/etc/init.d/nfs-common start'
-    - 'sleep 10 && (grep nfs /etc/fstab | cut -d" " -f 2 | xargs -l mount) &'
+- name: pi | copy rc.local to mount nfs post boot
+  template:
+    src: "./templates/rpi_rc.local.j2"
+    dest: "/etc/rc.local"
+    owner: "root"
+    group: "root"
+    mode: 0755
   tags: nfs
 
 - name: pi | copy start_tunnel.sh script
   template:
-    src: "./resources/start_tunnel.j2"
+    src: "./templates/rpi_start_tunnel.j2"
     dest: "/usr/local/sbin/start_tunnel.sh"
     owner: "{{ server_user }}"
     group: "{{ server_user }}"

--- a/ansible/roles/jenkins-worker/templates/rpi_rc.local.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_rc.local.j2
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+/etc/init.d/rpcbind start
+/etc/init.d/nfs-common start
+sleep 10 && (grep nfs /etc/fstab | cut -d" " -f 2 | xargs -l mount) &
+exit 0

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -99,8 +99,10 @@ bash_path: {
   }
 
 raspberry_pi: {
-  nfs_server: '192.168.1.10',
-  nfs_share_root: '/exports/nodejs/pi',
+  nfs_root_server: '192.168.1.10',
+  nfs_boot_server: '192.168.2.100',
+  nfs_root_share_root: '/exports/nodejs/pi',
+  nfs_boot_share_root: '/var/tftpd',
   containers: {
     armv6l: [
       { name: 'wheezy', template: 'rpi_wheezy.Dockerfile.j2' },


### PR DESCRIPTION
* migrated the remaining pi's to the new dockerized setup
* mounted /boot/ on all of the nfs-root pi's so any updates get pushed back into the tftp nfs server
* minor fixes

interesting thing happened with this though, one of the Pi's, the last of the Pi 1 B+'s (number 14 according to how I number them, and one of the most recently purchased ones so it's not ancient) test-requireio_davglass-debian9-armv6l_pi1p-1 won't stay running while nfs booted. I've updated firmware, tried using a "next" branch bootloader, all sorts of things but I can't stop it from doing a kernel panic fairly soon after starting up. So I've left it with a classic SD card setup, but it's the only one out of all of them. Pretty strange. Good chance to get these scripts working for both nfs-booted and SD card booted Pi's.