### PR TITLE
ansible: add role to install Linux perf on Ubuntu

### DIFF
--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -55,3 +55,12 @@
 
   roles:
     - cross-compiler
+
+#
+# Install Linux perf on Ubuntu 16.04 servers
+#
+
+- hosts:
+    - test-*-ubuntu1604-x*
+  roles:
+    - linux-perf

--- a/ansible/roles/linux-perf/tasks/main.yml
+++ b/ansible/roles/linux-perf/tasks/main.yml
@@ -24,20 +24,13 @@
         depth: 1
         dest: /data/tmp/linux
 
-    - name: Install build-essential
+    - name: Install packages
       package:
-        name: build-essential
+        name: "{{ package }}"
         state: present
-
-    - name: Install flex
-      package:
-        name: flex
-        state: present
-
-    - name: Install bison
-      package:
-        name: bison
-        state: present
+      loop_control:
+        loop_var: package
+      with_items: "{{ packages }}"
 
     - name: build Linux perf
       shell: make -j{{ ansible_processor_cores | default(1) }}

--- a/ansible/roles/linux-perf/tasks/main.yml
+++ b/ansible/roles/linux-perf/tasks/main.yml
@@ -5,7 +5,7 @@
 #
 
 - stat:
-    path=/usr/local/bin/perf
+    path: /usr/local/bin/perf
   register: linux_perf
   tags: linux_perf
 
@@ -16,13 +16,13 @@
     - name: Clean path
       file:
         state: absent
-        path: /data/tmp/
+        path: "{{ tmp_folder }}"
 
     - name: Download Linux source code
       git:
         repo: https://github.com/torvalds/linux.git
         depth: 1
-        dest: /data/tmp/linux
+        dest: "{{ tmp_folder }}/linux"
 
     - name: Install packages
       package:
@@ -35,12 +35,12 @@
     - name: build Linux perf
       shell: make -j{{ ansible_processor_cores | default(1) }}
       args:
-        chdir: /data/tmp/linux/tools/perf
+        chdir: "{{ tmp_folder }}/linux/tools/perf"
 
     - name: install Linux perf
-      shell: cp /data/tmp/linux/tools/perf/perf /usr/local/bin/perf
+      shell: "cp {{ tmp_folder }}/linux/tools/perf/perf /usr/local/bin/perf"
 
     - name: Clean path
       file:
         state: absent
-        path: /data/tmp/
+        path: "{{ tmp_folder }}"

--- a/ansible/roles/linux-perf/tasks/main.yml
+++ b/ansible/roles/linux-perf/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+
+#
+# installs Linux perf @ /usr/local/bin/perf
+#
+
+- stat: path=/usr/local/bin/perf
+  register: linux_perf
+  tags: linux_perf
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: Download Linux source code
+  git:
+    repo: https://github.com/torvalds/linux.git
+    depth: 1
+    dest: /data/tmp/linux
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: Install build-essential
+  package:
+    name: build-essential
+    state: present
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: Install flex
+  package:
+    name: flex
+    state: present
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: Install bison
+  package:
+    name: bison
+    state: present
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: build Linux perf
+  shell: make -j{{ ansible_processor_cores }}
+  args:
+    chdir: /data/tmp/linux/tools/perf
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: install Linux perf
+  shell: cp /data/tmp/linux/tools/perf/perf /usr/local/bin/perf
+  when: linux_perf.stat.exists == False
+  tags: linux_perf
+
+- name: Clean path
+  file:
+    state: absent
+    path: /data/tmp/
+  when: linux_perf.stat.exists == False
+  tags: linux_perf

--- a/ansible/roles/linux-perf/tasks/main.yml
+++ b/ansible/roles/linux-perf/tasks/main.yml
@@ -4,61 +4,50 @@
 # installs Linux perf @ /usr/local/bin/perf
 #
 
-- stat: path=/usr/local/bin/perf
+- stat:
+    path=/usr/local/bin/perf
   register: linux_perf
   tags: linux_perf
 
-- name: Clean path
-  file:
-    state: absent
-    path: /data/tmp/
-  when: linux_perf.stat.exists == False
+- name: install perf on linux
   tags: linux_perf
+  when: not (linux_perf.stat.exists | bool)
+  block:
+    - name: Clean path
+      file:
+        state: absent
+        path: /data/tmp/
 
-- name: Download Linux source code
-  git:
-    repo: https://github.com/torvalds/linux.git
-    depth: 1
-    dest: /data/tmp/linux
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: Download Linux source code
+      git:
+        repo: https://github.com/torvalds/linux.git
+        depth: 1
+        dest: /data/tmp/linux
 
-- name: Install build-essential
-  package:
-    name: build-essential
-    state: present
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: Install build-essential
+      package:
+        name: build-essential
+        state: present
 
-- name: Install flex
-  package:
-    name: flex
-    state: present
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: Install flex
+      package:
+        name: flex
+        state: present
 
-- name: Install bison
-  package:
-    name: bison
-    state: present
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: Install bison
+      package:
+        name: bison
+        state: present
 
-- name: build Linux perf
-  shell: make -j{{ ansible_processor_cores }}
-  args:
-    chdir: /data/tmp/linux/tools/perf
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: build Linux perf
+      shell: make -j{{ ansible_processor_cores | default(1) }}
+      args:
+        chdir: /data/tmp/linux/tools/perf
 
-- name: install Linux perf
-  shell: cp /data/tmp/linux/tools/perf/perf /usr/local/bin/perf
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: install Linux perf
+      shell: cp /data/tmp/linux/tools/perf/perf /usr/local/bin/perf
 
-- name: Clean path
-  file:
-    state: absent
-    path: /data/tmp/
-  when: linux_perf.stat.exists == False
-  tags: linux_perf
+    - name: Clean path
+      file:
+        state: absent
+        path: /data/tmp/

--- a/ansible/roles/linux-perf/vars/main.yml
+++ b/ansible/roles/linux-perf/vars/main.yml
@@ -1,0 +1,5 @@
+---
+packages:
+  - build-essential
+  - flex
+  - bison

--- a/ansible/roles/linux-perf/vars/main.yml
+++ b/ansible/roles/linux-perf/vars/main.yml
@@ -3,3 +3,4 @@ packages:
   - build-essential
   - flex
   - bison
+tmp_folder: /data/tmp


### PR DESCRIPTION
Ansible role to install Linux perf on Ubuntu by cloning the Linux source
code and building tools/perf to avoid Kernel mismatch errors.

I wasn't sure which playbook should call this role, so I'm submitting only 
the role for now.

Tested on Ubuntu 16.04 from DigitalOcean.

Ref: https://github.com/nodejs/build/issues/1274