### PR TITLE
jenkins: don't run pi1-docker for releases on 10+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -24,6 +24,7 @@ def buildExclusions = [
   [ /^debian7-docker-armv7$/,         anyType,     gte(10) ],
   [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
+  [ /^pi1-docker$/,                   releaseType, gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],


### PR DESCRIPTION
`pi1-docker` builds are failing on ci-release for 10+ (i.e. nightly/master too). The reason it's failing is that the v10 and master branches aren't available in the git shared reference repo, which is updated @ https://ci.nodejs.org/view/All/job/git-nodesource-update-reference/ (at least I'm fairly sure this is related). I'll update that _but_ it shouldn't even be running on ci-release because we use the cross-compiler for Node 10+ now for armv6 and armv7, no pi1-docker necessary. I thought we took this out of action already but perhaps we've been trying to push releases with this for some time now? I'm not sure about the history here and why we're in a failing state now, I'm pretty certain that this wasn't happening when we first release 10.0.0, maybe it was a slip-up in VersionSelectorScript.groovy at some point since then.

So what this change does is exclude `pi1-docker` for _release_ builds for node 10+. `cross-compiler-armv6-gcc-4.9.4` will run on there and there is no `cross-compiler-armv6-gcc-4.8` on ci-release for it to get confused with either. I don't think we use the `pi1-docker` label for anything meaningful on ci, we use the extended labels with debian name in them, although the `pi1-docker` label exists so I'm being careful here.

I'm going to expedite this merge to sort ci-release out and get rid of the ugly (but ultimately harmless) fails.