### PR TITLE
add ccache to jenkins_path for macOS

### DIFF
--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -6,7 +6,8 @@ export JOBS="{{ jobs_env }}"
 export OSTYPE=osx
 export ARCH=x64
 export DESTCPU=x64
+export JENKINS_PATH="/usr/localopt/ccache/libexec:$PATH"
 
-{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
+PATH="$JENKINS_PATH" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp


### PR DESCRIPTION
This fix means that ccache is now in the path on new mac. I have tested tested this change on `test-macstadium-macos10.10-x64-1` and the jenkins_path now shows to be `/usr/localopt/ccache/libexec:/usr/bin:/bin:/usr/sbin:/sbin`