### PR TITLE
www: nodejs.org/github-webhook.log

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -306,6 +306,11 @@ server {
         default_type text/plain;
     }
 
+    location /github-webhook.log {
+        alias /home/nodejs/github-webhook.log;
+        default_type text/plain;
+    }
+
     location /metrics {
         alias /home/dist/metrics/;
         autoindex on;


### PR DESCRIPTION
Expose the website build log, I don't believe there's anything in here that needs to be protected, it's all run inside a Docker container too so you can't even manipulate the website repo to expose secrets through this file.

Need a sanity check from @nodejs/website: is there anything in the build output that we wouldn't want to expose publicly? `npm install --cache-min 1440 --production && npm run deploy` is what's run on the server.

Would also appreciate sanity check from any build folks who might think of a security concern that I haven't.