### PR TITLE
github-bot: restart service without sudo

### DIFF
--- a/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
+++ b/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
@@ -13,4 +13,4 @@ git fetch origin
 git checkout origin/master
 
 npm install --cache-min 1440 --production
-sudo systemctl restart github-bot
+systemctl restart github-bot


### PR DESCRIPTION
`iojs` on the github-bot server is not a sudo user, and we don't need
sudo anyways. This was preventing the server from relaunching.