### PR TITLE
github-bot: fix privilege for iojs user

### DIFF
--- a/ansible/roles/github-bot/tasks/main.yml
+++ b/ansible/roles/github-bot/tasks/main.yml
@@ -112,7 +112,7 @@
     dest: /etc/sudoers
     state: present
     regexp: "^{{ server_user }}"
-    line: "'{{ server_user }} ALL=(ALL) NOPASSWD: /bin/systemctl restart github-bot'"
+    line: "{{ server_user }} ALL=(ALL) NOPASSWD: /bin/systemctl restart github-bot"
 
 - name: Runtime dependencies | Clone node repo
   become: yes

--- a/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
+++ b/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
@@ -13,4 +13,4 @@ git fetch origin
 git checkout origin/master
 
 npm install --cache-min 1440 --production
-systemctl restart github-bot
+sudo systemctl restart github-bot


### PR DESCRIPTION
Turns out #1382 was not the right fix, the issue was that the `iojs`
user did not have proper privileges to run the command, not the command
itself.