### PR TITLE
ansible: added keybox & ansible to inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -25,6 +25,8 @@ hosts:
         debian8-x64-1: {ip: 184.172.29.199, alias: registry-mirror}
         ubuntu1404-x64-1: {ip: 169.44.16.104, alias: ci-release}
         ubuntu1404-x64-2: {ip: 50.23.85.254}
+        ubuntu1804-x64-1: {ip: 169.60.150.86, alias: keybox}
+        ubuntu1804-x64-2: {ip: 169.62.77.235, alias: ansible}
 
 
   - release:


### PR DESCRIPTION
@gdams I have put your github ssh key in both of these for now. If you put together an ansible script then I guess we can decide how to move forward when access control when we move closer to actually using these. Good luck & lemme know if you need any further help with these.