### PR TITLE
Add virtualenv to ansible directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ setup/*/host_vars/release-*
 ansible/host_vars/*
 !ansible/host_vars/README.md
 !ansible/host_vars/*-template
+
+# python virtualenv
+virtualenv/

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -7,7 +7,7 @@ ENV: Makefile
 
 CHECK_ENV:
 ifndef VIRTUAL_ENV
-	$(error PLEASE ENTER THE VIRTUALENV BEFORE FUN THE COMMAND)
+	$(error PLEASE ENTER THE VIRTUALENV BEFORE RUNNING THE COMMAND)
 endif
 
 UPDATE_ENV: requirements.txt
@@ -17,4 +17,3 @@ UPDATE_ENV: requirements.txt
 
 FLAKE8: CHECK_ENV
 	flake8
-

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,0 +1,20 @@
+.PHONY: ENV
+
+virtualenv_path = ./virtualenv
+
+ENV: Makefile
+	virtualenv2 --distribute $(virtualenv_path)
+
+CHECK_ENV:
+ifndef VIRTUAL_ENV
+	$(error PLEASE ENTER THE VIRTUALENV BEFORE FUN THE COMMAND)
+endif
+
+UPDATE_ENV: requirements.txt
+	$(virtualenv_path)/bin/pip install --upgrade setuptools
+	$(virtualenv_path)/bin/pip install --upgrade pip
+	$(virtualenv_path)/bin/pip install -r requirements.txt
+
+FLAKE8: CHECK_ENV
+	flake8
+

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -8,15 +8,15 @@
 1. Read this document.
 2. For SSH access, see the [SSH guide](../doc/ssh.md).
 
-### Install ansible system wide
+### Install ansible systemwide
 
 Follow the [instructions to install the latest version of Ansible][ansible-install].
-* In most cases, using pip: `pip install ansible`.
+* In most cases, use pip: `pip install ansible`.
 * If you use brew, then `brew install python2 ansible`, and then run
 `export PYTHONPATH=$(pip2 show pyyaml | grep Location | awk '{print $2}') `
 before you use `ansible-playbook`.
 
-### Install ansible in virtualenv
+### Install ansible via virtualenv
 
 From the `ansible` directory:
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -5,14 +5,27 @@
 
 ## Getting started
 
-1. Follow the [instructions to install the latest version of Ansible][ansible-install].
-   * In most cases, using pip: `pip install ansible`.
-   * If you use brew, then `brew install python2 ansible`, and then run
-   `export PYTHONPATH=$(pip2 show pyyaml | grep Location | awk '{print $2}') `
-   before you use `ansible-playbook`.
-2. Read this document.
-3. For SSH access, see the [SSH guide](../doc/ssh.md).
+1. Read this document.
+2. For SSH access, see the [SSH guide](../doc/ssh.md).
 
+### Install ansible system wide
+
+Follow the [instructions to install the latest version of Ansible][ansible-install].
+* In most cases, using pip: `pip install ansible`.
+* If you use brew, then `brew install python2 ansible`, and then run
+`export PYTHONPATH=$(pip2 show pyyaml | grep Location | awk '{print $2}') `
+before you use `ansible-playbook`.
+
+### Install ansible in virtualenv
+
+From the `ansible` directory:
+
+1. Run `make && make UPDATE_ENV`
+2. Run `source ./virtualenv/bin/activate` to activate the virtualenv
+3. You can now use `ansible-playbook`
+4. When done you can quit the virtualenv with `deactivate`
+
+**NOTE**: Virtualenv is now set to use _ansible 2.4.0_
 
 ## Getting things done
 

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,0 +1,5 @@
+ansible==2.4.0
+flake8==2.3.0
+flake8-blind-except==0.1.0
+flake8-import-order==0.5.1
+pep8==1.7.0

--- a/ansible/setup.cfg
+++ b/ansible/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+exclude=virtualenv
+max-line-length=110
+import-order-style=google


### PR DESCRIPTION
In my Linux distribution the default python is python3, thus
I was then having issues with the python scripts in the repo
where the shabang is `#!/usr/bin/env python`.

First idea was to change the shabang to `... python2` but I
realized that a virtual env can also help to pin the versions of
ansible and libraries eg. Jinja2 and make everyone env consistent.