### PR TITLE
www: letsencrypt config for dist.libuv.org

### DIFF
--- a/doc/non-ansible-configuration-notes.md
+++ b/doc/non-ansible-configuration-notes.md
@@ -2,6 +2,21 @@
 
 There are a number of infrastructure setup tasks that are not currently automated by Ansible, either for technical reasons or due to lack of time available by the individuals involved in these processes. This document is intended to collect that information, to serve as a task list for additional Ansible work and as a central place to note special tasks.
 
+## nodejs.org / web host
+
+For dist.libuv.org we use letsencrypt.org for HTTPS certificate. Use Certbot to register and generate a certificate on the main nodejs.org server; only the single server serves dist.libuv.org so this configuration is simple. Certbot sets up auto-renewal for the certificate in /etc/cron.d/certbot.
+
+```sh
+sudo apt-get install software-properties-common
+sudo add-apt-repository ppa:certbot/certbot
+sudo apt-get update
+sudo apt-get install python-certbot-nginx
+mkdir -p /home/libuv/www/.well-known/acme-challenge/
+certbot --manual certonly -d dist.libuv.org -m buil@iojs.org
+# take the CODE and the FILE and insert into the following command:
+echo "CODE" > /home/libuv/www/.well-known/acme-challenge/FILE
+```
+
 ## Windows (Azure/Rackspace)
 
 In order to get Windows machines to a state where Ansible can be run against them, some manual steps need to be taken so that Ansible can connect.

--- a/setup/www/resources/config/libuv.org
+++ b/setup/www/resources/config/libuv.org
@@ -3,12 +3,40 @@ server {
     listen [::]:80;
     server_name dist.libuv.org;
 
+    resolver 8.8.4.4 8.8.8.8 valid=300s;
+    resolver_timeout 10s;
+
+    access_log /var/log/nginx/libuv/libuv.org-access.log nodejs;
+    error_log /var/log/nginx/libuv/libuv.org-error.log;
+
+    location ~ ^/(?!(\.well-known)) {
+        rewrite ^ https://dist.libuv.org$request_uri permanent;
+    }
+
+    root /home/libuv/www;
+    default_type text/plain;
+    index index.html;
+    autoindex on;
+
+}
+
+server {
+    listen *:443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name dist.libuv.org;
+
+    ssl_certificate /etc/letsencrypt/live/dist.libuv.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/dist.libuv.org/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
     keepalive_timeout 60;
     server_tokens off;
 
     resolver 8.8.4.4 8.8.8.8 valid=300s;
     resolver_timeout 10s;
 
+    add_header Strict-Transport-Security max-age=63072000;
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
 


### PR DESCRIPTION
Existing `libuv.org` nginx config file isn't accurate for what's on the server at the moment, it looks like we (me probably) forgot to sync the two when we went https a while back. This update fixes that but there is a minor adjustment to what was on the server: port 80 doesn't just do an everything-redirect, there's a fall-through for `/.well-known/` because letsencrypt apparently likes to go straight for port 80 to verify (there may be a way around this but I couldn't find anything other than doing DNS validation). I don't think this is a big deal, we're serving `Strict-Transport-Security` anyway so browsers at least will always just jump to https.

For letsencrypt, I've opted to include instructions in doc form rather than ansible, it just gets too complicated, particularly since we have two servers this ansible setup gets applied to but only one needs the Certbot stuff. This is probably something to rectify when (if) we re-do the www ansible scripts.

So, https://dist.libuv.org/ is now serving a certificate generated from letsencrypt, its Comodo certificate expires next month so we'll let it go. We have another year on the nodejs.org certificate I think but since we front it with Cloudflare we need to come up with something more creative for that, or possibly just rely on Cloudflare's own issued certificates.