### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -113,7 +113,7 @@ def main():
                             parsed_host = parse_host(hostname)
                             for k, v in parsed_host.iteritems():
                                 c.update({k: v[0] if type(v) is dict else v})
-                        except Exception, e:
+                        except Exception as e:
                             raise Exception('Failed to parse host: %s' % e)
 
                         c.update({'ansible_host': metadata['ip']})


### PR DESCRIPTION
Python 3 treats old style exceptions as syntax errors.

Discovered via https://travis-ci.com/nodejs/node/builds/79706150 (https://github.com/nodejs/node/pull/21942)