### PR TITLE
ansible: make server_jobs work on FreeBSD in DigitalOcean

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -17,6 +17,11 @@
 - name: set jobs_env from server_jobs or ansible_processor_vcpus
   set_fact:
     jobs_env: "{{ server_jobs|default(ansible_processor_vcpus) }}"
+  when: server_jobs is defined or ansible_processor_vcpus is defined
+
+- name: set jobs_env from server_jobs or ansible_processor_vcpus
+  set_fact:
+    jobs_env: "2"
   when: jobs_env is undefined
 
 - name: create group


### PR DESCRIPTION
ansible_processor_vcpus is known to be busted on DigitalOcean for FreeBSD so we have to have a sensible fall-back

I haven't tested this on another type of machine yet, that probably needs to be done before merging!