### PR TITLE
ansible: retire Alpine 3.6, introduce 3.8

### DIFF
--- a/ansible/roles/docker/templates/alpine38.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine38.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
@@ -13,12 +13,11 @@ ENV OSVARIANT docker
 ENV DESTCPU x64
 ENV ARCH x64
 
-RUN echo 'https://dl-3.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories && \
-    echo 'https://dl-3.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
+RUN apk add --no-cache --upgrade apk-tools
 
-RUN apk add --no-cache \
-        libstdc++ \
-    && apk add --no-cache --virtual .build-deps \
+RUN apk add --no-cache libstdc++
+
+RUN apk add --no-cache --virtual .build-deps \
         shadow \
         binutils-gold \
         curl \
@@ -51,6 +50,7 @@ RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 USER iojs:iojs
+
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 
 CMD cd /home/iojs \


### PR DESCRIPTION
This is just a copy of the Alpine 3.7 Dockerfile, local testing suggests it's good as is for 3.8.

I'll confirm locally that it's good for our major branches before pushing into our infra. Updating our infra involves the following steps FYI:

1. Adding new nodes to ci.nodejs.org, with names like `test-digitalocean-alpine38_container-x64-1` and grabbing the secrets.
2. Editing host_vars for test-digitalocean-ubuntu1604_docker-x64-1, test-digitalocean-ubuntu1604_docker-x64-2, test-joyent-ubuntu1604_docker-x64-1, and test-softlayer-ubuntu1604_docker-x64-1 and removing the `alpine36` lines and adding new `alpine38` lines like this:  `  - { name: 'test-digitalocean-alpine38_container-x64-1', os: 'alpine38', secret: '<secret here>' }` (the `os` descriptor here fetches the right Dockerfile).
3. Running Ansible against all of those hosts to have the new images build and containers started.
4. Changing the `alpine-latest` and `alpine-last-latest` (or whatever they are) labels in Jenkins to point to 3.8 and 3.7 respectively. We only use labels in jobs so no need to go editing jobs manually.
4. Manually removing containers from each of the Docker host machines since Ansible doesn't do cleanup of old images. This is not a critical step btw, it's not the end of the world if we have dangling and non-connecting images running on these servers, it's at the cost of a JVM in memory. Something like:
  a. `systemctl stop jenkins-test-digitalocean-alpine37_container-x64-1`
  b. `systemctl disable jenkins-test-digitalocean-alpine37_container-x64-1`
  c. `rm /lib/systemd/system/jenkins-test-digitalocean-alpine37_container-x64-1.service`
  d. `systemctl daemon-reload`
  e. `systemctl reset-failed` (aren't you so happy that systemd is our overlord now? this is all perfectly intuitive)
  f. `docker rmi test-digitalocean-alpine37_container-x64-1`
  g. `docker system prune -f`

It's been a while since some of the images we have deployed were updated so it might be a good chance to flush out all images and rebuild from scratch, but that's going to have to happen one machine at a time so as not to cause disruption.