### PR TITLE
ci-change: timeout in post-build-status

### DIFF
--- a/jenkins/pipelines/post-build-status-update.jenkinsfile
+++ b/jenkins/pipelines/post-build-status-update.jenkinsfile
@@ -58,13 +58,24 @@ def sendBuildStatus(repo, identifier, status, url, commit, ref) {
         'message': message
         ])
 
-    httpRequest(
-        url: "http://github-bot.nodejs.org:3333/${repo}/jenkins/${path}",
-        httpMode: "POST",
-        timeout: 30,
-        contentType: 'APPLICATION_JSON_UTF8',
-        requestBody: buildPayload
-    )
+    println(buildPayload)
+    
+    def response
+    try {
+        response = httpRequest(
+            url: "http://github-bot.nodejs.org:3333/${repo}/jenkins/${path}",
+            httpMode: "POST",
+            timeout: 30,
+            contentType: 'APPLICATION_JSON_UTF8',
+            requestBody: buildPayload
+        )
+    } catch (Exception e) {
+        println(e.toString())
+        if (response) {
+            println("Status: "+response.status)
+            println("Content: "+response.content)
+        }
+    }
 }
 
 def validateParams(params) {

--- a/jenkins/pipelines/post-build-status-update.jenkinsfile
+++ b/jenkins/pipelines/post-build-status-update.jenkinsfile
@@ -22,7 +22,9 @@ pipeline {
         stage('Send status report') {
             steps {
                 validateParams(params)
-                sendBuildStatus(params.REPO, params.IDENTIFIER, params.STATUS, params.URL, params.COMMIT, params.REF)
+                timeout(activity: true, time: 30, unit: 'SECONDS') {
+                    sendBuildStatus(params.REPO, params.IDENTIFIER, params.STATUS, params.URL, params.COMMIT, params.REF)
+                }
             }
         }
     }
@@ -56,11 +58,13 @@ def sendBuildStatus(repo, identifier, status, url, commit, ref) {
         'message': message
         ])
 
-    def script = "curl --ipv4 -s -o /dev/null --connect-timeout 5 -X POST " +
-        "-H 'Content-Type: application/json' -d '${buildPayload}' " +
-        "http://github-bot.nodejs.org:3333/${repo}/jenkins/${path}"
-
-    sh(returnStdout: true, script: script)
+    httpRequest(
+        url: "http://github-bot.nodejs.org:3333/${repo}/jenkins/${path}",
+        httpMode: "POST",
+        timeout: 30,
+        contentType: 'APPLICATION_JSON_UTF8',
+        requestBody: buildPayload
+    )
 }
 
 def validateParams(params) {


### PR DESCRIPTION
* Add timeout to `post-build-status-update`
* Switch from shelling out `curl` to `httpRequest`

---

Jenkins got stuck on a status update [job](https://ci.nodejs.org/job/post-build-status-update/464751/) (it run for 1:27 hours), so I changed the script ad-hoc.

Please review.

