### PR TITLE
Updates for jenkins-workspace binary temporaries repository

### DIFF
--- a/ansible/roles/jenkins-workspace/files/clean_binary_tmp.sh
+++ b/ansible/roles/jenkins-workspace/files/clean_binary_tmp.sh
@@ -2,12 +2,13 @@
 
 cd ~binary_tmp/binary_tmp.git
 (echo; date) >> ~binary_tmp/clean_binary_tmp.log
+du -sh ~binary_tmp/binary_tmp.git/ >> ~binary_tmp/clean_binary_tmp.log
 
 git fetch origin +master:master
 
 for b in $(git branch | sed /\*/d); do
-  if [ -z "$(git log -1 --since='4 weeks ago' -s $b)" ]; then
-    (git branch -D $b || true) |& tee -a ~binary_tmp/clean_binary_tmp.log
+  if [ -z "$(git log -1 --since='7 days ago' -s $b)" ]; then
+    (git branch -D $b |& tee -a ~binary_tmp/clean_binary_tmp.log) || true
   fi
 done
 

--- a/ansible/roles/jenkins-workspace/files/clean_binary_tmp.sh
+++ b/ansible/roles/jenkins-workspace/files/clean_binary_tmp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+cd ~binary_tmp/binary_tmp.git
+(echo; date) >> ~binary_tmp/clean_binary_tmp.log
+
+git fetch origin +master:master
+
+for b in $(git branch | sed /\*/d); do
+  if [ -z "$(git log -1 --since='4 weeks ago' -s $b)" ]; then
+    (git branch -D $b || true) |& tee -a ~binary_tmp/clean_binary_tmp.log
+  fi
+done
+
+git prune
+
+du -sh ~binary_tmp/binary_tmp.git/ >> ~binary_tmp/clean_binary_tmp.log

--- a/ansible/roles/jenkins-workspace/handlers/main.yml
+++ b/ansible/roles/jenkins-workspace/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+
+#
+# generic handlers for jenkins-workspace stuff
+#
+
+- name: restart sshd
+  service: name="{{ sshd_service_name }}" state=restarted

--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -87,3 +87,17 @@
     line: "MaxStartups 100:30:150"
     dest: "{{ ssh_config }}"
     regexp: "MaxStartups"
+
+- name: Create clean-up script
+  copy:
+    src: "{{ role_path }}/files/clean_binary_tmp.sh"
+    dest: "~binary_tmp/clean_binary_tmp.sh"
+    owner: "binary_tmp"
+    group: "binary_tmp"
+    mode: 0755
+
+- name: Schedule clean-up script to run weekly
+  lineinfile:
+    line: "0 5	* * 0	binary_tmp	~binary_tmp/clean_binary_tmp.sh"
+    dest: "/etc/crontab"
+    regexp: "clean_binary_tmp"

--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -80,3 +80,10 @@
     owner: "binary_tmp"
     group: "binary_tmp"
     mode: 0755
+
+- name: Increase the maximum number of connections trying to authenticate
+  notify: restart sshd
+  lineinfile:
+    line: "MaxStartups 100:30:150"
+    dest: "{{ ssh_config }}"
+    regexp: "MaxStartups"

--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -96,8 +96,13 @@
     group: "binary_tmp"
     mode: 0755
 
-- name: Schedule clean-up script to run weekly
+- name: Schedule clean-up script to run daily
   lineinfile:
-    line: "0 5	* * 0	binary_tmp	~binary_tmp/clean_binary_tmp.sh"
+    line: "0 5	* * *	binary_tmp	~binary_tmp/clean_binary_tmp.sh"
     dest: "/etc/crontab"
     regexp: "clean_binary_tmp"
+
+- name: Disable automatic garbage collection
+  command: "git config gc.auto 0"
+  args:
+    chdir: "~binary_tmp/binary_tmp.git/"

--- a/ansible/roles/jenkins-workspace/vars/main.yml
+++ b/ansible/roles/jenkins-workspace/vars/main.yml
@@ -1,0 +1,13 @@
+---
+
+#
+# variables for jenkins-workspace
+#
+
+ssh_config: /etc/ssh/sshd_config
+
+sshd_service_map: {
+  'ubuntu1604': 'ssh',
+}
+
+sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"


### PR DESCRIPTION
This does two things:
- Increase MaxSartups in `sshd_config`. This is necessary when many workers running tests try to access the temp repo to download binaries simultaneously. Not sure if there is an optimal value for this. Since the previous value seemed to just barely not be enough, I increased it 10x considering it is possible that more than one job might be started at the same time.
- Weekly clean-up of the repository. This deletes branches where the last commit is more than one month old. This is not ideal, but since https://github.com/nodejs/build/issues/1496 the branches no longer have the number of the job that started them, so looking at Jenkins jobs is no longer possible. This replaces `git-clean-temp-repo`, which was broken not only because of this but also because unauthenticated access to Jenkins is disabled.
