### PR TITLE
www: letsencrypt --manual doesn't allow auto-renew, use --nginx

### DIFF
--- a/doc/non-ansible-configuration-notes.md
+++ b/doc/non-ansible-configuration-notes.md
@@ -11,10 +11,10 @@ sudo apt-get install software-properties-common
 sudo add-apt-repository ppa:certbot/certbot
 sudo apt-get update
 sudo apt-get install python-certbot-nginx
-mkdir -p /home/libuv/www/.well-known/acme-challenge/
-certbot --manual certonly -d dist.libuv.org -m build@iojs.org
-# take the CODE and the FILE and insert into the following command:
-echo "CODE" > /home/libuv/www/.well-known/acme-challenge/FILE
+certbot --nginx run -d dist.libuv.org -m build@iojs.org --agree-tos --no-redirect
+certbot --nginx run -d iojs.org -m build@iojs.org --agree-tos --no-redirect
+certbot --nginx run -d www.iojs.org -m build@iojs.org --agree-tos --no-redirect
+certbot --nginx run -d roadmap.iojs.org -m build@iojs.org --agree-tos --no-redirect
 ```
 
 ## Windows (Azure/Rackspace)


### PR DESCRIPTION
found this in my commit queue, discovered a few weeks back when the dist.libuv.org cert didn't renew. It turns out that `--manual` doesn't allow for auto-renewal with certbot, you have to use `--nginx`, which is unfortunate, but it works and is apparently safe for our config.