### PR TITLE
jenkins: remove deprecated NOP target lint-md-build

### DIFF
--- a/jenkins/pipelines/node-linter.jenkinsfile
+++ b/jenkins/pipelines/node-linter.jenkinsfile
@@ -38,13 +38,6 @@ pipeline {
             }
         }
 
-        stage('Build linting tools') {
-            steps {
-                // Calling with `returnStatus` suppresses automatic failures
-                sh(script: "${env.MAKE} lint-md-build", returnStatus: true)
-            }
-        }
-         
         stage('Run tests') {
             steps {
                 script {


### PR DESCRIPTION
I noticed this for the first time in https://ci.nodejs.org/job/node-linter/1598/console