### PR TITLE
jenkins: add node-update-ecmascript-modules script

### DIFF
--- a/jenkins/scripts/node-update-ecmascript-modules.sh
+++ b/jenkins/scripts/node-update-ecmascript-modules.sh
@@ -1,0 +1,16 @@
+# This script is run by the job:
+# https://ci.nodejs.org/view/All/job/node-update-ecmascript-modules
+# It mirrors the master branch from node/node with nodejs/ecmascript-modules and
+# then attempts to rebase the modules-lkgr branch on top of it.
+
+cd node
+git config --replace-all user.name "Node.js Jenkins CI"
+git config --replace-all user.email ci@iojs.org
+
+git reset --hard ecmascript-modules/modules-lkgr
+get rebase origin/master
+
+# Force-push to the ecmascript-modules repo as the nodejs-ci user if PUSH_TO_GITHUB set.
+if [ "$PUSH_TO_GITHUB" = true ]; then
+  ssh-agent sh -c "ssh-add $NODEJS_CI_SSH_KEY && git push ecmascript-modules origin/master:master && git push --force ecmascript-modules HEAD:modules-lkgr"
+fi

--- a/jenkins/scripts/node-update-ecmascript-modules.sh
+++ b/jenkins/scripts/node-update-ecmascript-modules.sh
@@ -1,7 +1,7 @@
 # This script is run by the job:
 # https://ci.nodejs.org/view/All/job/node-update-ecmascript-modules
-# It mirrors the master branch from node/node with nodejs/ecmascript-modules and
-# then attempts to rebase the modules-lkgr branch on top of it.
+# It mirrors the master branch from nodejs/node with nodejs/ecmascript-modules
+# and then attempts to rebase the modules-lkgr branch on top of it.
 
 cd node
 git config --replace-all user.name "Node.js Jenkins CI"


### PR DESCRIPTION
As discussed in yesterday's modules team meeting, I'm proposing here a script that will be used by a daily CI job to automatically update the [`ecmascript-modules`](https://github.com/nodejs/ecmascript-modules) fork of `nodejs/node`.

@nodejs/jenkins-admins can I please have access to a new job named `node-update-ecmascript-modules` based on https://ci.nodejs.org/view/MyJobs/job/node-update-v8-canary ? I think I know how to modify it to make this work.

/cc @MylesBorins @devsnek @guybedford