### PR TITLE
Create VersionSelectorScript.md

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.md
+++ b/jenkins/scripts/VersionSelectorScript.md
@@ -1,0 +1,97 @@
+### The current file list the compiler versions used to build each node version on each platform:
+
+#### Linux
+
+node 6,7 => built on **centos5**
+
+node 8,9,10,11 => built on **centos6**
+
+node 6,7,8,9 => built on **centos[67]-(arm)?(64|32)-gcc48**
+
+node 10,11 => built on **centos[67]-(arm)?(64|32)-gcc6**
+
+node 6,7,8,9 => built on **centos6-32-gcc6**
+
+node 6,7,8,9 => built on **debian8-x86**
+
+node 10,11 => built on **ubuntu1804**
+
+node 6,7,8,9 => built on **ubuntu1204**
+
+node 6,7,8,9 => built on **ubuntu1404-32**
+
+node 6,7,8,9 => built on **ubuntu1604-32**
+
+#### ARM
+
+node 6,7,8,9 => built on **debian7-docker-armv7**
+
+node 10,11 => built on **debian8-docker-armv7**
+
+node 10,11 => built on **debian9-docker-armv7**
+
+node 6,7,8,9 => built on **pi1-docker**
+
+node 6,7,8,9 => built on **cross-compiler-armv[67]-gcc-4.8**
+
+node 6,7,8,9 => built on **cross-compiler-armv[67]-gcc-4.8**
+
+node 10,11 => built on **cross-compiler-armv[67]-gcc-4.9**
+
+node 10,11 => built on **cross-compiler-armv[67]-gcc-4.9**
+
+#### Windows
+
+node 1,2,3,4,5 => built on **vs2013**
+
+node 6,7,8,9 => built on **vs2015**
+
+node 11 => built on **vs2017**
+
+#### SmartOS
+
+node 1,2,3,4,5,6,7 => built on **smartos14**
+
+node 8,9 => built on **smartos15**
+
+node 9,10,11 => built on **smartos16**
+
+node 11 => built on **smartos17**
+
+#### PPC BE
+
+node 1,2,3,4,5,6,7 => built on **ppcbe-ubuntu**
+
+#### s390x
+
+node 6,7,8,9,10,11 => built on **s390x**
+
+#### AIX61
+
+node 6,7,8,9,10,11 => built on **AIX61**
+
+#### Sharid Libs docker containers
+
+node 9,10,11 => built on **sharedlibs_openssl111**
+
+node 9,10,11 => built on **sharedlibs_openssl110**
+
+node 1,2,3,4,5,6,7,8,9 => built on **sharedlibs_openssl102**
+
+node 1,2,3,4,5,6,7,8,9 => built on **sharedlibs_fips20**
+
+node 9,10,11 => built on **sharedlibs_withoutintl**
+
+node 10,11 => built on **sharedlibs_withoutssl**
+
+node 9,10,11 => built on **sharedlibs_shared**
+
+#### OSX
+
+node 6,7,8,9,10 => built on **osx1010**   // the following variable is also set 'MACOSX_DEPLOYMENT_TARGET': '10.7'
+
+node 11 => built on **osx1011**           // the following variable is also set 'MACOSX_DEPLOYMENT_TARGET': '10.7'
+
+#### FreeBSD
+
+node 6,7,8,9,10 => built on **freebsd10**


### PR DESCRIPTION
First version of the documentation showing the list of compiler versions used to build each node version on each platform