### PR TITLE
docker: upgrade the versions of openssl we're using for sharedlibs

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -31,35 +31,35 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
-ENV OPENSSL102DIR /opt/openssl-1.0.2n
+ENV OPENSSL102DIR /opt/openssl-1.0.2q
 
-RUN mkdir -p /tmp/openssl_1.0.2n && \
-    cd /tmp/openssl_1.0.2n && \
-    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_0_2n.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.0.2q && \
+    cd /tmp/openssl_1.0.2q && \
+    curl -sL https://www.openssl.org/source/openssl-1.0.2q.tar.gz | tar zxv --strip=1 && \
     ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.0.2n
+    rm -rf /tmp/openssl_1.0.2q
 
-ENV OPENSSL110DIR /opt/openssl-1.1.0g
+ENV OPENSSL110DIR /opt/openssl-1.1.0j
 
-RUN mkdir -p /tmp/openssl_1.1.0g && \
-    cd /tmp/openssl_1.1.0g && \
-    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_1_0g.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.0j && \
+    cd /tmp/openssl_1.1.0j && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.0j.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL110DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.0g
+    rm -rf /tmp/openssl_1.1.0j
 
-ENV OPENSSL111DIR /opt/openssl-1.1.1-pre1
+ENV OPENSSL111DIR /opt/openssl-1.1.1a
 
-RUN mkdir -p /tmp/openssl_1.1.1-pre1 && \
-    cd /tmp/openssl_1.1.1-pre1 && \
-    curl -sL https://github.com/openssl/openssl/archive/OpenSSL_1_1_1-pre1.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.1a && \
+    cd /tmp/openssl_1.1.1a && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.1a.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.1-pre1
+    rm -rf /tmp/openssl_1.1.1a
 
 ENV FIPS20DIR /opt/openssl-fips_2.0.16
 


### PR DESCRIPTION
I reprovisioned the softlayer docker host and used this as the config, will do the rest shortly