### PR TITLE
jenkins: add an llhttp builder to the mix for 11+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -62,6 +62,7 @@ def buildExclusions = [
   [ /sharedlibs_fips20/,              anyType,     gte(10) ],
   [ /sharedlibs_withoutintl/,         anyType,     lt(9)   ],
   [ /sharedlibs_withoutssl/,          anyType,     lt(10)  ],
+  [ /sharedlibs_llhttp/,              anyType,     lt(11)  ],
   [ /sharedlibs_shared/,              anyType,     lt(9)   ],
 
   // OSX ---------------------------------------------------


### PR DESCRIPTION
I've added this tag already, just not build config, need this first