### PR TITLE
jenkins: remove ubuntu 14.04 from Node 12+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -21,6 +21,7 @@ def buildExclusions = [
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],
   [ /^ubuntu1404-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
+  [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
 
   // ARM  --------------------------------------------------


### PR DESCRIPTION
14.04 ends its standard support lifetime in April 2019.

However, they have announced that they're doing an extended-LTS (paid) for 14.04 like they did for 12.04. Word is that extended-LTS turned out to be quite profitable for them so it's no surprise.

<img width="855" alt="screenshot 2018-11-30 14 29 54" src="https://user-images.githubusercontent.com/495647/49266986-6a504d80-f4ac-11e8-914f-47f41ab21867.png">

No EOL date for that yet afaik but I think we can assume it'll be another 3 years.

So an argument could be made that we should continue to test our builds on 14.04 until then. However, without support from Canonical (I've tried, to no avail), we won't get access to the extended LTS repos and we persist the support burden on the Build team. The latter concerns me the most so I'm in favour of a slightly more aggressive pruning policy than we've adopted in the past.