### PR TITLE
docker: use --init for all docker images

### DIFF
--- a/ansible/roles/docker/templates/jenkins.service.j2
+++ b/ansible/roles/docker/templates/jenkins.service.j2
@@ -9,7 +9,7 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/docker run --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} -v /home/{{ server_user }}/.ccache/:/home/{{ server_user }}/.ccache --name node-ci-{{ item.name }} node-ci:{{ item.name }}
+ExecStart=/usr/bin/docker run --init --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} -v /home/{{ server_user }}/.ccache/:/home/{{ server_user }}/.ccache --name node-ci-{{ item.name }} node-ci:{{ item.name }}
 ExecStop=/usr/bin/docker stop -t 5 node-ci-{{ item.name }}
 Restart=always
 RestartSec=30


### PR DESCRIPTION
ARM Docker use already has this, this expands it to the rest of our
Docker usage. It helps with reping defunct processes when running bare
commands (i.e. jenkins).

Ref: https://github.com/nodejs/node/issues/22308