### PR TITLE
Fix VersionSelectorScript.groovy on non-release CI

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -34,10 +34,10 @@ def buildExclusions = [
   [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
 
   // Windows -----------------------------------------------
-  [ /^vs2013-/,                       anyType,     gte(6)  ],
-  [ /^vs2015-/,                       anyType,     lt(6)   ],
-  [ /^vs2015-/,                       anyType,     gte(10) ],
-  [ /^vs2017-/,                       anyType,     lt(10)  ],
+  [ /vs2013/,                       anyType,     gte(6)  ],
+  [ /vs2015/,                       anyType,     lt(6)   ],
+  [ /vs2015/,                       anyType,     gte(10) ],
+  [ /vs2017/,                       anyType,     lt(10)  ],
 
   // SmartOS -----------------------------------------------
   [ /^smartos14/,                     anyType,     gte(8)  ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -34,10 +34,10 @@ def buildExclusions = [
   [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
 
   // Windows -----------------------------------------------
-  [ /vs2013/,                       anyType,     gte(6)  ],
-  [ /vs2015/,                       anyType,     lt(6)   ],
-  [ /vs2015/,                       anyType,     gte(10) ],
-  [ /vs2017/,                       anyType,     lt(10)  ],
+  [ /vs2013/,                         anyType,     gte(6)  ],
+  [ /vs2015/,                         anyType,     lt(6)   ],
+  [ /vs2015/,                         anyType,     gte(10) ],
+  [ /vs2017/,                         anyType,     lt(10)  ],
 
   // SmartOS -----------------------------------------------
   [ /^smartos14/,                     anyType,     gte(8)  ],


### PR DESCRIPTION
Windows labels on https://ci.nodejs.org/ are of the form `*-vs201?`, 

e.g. `win10-vs2017`.
![image](https://user-images.githubusercontent.com/5445507/49750866-e401eb80-fca3-11e8-9349-828534c7b4e1.png)