### PR TITLE
Old style exception --> new style for Python 3

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -113,7 +113,7 @@ def main():
                             parsed_host = parse_host(hostname)
                             for k, v in parsed_host.items():
                                 c.update({k: v[0] if type(v) is dict else v})
-                        except Exception, e:
+                        except Exception as e:
                             raise Exception('Failed to parse host: %s' % e)
 
                         c.update({'ansible_host': metadata['ip']})


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.  @rvagg Your review please?