### PR TITLE
ansible: new smartos15 release host

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,7 +36,7 @@ hosts:
 
     - joyent:
         smartos14-x64-1: {ip: 72.2.113.193}
-        smartos15-x64-1: {ip: 165.225.131.14}
+        smartos15-x64-1: {ip: 165.225.170.142}
         smartos17-x64-1: {ip: 72.2.114.225}
         ubuntu1604_arm_cross-x64-1: {ip: 72.2.114.100, user: ubuntu}
 


### PR DESCRIPTION
Lost access to existing smartos15 host, something's up with ssh keys, maybe related to their custom ssh SDC setup 🤷‍♂️. New host provisioned and seems to be working fine. I'll delete the old one when I can confirm Node 6 * 8 build OK (in progress).

A couple of problems encountered:

1. I can't use Python 3 with this, roles/baselayout/tasks/ccache.yml does some jinja2 stuff that doesn't work:

```
- name: "ccache : extract ccache latest version"
  set_fact:
    ccache_latest: "{{ ccache_html_content.stdout | regex_findall('ccache-[0-9]+.[0-9]+(?:.[0-9]+)*.tar.gz') | map('regex_replace', 'ccache-') | map('regex_replace', '.tar.gz') | list | latest_version }}"
```

yields:

```
 fatal: [release-joyent-smartos15-x64-1]: FAILED! => {"msg": "Unexpected templating type error occurred on ({{ ccache_html_content.stdout | regex_findall('ccache-[0-9]+.[0-9]+(?:.[0-9]+)*.tar.gz') | map('regex_replace', 'ccache-') | map('regex_replace', '.tar.gz') | list | latest_version }}): '<' not supported between instances of 'map' and 'map'"}
```

I can't fix this, so I just ran it on Linux where I have Python 2 for Ansible and it's fine.

2. The ccache-3.6 source doesn't quite compile right on SmartOS, it may be an autoconf problem, but I ended up manually doing some config.status mangling, compiling and installing.

Aside from that this worked OK. The Python 3 thing needs to be fixed but it's beyond me (I tried! but only ended up a tiny bit more cranky at Python).