### PR TITLE
WIP ansible: add role to install ci-health-dashboard on github-bot server

### DIFF
--- a/ansible/playbooks/create-github-bot.yml
+++ b/ansible/playbooks/create-github-bot.yml
@@ -13,6 +13,7 @@
     - bootstrap
     - package-upgrade
     - github-bot
+    - ci-health-dashboard
   pre_tasks:
     - name: check if secrets are properly set
       fail:

--- a/ansible/roles/ci-health-dashboard/tasks/main.yml
+++ b/ansible/roles/ci-health-dashboard/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Bootstrap | Install packages
+  package:
+    name: "{{ package }}"
+    state: present
+  loop_control:
+    loop_var: package
+  with_items: "{{ packages }}"
+
+- name: Init | Generate and copy init script
+  template:
+    src: "{{ role_path }}/templates/ci-health-dashboard.service.j2"
+    dest: /lib/systemd/system/ci-health-dashboard.service
+
+- name: Init | Generate and copy systemd EnvironmentFile
+  template:
+    src: "{{ role_path }}/templates/environment-file.j2"
+    dest: "/home/{{ server_user }}/environment/ci-health-dashboard"
+
+- name: Init | Clone ci-health-dashboard repo
+  become: yes
+  become_user: "{{ server_user }}"
+  git:
+    repo: https://github.com/nodejs/ci-health-dashboard.git
+    dest: "/home/{{ server_user }}/ci-health-dashboard"
+
+- name: Init | Build image
+  command: docker build -t {{ ci_health_dashboard_image }} /home/{{ server_user }}/ci-health-dashboard/
+
+- name: Init | Start ci-health-dashboard
+  service:
+    name: ci-health-dashboard
+    state: started
+    enabled: yes

--- a/ansible/roles/ci-health-dashboard/templates/ci-health-dashboard.service.j2
+++ b/ansible/roles/ci-health-dashboard/templates/ci-health-dashboard.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=ci-health-dashboard
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ExecStart=/usr/bin/docker run -d --rm --name {{ ci_health_dashboard_container }} --port {{ ci_health_dashboard_port }}:3000 {{ ci_health_dashboard_image }}
+ExecStop=/usr/bin/docker stop {{ ci_health_dashboard_container }}
+EnvironmentFile=/home/{{ server_user }}/environment/ci-health-dashboard
+WorkingDirectory=/home/{{ server_user }}/ci-health-dashboard
+Restart=always
+RestartSec=10
+User=root

--- a/ansible/roles/ci-health-dashboard/templates/environment-file.j2
+++ b/ansible/roles/ci-health-dashboard/templates/environment-file.j2
@@ -1,0 +1,1 @@
+JENKINS_API_CREDENTIALS={{ envs.jenkins_api_credentials }}

--- a/ansible/roles/ci-health-dashboard/vars/main.yml
+++ b/ansible/roles/ci-health-dashboard/vars/main.yml
@@ -1,0 +1,9 @@
+---
+ci_health_dashboard_image: "ci-health-dashboard:latest"
+ci_health_dashboard_container: "ci-health-dashboard"
+ci_health_dashboard_port: 80
+
+packages:
+  - docker-ce
+  - git
+


### PR DESCRIPTION
I haven't tested it yet, but this should work.

I still have to update https://github.com/mmarchini/nodejs-ci-health-dashboard to accept credentials in the format provided by `envs.jenkins_api_credentials`.

Also, we should probably use nginx as a proxy instead of exposing the port directly. There's a nginx role already, but I think it is specific to the website. Should I try to reuse the existing `nginx` role, or is it ok to install nginx as a dependency in this new `ci-health-dashboard` role?

cc @maclover7 @rvagg 