### PR TITLE
jenkins: add patch to work around 24966

### DIFF
--- a/jenkins/scripts/coverage/24966-work-around.diff
+++ b/jenkins/scripts/coverage/24966-work-around.diff
@@ -1,0 +1,23 @@
+diff --git a/tools/gyp/pylib/gyp/generator/make.py b/tools/gyp/pylib/gyp/generator/make.py
+index e98d93a..bf08a5c 100644
+--- a/tools/gyp/pylib/gyp/generator/make.py
++++ b/tools/gyp/pylib/gyp/generator/make.py
+@@ -1758,8 +1758,15 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
+       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
+       self.WriteLn('\t%s' % '@:')
+       self.WriteLn('%s: %s' % ('.INTERMEDIATE', intermediate))
+-      self.WriteLn('%s: %s%s' %
+-                   (intermediate, ' '.join(inputs), force_append))
++      # Don't add `force_append` (FORCE_DO_CMD) to the intermediate sentinal.
++      # Adding it makes the action run alway, even when there are no changes.
++      # Excluding macOS which has a different way of resolving dependancies
++      # which can lead to deadlocks.
++      # (refack): AFAICT because `*.intermediate` files don't have build rules.
++      if self.flavor == 'mac':
++        self.WriteLn('%s: %s%s' % (intermediate, ' '.join(inputs), force_append))
++      else:
++        self.WriteLn('%s: %s' % (intermediate, ' '.join(inputs)))
+       actions.insert(0, '$(call do_cmd,touch)')
+
+     if actions:
+~                 


### PR DESCRIPTION
Patch required to work around problem affecting
coverage builds.  24966 is not related to coverage
but a more general issue that manifests in the
coverage builds.

We need this in CI to be able to run coverage on more than one machine which we are trying to do as part of adding a coverage check to the main PR regression job.