### PR TITLE
build: add python3-pip to ubuntu.Dockerfiles

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -21,9 +21,12 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     openjdk-8-jre-headless \
     curl \
     python-pip \
+    python3-pip \
     libfontconfig1
 
 RUN pip install tap2junit
+
+RUN pip3 install tap2junit
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_sharedlibs.Dockerfile.j2
@@ -23,9 +23,12 @@ RUN apt-get update && apt-get install apt-utils -y && \
       openjdk-8-jre-headless \
       curl \
       python-pip \
+      python3-pip \
       libfontconfig1
 
 RUN pip install tap2junit
+
+RUN pip3 install tap2junit
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -21,9 +21,12 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     openjdk-8-jre-headless \
     curl \
     python-pip \
+    python3-pip \
     libfontconfig1
 
 RUN pip install tap2junit
+
+RUN pip3 install tap2junit
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 


### PR DESCRIPTION
https://pypi.org/project/tap2junit says that __tap2junit__ is compatible with legacy Python but says nothing about Python 3 compatibility.  Related to #1674