### PR TITLE
doc: update the security embargo banner style

### DIFF
--- a/doc/jenkins-guide.md
+++ b/doc/jenkins-guide.md
@@ -59,14 +59,14 @@ Add a Jenkins "system message" in https://ci.nodejs.org/configure. Something lik
 ```
 And some fancy "extra-css" to the Theme at https://ci.nodejs.org/configure#section122:
 ```css
-#header {
+#header, .task-icon-link[href="/"] {
   background-color: red;
 }
 a#jenkins-home-link:after {
-    content: "Under security embargo!";
-    font-size: larger;
-    color: yellow;
-    margin-left: 200px;
+  content: "Under security embargo!";
+  font-size: larger;
+  color: yellow;
+  margin-left: 250px;
 }
 ```
 


### PR DESCRIPTION
So that it also displays nicely in the job page.

Before:

<img width="575" alt="screen shot 2019-02-22 at 10 34 52 pm" src="https://user-images.githubusercontent.com/4299420/53249153-68d0a300-36f2-11e9-8c9e-e31102c01757.png">

After:
<img width="602" alt="screen shot 2019-02-22 at 10 36 30 pm" src="https://user-images.githubusercontent.com/4299420/53249157-69693980-36f2-11e9-9457-1bb33443d7b4.png">
