### PR TITLE
www: check_assets.js should allow for blank lines in expected assets list

### DIFF
--- a/setup/www/tools/promote/check_assets.js
+++ b/setup/www/tools/promote/check_assets.js
@@ -107,7 +107,7 @@ async function loadExpectedAssets (version, line) {
   try {
     const templateFile = path.join(__dirname, 'expected_assets', line)
     let files = await fs.readFile(templateFile, 'utf8')
-    return files.replace(/{VERSION}/g, version).split(/\n/g)
+    return files.replace(/{VERSION}/g, version).split(/\n/g).filter(Boolean)
   } catch (e) { }
   return null
 }


### PR DESCRIPTION
Manually edited #1673 into the file in question with vim and it made a newline at the end and check_assets.js borked on it. I made it originally with an editor that didn't append that last line so this wasn't a problem.