### PR TITLE
AIX & RPi fixes

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/raspberry-pi.yml
+++ b/ansible/roles/bootstrap/tasks/partials/raspberry-pi.yml
@@ -133,3 +133,27 @@
         mode: 0755
       when: pi_type in ("pi1p", "pi2")
       tags: general
+
+      # We need to do this here because the apt upgrade may upgrade what's in /boot and
+      # we'll end up out of sync and some services won't start properly on reboot
+
+    - name: pi | enable rpcbind service
+      service: name=rpcbind state=started enabled=yes
+      tags: init
+
+      # re-test this because we don't care about sd card at this stage
+    - name: pi | test if nfs-root
+      shell: |
+        test -n "$(grep ' / ' /proc/mounts | grep -E '^[0-9\.]+:/')"
+      register: nfs_root_check_result
+      ignore_errors: true
+
+    - name: pi | mount /boot/ via nfs
+      mount:
+        name: "/boot"
+        src: "{{ raspberry_pi.nfs_boot_server }}:{{ raspberry_pi.nfs_boot_share_root }}/{{ inventory_hostname }}"
+        fstype: nfs4
+        opts: nfsvers=3,rw,noexec,async,noauto
+        state: mounted
+      when: nfs_root_check_result.rc == 0
+      tags: nfs

--- a/ansible/roles/bootstrap/vars/main.yml
+++ b/ansible/roles/bootstrap/vars/main.yml
@@ -1,5 +1,7 @@
 raspberry_pi: {
   apt_proxy: 'http://192.168.2.100:3142',
+  nfs_boot_server: '192.168.2.100',
+  nfs_boot_share_root: '/var/tftpd',
 }
 
 autologon_regpath: 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -76,7 +76,7 @@
     url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12/OpenJDK8U-jre_ppc64_aix_hotspot_8u192b12.tar.gz
     dest: /tmp/
   tags: java
-  when: java_exists.stat.exists == False and os|startswith("aix")
+  when: os|startswith("aix") and java_exists.stat.exists == False
 
 - name: unarchive java AIX
   unarchive:
@@ -84,7 +84,7 @@
     remote_src: yes
     dest: /home/iojs
   tags: java
-  when: java_exists.stat.exists == False and os|startswith("aix")
+  when: os|startswith("aix") and java_exists.stat.exists == False
 
 - name: install webupd8 oracle java 8 extras
   when: java.rc > 0 and os in ("ubuntu1204", "ubuntu1404") and arch != "ppc64"

--- a/ansible/roles/jenkins-worker/tasks/partials/docker-host.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/docker-host.yml
@@ -10,7 +10,6 @@
 
 - name: docker | fetch samba ccache HTML page
   local_action: shell curl -sL https://www.samba.org/ftp/ccache/
-  warn: False
   register: ccache_html_content
 
 - name: docker | extract ccache latest version

--- a/ansible/roles/jenkins-worker/tasks/partials/raspberry-pi.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/raspberry-pi.yml
@@ -2,26 +2,6 @@
 
 # For Raspberry Pis of any type, assumed to be running Debian 9
 
-- name: pi | enable rpcbind service
-  service: name=rpcbind state=started enabled=yes
-  tags: init
-
-- name: pi | test if nfs-root
-  shell: |
-    test -n "$(grep ' / ' /proc/mounts | grep -E '^[0-9\.]+:/')"
-  register: nfs_root_check_result
-  ignore_errors: true
-
-- name: pi | mount /boot/ via nfs
-  mount:
-    name: "/boot"
-    src: "{{ raspberry_pi.nfs_boot_server }}:{{ raspberry_pi.nfs_boot_share_root }}/{{ inventory_hostname }}"
-    fstype: nfs4
-    opts: nfsvers=3,rw,noexec,async,noauto
-    state: mounted
-  when: nfs_root_check_result.rc == 0
-  tags: nfs
-
 - name: pi | make .ccache
   file:
     path: "/home/{{ server_user }}/.ccache"

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -111,9 +111,7 @@ bash_path: {
 
 raspberry_pi: {
   nfs_root_server: '192.168.1.10',
-  nfs_boot_server: '192.168.2.100',
   nfs_root_share_root: '/exports/nodejs/pi',
-  nfs_boot_share_root: '/var/tftpd',
   containers: {
     armv6l: [
       { name: 'wheezy', template: 'rpi_wheezy.Dockerfile.j2' },


### PR DESCRIPTION
two things in one while trying to get RPi reprovisions done:

1. there's new code from earlier this month in 85c9a8635cbf35569f7e6a222608313ef8527f1c that does an AIX-specific check for Java _only_ if running AIX, then later it checks the contents of that check to determine if it should install Java, also checking if running AIX but it does it in that order. So if you're not running AIX, it won't run the new check for Java but it will require the results of that check. Switched ordering of conditional to fix.
2. Brought nfs mounting of /boot/ of the RPis much earlier in the setup process so it's before the initial `apt-get upgrade`. Assets from an upgrade impacting /boot/ can leave the system out of sync, e.g. booting on an older kernel and not having the /lib/modules/x.x.x for it anymore. /boot/ is mounted on the tftp server it uses so these are assets that get pushed down for nfs-boot.