### PR TITLE
jenkins: openssl1.1.0 not supported on node.js 12+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -57,7 +57,7 @@ def buildExclusions = [
   [ /aix61/,                          anyType,     lt(6)   ],
 
   // Shared libs docker containers -------------------------
-  [ /sharedlibs_openssl111/,          anyType,     lt(9)   ],
+  [ /sharedlibs_openssl111/,          anyType,     lt(10)  ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     gte(12) ],
   [ /sharedlibs_openssl102/,          anyType,     gte(10) ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -59,6 +59,7 @@ def buildExclusions = [
   // Shared libs docker containers -------------------------
   [ /sharedlibs_openssl111/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
+  [ /sharedlibs_openssl110/,          anyType,     gte(12) ],
   [ /sharedlibs_openssl102/,          anyType,     gte(10) ],
   [ /sharedlibs_fips20/,              anyType,     gte(10) ],
   [ /sharedlibs_withoutintl/,         anyType,     lt(9)   ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -57,7 +57,7 @@ def buildExclusions = [
   [ /aix61/,                          anyType,     lt(6)   ],
 
   // Shared libs docker containers -------------------------
-  [ /sharedlibs_openssl111/,          anyType,     lt(10)  ],
+  [ /sharedlibs_openssl111/,          anyType,     lt(11)  ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     gte(12) ],
   [ /sharedlibs_openssl102/,          anyType,     gte(10) ],


### PR DESCRIPTION
See: https://github.com/nodejs/node/pull/26209#issuecomment-469777736