### PR TITLE
Put a list between the two maps for Python 3

### DIFF
--- a/ansible/roles/baselayout/tasks/ccache.yml
+++ b/ansible/roles/baselayout/tasks/ccache.yml
@@ -10,7 +10,7 @@
 
 - name: "ccache : extract ccache latest version"
   set_fact:
-    ccache_latest: "{{ ccache_html_content.stdout | regex_findall('ccache-[0-9]+.[0-9]+(?:.[0-9]+)*.tar.gz') | map('regex_replace', 'ccache-') | map('regex_replace', '.tar.gz') | list | latest_version }}"
+    ccache_latest: "{{ ccache_html_content.stdout | regex_findall('ccache-[0-9]+.[0-9]+(?:.[0-9]+)*.tar.gz') | map('regex_replace', 'ccache-') | list | map('regex_replace', '.tar.gz') | list | latest_version }}"
 
 - name: "ccache : download and extract"
   unarchive:


### PR DESCRIPTION
As discussed at https://github.com/nodejs/build/pull/1399#issuecomment-473137730 and https://github.com/nodejs/build/issues/1674#issuecomment-472631285

> You could try putting | list | in between the two calls to map(). Python 3 often creates generators instead of lists so perhaps forcing the results of the first map() call into a list will placate Jinja2.