### PR TITLE
github-bot: update Node.js from 6 -> 10

### DIFF
--- a/ansible/roles/github-bot/tasks/main.yml
+++ b/ansible/roles/github-bot/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Bootstrap | Add nodesource repo
   apt_repository:
-    repo: deb https://deb.nodesource.com/node_6.x jessie main
+    repo: deb https://deb.nodesource.com/node_10.x jessie main
     state: present
 
 - name: Bootstrap | APT Update and upgrade


### PR DESCRIPTION
It's been a while since we setup the github-bot initially and a few Node.js major releases has been cut since then..

Thought we better settle on current LTS for now.

/cc @nodejs/github-bot