### PR TITLE
pipelines: add lint-py to linter pipeline

### DIFF
--- a/jenkins/pipelines/node-linter.jenkinsfile
+++ b/jenkins/pipelines/node-linter.jenkinsfile
@@ -6,15 +6,12 @@ pipeline {
         string(name: 'GITHUB_ORG', defaultValue: 'nodejs', description: 'The user/org of the GitHub repo')
         string(name: 'REPO_NAME', defaultValue: 'node', description: 'The name of the repo')
         string(name: 'GIT_REMOTE_REF', defaultValue: 'refs/heads/master', description: 'The remote portion of the Git refspec to fetch and test')
-        string(name: 'REBASE_ONTO', defaultValue: '', description: 'Optionally, rebase onto the given ref before testing. Leave blank to skip rebasing.')
-        string(name: 'POST_REBASE_SHA1_CHECK', defaultValue: '', description: 'After rebasing, check that the resulting commit sha1 matches the given one. If left blank, no check is performed.')
-        string(name: 'CONFIG_FLAGS', defaultValue: '', description: 'Add arguments to ./configure.')
     }
 
     stages {
         stage("Setup repository") {
             steps {
-                checkout(poll: false, scm: [
+                checkout(changelog: false, poll: false, scm: [
                     $class: 'GitSCM',
                     branches: [[
                         name: 'refs/heads/_jenkins_local_branch'
@@ -22,7 +19,6 @@ pipeline {
                     userRemoteConfigs: [[
                         credentialsId: "96d5f81c-e9ad-45f7-ba5d-bc8107c0ae2c",
                         url: "git@github.com:${params.GITHUB_ORG}/${params.REPO_NAME}",
-                        refspec: "+refs/heads/*:refs/remotes/origin/* +${params.GIT_REMOTE_REF}:refs/remotes/origin/_jenkins_local_branch"
                     ]]
                 ])
             }
@@ -38,19 +34,30 @@ pipeline {
             }
         }
 
+
         stage('Build linting tools') {
             steps {
                 // Calling with `returnStatus` suppresses automatic failures
                 sh(script: "${env.MAKE} lint-md-build", returnStatus: true)
+                sh(script: "${env.MAKE} lint-py-build", returnStatus: true)
             }
         }
          
         stage('Run tests') {
             steps {
                 script {
+                    def node_version = sh(script: "python  tools/getnodeversion.py", returnStdout: true).trim()
+                    echo node_version
+                    def node_version_parts = node_version.tokenize('.')
+                    def node_major = node_version_parts[0] as int
+                    def lint_py3_ret = 0
+                    if (node_major > 11) {
+                    // this job does not build node, so we use the system's node 
+                      lint_py3_ret = sh(script: "NODE=node PYTHON=python3 ${env.MAKE} lint-py", returnStatus: true)
+                    }
                     // this job does not build node, so we use the system's node 
                     def ret = sh(script: "NODE=node ${env.MAKE} lint-ci", returnStatus: true)
-                    if (ret != 0) {
+                    if (ret != 0 || lint_py3_ret != 0) {
                         echo(extractErrors())
                         error('lint failed - open above section for details')
                     }

--- a/jenkins/pipelines/node-test-pull-request-lite-pipeline.jenkinsfile
+++ b/jenkins/pipelines/node-test-pull-request-lite-pipeline.jenkinsfile
@@ -4,53 +4,53 @@ pipeline {
     agent { label 'jenkins-workspace' }
     parameters {
         booleanParam(name: 'CERTIFY_SAFE', defaultValue: false, description: 'I have reviewed *the latest version of* these changes and I am sure that they don’t contain any code that could compromise the security of the CI infrastructure.')
-        string(name: 'GITHUB_ORG', defaultValue: 'nodejs', description: 'The user/org of the GitHub repo')
-        string(name: 'REPO_NAME', defaultValue: 'node', description: 'The name of the repo')
         string(name: 'PR_ID', defaultValue: '', description: 'PR ID')
-        string(name: 'REBASE_ONTO', defaultValue: '', description: 'Optionally, rebase onto the given ref before testing. Leave blank to skip rebasing.')
-        string(name: 'CONFIG_FLAGS', defaultValue: '', description: 'Add arguments to ./configure.')
     }
     stages {
         stage("Setup repository") {
             steps {
-                checkout(poll: false, scm: [
-                    $class: 'GitSCM',
-                    branches: [[
-                        name: 'refs/heads/_jenkins_local_branch'
-                    ]],
-                    userRemoteConfigs: [[
-                        credentialsId: "96d5f81c-e9ad-45f7-ba5d-bc8107c0ae2c",
-                        url: "git@github.com:${params.GITHUB_ORG}/${params.REPO_NAME}.git",
-                        refspec: "+refs/heads/*:refs/remotes/origin/* +${getBranchName(params)}:refs/remotes/origin/_jenkins_local_branch"
-                    ]]
-                ])
+                checkout(
+                    changelog: false,
+                    poll: false,
+                    scm: [
+                        $class: 'GitSCM',
+                        branches: [[
+                            name: 'refs/heads/_jenkins_local_branch'
+                        ]],
+                        userRemoteConfigs: [[
+                            credentialsId: "96d5f81c-e9ad-45f7-ba5d-bc8107c0ae2c",
+                            url: "git@github.com:nodejs/node.git"
+                        ]]
+                    ]
+                )
             }
         }
 
         stage('Preflight') {
             steps {
-                checkCertify(params)
-                setupGit(env, params)
-                setupSubParams(env, params)
+                script {
+                    if (!params.CERTIFY_SAFE) {
+                        error "Please certify that you have reviewed the changes to be tested, by ticking the CERTIFY_SAFE checkbox on the job launch page."
+                    }
+                    setupEnv(env, params)
+                }
             }
         }
 
         stage('Run tests') {
-            parallel {
-                stage('Run linuxone') {
-                    steps {
-                        build(job: "node-test-commit-linuxone",
-                            parameters: setupSubParams(env, params),
-                            propagate: true)
-                    }
-                }
-
-                stage('Run linter') {
-                    steps {
-                        build(job: "node-linter",
-                            parameters: setupSubParams(env, params),
-                            propagate: true)
-                    }
+            steps {
+                script {
+                    def buildParams = setupSubParams(env, params)
+                    def testResult
+                    parallel(
+                        regressionTests: {
+                            testResult = build job: "node-test-commit-linuxone", parameters: buildParams, propagate: false
+                        },
+                        linter: {
+                            build job: "node-linter", parameters: buildParams, propagate: true
+                        }
+                    )
+                    currentBuild.result = testResult.result
                 }
             }
         }
@@ -65,49 +65,22 @@ def getBranchName(params) {
     }
 }
 
-def checkCertify(params) {
-    if (!params.CERTIFY_SAFE) {
-        echo "Please certify that you have reviewed the changes to be tested, by ticking the CERTIFY_SAFE checkbox on the job launch page."
-        currentBuild.result = 'FAILURE'
-        sh "exit 1"
-    }
-}
-
-def setupGit(env, params) {
-    sh '''
-    git config --replace-all user.name Dummy
-    git config --replace-all user.email dummy@dummy.com
-    git config user.name
-    git config user.email
-    echo $GIT_COMMITTER_NAME
-    echo $GIT_AUTHOR_NAME
-
-    git rebase --abort || true
-    git checkout -f refs/remotes/origin/_jenkins_local_branch
-
-    git status
-    git rev-parse HEAD
-    '''
-
-    env.POST_REBASE_SHA1_CHECK = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
-
-    def node_version_from_branch = sh(script: "python tools/getnodeversion.py", returnStdout: true).trim()
-    echo "Detected version from branch: ${node_version_from_branch}"
-
-    env.NODE_MAJOR_VERSION = sh(script: "grep '^#define[[:space:]]*NODE_MAJOR_VERSION[[:space:]]' src/node_version.h | sed 's/^#define[[:space:]]*NODE_MAJOR_VERSION[[:space:]]*//'", returnStdout: true).trim()
-    echo "Detected node major version: ${env.NODE_MAJOR_VERSION}"
+def setupEnv(env, params) {
+    def node_version = sh(script: "python tools/getnodeversion.py", returnStdout: true).trim()
+    echo "Detected node version: ${node_version}"
+    def node_version_parts = node_version.tokenize('.')
+    env.NODE_MAJOR_VERSION = node_version_parts[0]
+    echo "NODE_MAJOR_VERSION=${env.NODE_MAJOR_VERSION}"
 }
 
 def setupSubParams(env, params) {
     def pr = [:] // Mutable copy of params.
     params.each{ key, value -> pr.put(key, value) }
-    pr['NODES_SUBSET'] = "auto"
-    pr['IGNORE_FLAKY_TESTS'] = "true"
-    pr["POST_STATUS_TO_PR"] = "true"
+    pr["GITHUB_ORG"] = "nodejs"
+    pr["REPO_NAME"] = "node"
     pr["GIT_REMOTE_REF"] = getBranchName(params)
     pr["GIT_ORIGIN_SCHEME"] = "git@github.com:"
     pr['NODE_MAJOR_VERSION'] = env.NODE_MAJOR_VERSION
-    pr['POST_REBASE_SHA1_CHECK'] = env.POST_REBASE_SHA1_CHECK
 
     p = []
     for (param in pr) {


### PR DESCRIPTION
fixes: #1631 

example output (`master`):
```
18:38:04  + python tools/getnodeversion.py
18:38:05  [Pipeline] sh
18:38:09  + NODE=node PYTHON=python3 gmake lint-py
18:38:09  PYTHONPATH=tools/pip python3 -m flake8 . \
18:38:09  	--count --show-source --statistics --select=E901,E999,F821,F822,F823 \
18:38:09  	--exclude=.git,deps,lib,src,test/fixtures,tools/*_macros.py,tools/gyp,tools/inspector_protocol,tools/jinja2,tools/markupsafe,tools/pip
18:38:18  0
18:38:19  [Pipeline] sh
18:38:22  + NODE=node gmake lint-ci
18:38:22  Running JS linter...
18:39:43  Running C++ linter...
18:40:19  PYTHONPATH=tools/pip python -m flake8 . \
18:40:19  	--count --show-source --statistics --select=E901,E999,F821,F822,F823 \
18:40:19  	--exclude=.git,deps,lib,src,test/fixtures,tools/*_macros.py,tools/gyp,tools/inspector_protocol,tools/jinja2,tools/markupsafe,tools/pip
18:40:25  0
```

`v10.x-staging`:
```
18:43:20  + python tools/getnodeversion.py
18:43:20  [Pipeline] sh
18:43:22  + NODE=node gmake lint-ci
```

`v8.x-staging` - https://ci.nodejs.org/job/node-linter/3040/console
```
19:19:36  + python tools/getnodeversion.py
19:19:37  [Pipeline] echo
19:19:37  8.15.2
19:19:37  [Pipeline] sh
19:19:38  + NODE=node gmake lint-ci
19:19:38  Running JS linter...
19:20:19  Running C++ linter on addon docs...
```