### PR TITLE
ansible: remove infra "collector"

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -10,7 +10,6 @@ hosts:
   - infra:
 
     - digitalocean:
-        debian8-x64-1: {ip: 198.199.72.83, alias: collector}
         ubuntu1404-x64-1: {ip: 107.170.240.62, alias: ci}
         ubuntu1604-x64-1: {ip: 138.197.224.240, alias: www}
         ubuntu1804-x64-1: {ip: 178.128.202.158, alias: gzemnid}


### PR DESCRIPTION
I've turned this off in DO (not destroyed) to see if anyone/anything yelps. It's an InfluxDB + Grafana server that @jbergstroem set up some time ago but I don't believe we ever hooked it up to collect stats for us. I've also turned off an old www server that I believe is redundant now.

Please yelp if you have a reason either of these shouldn't be destroyed.