### PR TITLE
Add support for Centos7/ppc64

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -50,6 +50,7 @@ hosts:
         aix61-ppc64_be-1: {ip: 140.211.9.99}
         ubuntu1404-ppc64_be-1: {ip: 140.211.168.76}
         ubuntu1404-ppc64_le-1: {ip: 140.211.168.66}
+        centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
 
     - scaleway:
         ubuntu1604-armv7l-1: {ip: 212.47.245.242}
@@ -150,6 +151,8 @@ hosts:
         ubuntu1404-ppc64_le-1: {ip: 140.211.168.106}
         ubuntu1404-ppc64_le-2: {ip: 140.211.168.94}
         ubuntu1404-ppc64_le-4: {ip: 140.211.168.140}
+        centos7-ppc64_le-1: {ip: 140.211.168.193, user: centos}
+        centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos}
 
     - rackspace:
         centos7-x64-1: {ip: 119.9.27.82}

--- a/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
@@ -6,16 +6,25 @@
     state: present
 
 - name: centos7 | install ius
-  when: "arch != 'arm64'"
+  when: "arch != 'arm64' and arch != 'ppc64'"
   yum:
     name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
     state: present
+
 
 - name: centos7 | install scl for devtoolset-6
   when: "arch != 'arm64' and arch != 'ppc64'"
   yum:
     name: centos-release-scl
     state: present
+
+- name: centos7 | ppc64 | install sclo7 devtoolset-6
+  when: "arch == 'ppc64'"
+  yum_repository:
+    name: sclo7-devtoolset-6
+    description: cbs.centos.org sclo7-devtoolset-6-rh-release
+    baseurl: https://cbs.centos.org/repos/sclo7-devtoolset-6-rh-release/$basearch/os/
+    gpgcheck: no
 
 - name: centos7 | aarch64 | install sclo repo
   when: "arch == 'arm64'"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -44,7 +44,7 @@ packages: {
   centos7_x64: ['git2u','centos-release-scl',], # centos-release-scl is required to enable SCLo
                                                # but we do it manually in partials/repo/centos7.yml for arm64
   centos7: [
-    'ccache,gcc-c++,devtoolset-6,sudo,git',
+    'ccache,gcc-c++,devtoolset-6,sudo,git,devtoolset-6-libatomic-devel',
   ],
 
   aix: [

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -32,19 +32,34 @@
   include_role:
     name: package-upgrade
 
-- name: download java
-  when: os in "ubuntu1404" and arch == "ppc64"
+- name: download java ppc64
+  when: os in ("ubuntu1404", "centos7") and arch == "ppc64"
   get_url:
     url: https://github.com/AdoptOpenJDK/openjdk8-releases/releases/download/jdk8u172-b11/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
     dest: /tmp/
 
-- name: unarchive java
+- name: unarchive java ubuntu1404 ppc64
   when: os in "ubuntu1404" and arch == "ppc64"
   unarchive:
     src: /tmp/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
     remote_src: yes
     dest: /home/iojs
   tags: java
+
+- name: unarchive java centos7 ppc64
+  when: os in "centos7" and arch == "ppc64"
+  unarchive:
+    src: /tmp/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
+    remote_src: yes
+    dest: /opt
+  tags: java
+
+- name: symlink java centos7 ppc64
+  when: os in "centos7" and arch == "ppc64"
+  file:
+    src: "/opt/jdk8u172-b11/bin/java"
+    dest: "/usr/bin/java"
+    state: link
 
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -19,6 +19,7 @@ def buildExclusions = [
   [ /centos[67]-(arm)?(64|32)-gcc6/,  anyType,     lt(10)  ],
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
   [ /^centos7-64/,                    releaseType, lt(12)  ],
+  [ /^centos7-ppcle/,                 anyType,     lt(12)  ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -4,7 +4,7 @@ if [ "$DONTSELECT_COMPILER" != "DONT" ]; then
   NODE_NAME=${NODE_NAME:-$HOSTNAME}
   echo "Selecting compiler based on $NODE_NAME"
   case $NODE_NAME in
-    *ppc64_le* ) SELECT_ARCH=PPC64LE ;;
+    *ppc64*le* ) SELECT_ARCH=PPC64LE ;;
     *s390x* ) SELECT_ARCH=S390X ;;
     *aix* ) SELECT_ARCH=AIXPPC ;;
   esac
@@ -21,6 +21,17 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
   export COMPILER_LEVEL="4.8"
 
   echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on ppc64le"
+
+  case $NODE_NAME in
+    *centos7* )
+      if [ "$NODEJS_MAJOR_VERSION" -gt "11" ]; then
+        # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
+        . /opt/rh/devtoolset-6/enable
+        echo "Compiler set to devtoolset-6"
+	return
+      fi
+      ;;
+   esac
 
   if [ "$NODEJS_MAJOR_VERSION" -gt "11" ]; then
     # See: https://github.com/nodejs/build/pull/1723#discussion_r265740122


### PR DESCRIPTION
- Add the repository for devtoolset-6.
- Do not use the "ius" repository, it doesn't support ppc64, and was not
  necessary.

Fixes: https://github.com/nodejs/build/issues/1705