### PR TITLE
ansible: release-centos7 and enable scl for devtoolset-6

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -32,6 +32,7 @@ hosts:
     - digitalocean:
         centos5-x64-1: {ip: 162.243.217.142}
         centos6-x86-1: {ip: 162.243.248.28}
+        centos7-x64-1: {ip: 138.68.12.105}
 
     - joyent:
         smartos14-x64-1: {ip: 72.2.113.193}

--- a/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
@@ -11,6 +11,12 @@
     name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
     state: present
 
+- name: centos7 | install scl for devtoolset-6
+  when: "arch != 'arm64' and arch != 'ppc64'"
+  yum:
+    name: centos-release-scl
+    state: present
+
 - name: centos7 | aarch64 | install sclo repo
   when: "arch == 'arm64'"
   copy:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -44,7 +44,7 @@ packages: {
   centos7_x64: ['git2u','centos-release-scl',], # centos-release-scl is required to enable SCLo
                                                # but we do it manually in partials/repo/centos7.yml for arm64
   centos7: [
-    'ccache,gcc-c++,devtoolset-6,sudo',
+    'ccache,gcc-c++,devtoolset-6,sudo,git',
   ],
 
   aix: [


### PR DESCRIPTION
two things in one:

1. add centos7 machine for ci-release for node 12
2. fix up baselayout to set up scl for installing devtoolset-6, everything else is in place but this piece is missing but it will conflict with https://github.com/nodejs/build/pull/1763