### PR TITLE
jenkins: exclude centos7 for release < Node 12

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -18,6 +18,7 @@ def buildExclusions = [
   [ /centos[67]-(arm)?(64|32)-gcc48/, anyType,     gte(10) ],
   [ /centos[67]-(arm)?(64|32)-gcc6/,  anyType,     lt(10)  ],
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
+  [ /^centos7/,                       releaseType, lt(12)  ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],


### PR DESCRIPTION
Unfortunately I need this in before I can hook centos7 up to ci-release and get the nightlies working again. If I hook up centos7 before this goes in then it'll try building other release lines. Review would be great but I might have to expedite this one tomorrow regardless.