### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -210,7 +210,7 @@ def parse_yaml(hosts, config):
 
                         # some hosts have metadata appended to provider
                         # which requires underscore
-                        delimiter = "_" if host.count('-') is 3 else "-"
+                        delimiter = "_" if host.count('-') == 3 else "-"
                         hostname = '{}-{}{}{}'.format(host_type, provider_name,
                                                       delimiter, host)
 
@@ -265,7 +265,7 @@ def parse_host(host):
 
     expected = ['type', 'provider', 'os', 'arch', 'uid']
 
-    if len(info) is not 5:
+    if len(info) != 5:
         raise Exception('Host format is invalid: %s,' % host)
 
     for key, item in enumerate(expected):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/nodejs/build on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./ansible/plugins/inventory/nodejs_yaml.py:213:44: F632 use ==/!= to compare str, bytes, and int literals
                        delimiter = "_" if host.count('-') is 3 else "-"
                                           ^
./ansible/plugins/inventory/nodejs_yaml.py:268:8: F632 use ==/!= to compare str, bytes, and int literals
    if len(info) is not 5:
       ^
2     F632 use ==/!= to compare str, bytes, and int literals
2
```