### PR TITLE
ansible,jenkins: smartos18 in ci and ci-release

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -37,6 +37,7 @@ hosts:
         smartos14-x64-1: {ip: 72.2.113.193}
         smartos15-x64-1: {ip: 72.2.113.195}
         smartos17-x64-1: {ip: 72.2.114.225}
+        smartos18-x64-1: {ip: 72.2.119.47}
         ubuntu1604_arm_cross-x64-1: {ip: 72.2.114.100, user: ubuntu}
 
     - requireio:
@@ -107,6 +108,8 @@ hosts:
         smartos16-x64-2: {ip: 72.2.113.74}
         smartos17-x64-1: {ip: 72.2.113.127}
         smartos17-x64-2: {ip: 72.2.115.11}
+        smartos18-x64-1: {ip: 72.2.115.192}
+        smartos18-x64-2: {ip: 72.2.119.5}
         ubuntu1604_docker-x64-1: {ip: 37.153.110.162, user: ubuntu}
         ubuntu1604_arm_cross-x64-1: {ip: 165.225.136.6, user: ubuntu}
         ubuntu1804-x64-1: {ip: 37.153.109.142, user: ubuntu}

--- a/ansible/roles/baselayout/tasks/ccache.yml
+++ b/ansible/roles/baselayout/tasks/ccache.yml
@@ -8,7 +8,7 @@
   # This depends on ansible being able to run curl locally, YMMV, if it doesn't
   # work, try changing the local_action to a remote one:
   #  raw: curl -sL https://www.samba.org/ftp/ccache/
-  local_action: command shell -sL https://www.samba.org/ftp/ccache/
+  local_action: command shell curl -sL https://www.samba.org/ftp/ccache/
   register: ccache_html_content
 
 - name: "ccache : extract ccache latest version"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -18,6 +18,7 @@ sshd_service_map: {
   'ubuntu1404': 'ssh',
   'ubuntu1204': 'ssh',
   'smartos17': 'ssh',
+  'smartos18': 'ssh',
 }
 
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
@@ -99,6 +100,11 @@ packages: {
 
   smartos17: [
     'gcc7'
+  ],
+
+  smartos18: [
+    'gcc7',
+    'ccache'
   ],
 
   ubuntu: [

--- a/ansible/roles/jenkins-worker/meta/main.yml
+++ b/ansible/roles/jenkins-worker/meta/main.yml
@@ -5,5 +5,4 @@
 #
 
 dependencies:
-- { 'role': 'java-base' }
 - { 'role': 'gcc', when: os|startswith("rhel7") }

--- a/ansible/roles/jenkins-worker/meta/main.yml
+++ b/ansible/roles/jenkins-worker/meta/main.yml
@@ -5,4 +5,5 @@
 #
 
 dependencies:
+- { 'role': 'java-base' }
 - { 'role': 'gcc', when: os|startswith("rhel7") }

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -252,6 +252,11 @@
   when: os|startswith("zos")
   command: "chown -R {{ server_user }} {{ home }}/{{ server_user }}/gyp"
 
+# This has to be done before the `service` (and similar) commands because
+# java is needed to start the service
+- include_role:
+    name: java-base
+
 - name: enable jenkins at startup - general
   when: not os|startswith("zos") and not os|startswith("macos") and not os|startswith("aix")
   service: name=jenkins state=restarted enabled=yes
@@ -294,6 +299,3 @@
   when: os in needs_monit
   include: monit.yml
   static: false
-
-- include_role:
-    name: java-base

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -99,6 +99,7 @@ java_path: {
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',
+  'smartos18': '/opt/local/java/openjdk8/bin/java',
   'zos13': '/usr/lpp/java/J8.0_64/bin/java'
   }
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -47,7 +47,10 @@ def buildExclusions = [
   [ /^smartos15/,                     anyType,     lt(8)   ],
   [ /^smartos15/,                     anyType,     gte(10) ],
   [ /^smartos16/,                     anyType,     lt(8)   ],
+  [ /^smartos16/,                     anyType,     gte(12) ],
   [ /^smartos17/,                     anyType,     lt(10)  ],
+  [ /^smartos17/,                     anyType,     gte(12) ],
+  [ /^smartos18/,                     anyType,     lt(12)  ],
 
   // PPC BE ------------------------------------------------
   [ /^ppcbe-ubuntu/,                  anyType,     gte(8)  ],


### PR DESCRIPTION
Got the machines provisioned, won't be active until we get the versionselectorscript changes in place though.

Picked up a couple of strange removals from #1723, probably just typos or debugging changes /cc @sam-github.