### PR TITLE
jenkins: more specific centos7 exclude

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -18,7 +18,7 @@ def buildExclusions = [
   [ /centos[67]-(arm)?(64|32)-gcc48/, anyType,     gte(10) ],
   [ /centos[67]-(arm)?(64|32)-gcc6/,  anyType,     lt(10)  ],
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
-  [ /^centos7/,                       releaseType, lt(12)  ],
+  [ /^centos7-64/,                    releaseType, lt(12)  ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],


### PR DESCRIPTION
We still need `centos7-arm64-gcc48` for node 8