### PR TITLE
ARM cross compiler GCC 6 for Node >= 12

### DIFF
--- a/ansible/roles/cross-compiler/files/cc-selector.sh
+++ b/ansible/roles/cross-compiler/files/cc-selector.sh
@@ -1,42 +1,61 @@
 # create CC, CXX, CC_host and CXX_host environment variables appropriate for the
-# worker label in use. Of the form: cross-compiler-(armv[67])-gcc-(4.[89](\.4)?)
-# e.g. cross-compiler-armv6-gcc-4.8, or cross-compiler-armv7-gcc-4.9.4
+# worker label in use. Of the form: cross-compiler-armv[67]-gcc-(4\.[89](\.4)?|6|8)
+
+# Possible labels:
+# cross-compiler-armv6-gcc-4.8
+# cross-compiler-armv7-gcc-4.8
+# cross-compiler-armv6-gcc-4.9
+# cross-compiler-armv7-gcc-4.9
+# cross-compiler-armv6-gcc-4.9.4
+# cross-compiler-armv7-gcc-4.9.4
+# cross-compiler-armv6-gcc-6
+# cross-compiler-armv7-gcc-6
+# cross-compiler-armv6-gcc-8
+# cross-compiler-armv7-gcc-8
 
 rpi_tools_base="/opt/raspberrypi/tools/"
 rpi_newer_tools_base="/opt/raspberrypi/rpi-newer-crosstools/"
-base_4_8_armv6="${rpi_tools_base}arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-"
-base_4_8_armv7="${rpi_tools_base}arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-"
-base_4_9_armv6="${rpi_tools_base}arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-"
-base_4_9_armv7="${rpi_tools_base}arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-"
-base_4_9_4_armv6="${rpi_newer_tools_base}x64-gcc-4.9.4-binutils-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
-base_4_9_4_armv7="${rpi_newer_tools_base}x64-gcc-4.9.4-binutils-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+base_4_8="${rpi_tools_base}arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/arm-linux-gnueabihf-"
+base_4_9="${rpi_tools_base}arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-"
+base_4_9_4="${rpi_newer_tools_base}x64-gcc-4.9.4-binutils-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+base_6="${rpi_newer_tools_base}x64-gcc-6.5.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+base_8="${rpi_newer_tools_base}x64-gcc-8.3.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 flags_armv6="-march=armv6zk"
 flags_armv7="-march=armv7-a"
 
-export arm_type=$(echo $1 | sed -E 's/^cross-compiler-(armv[67])-gcc-(4.[89](\.4)?)/\1/')
-export gcc_version=$(echo $1 | sed -E 's/^cross-compiler-(armv[67])-gcc-4\.([89](\.4)?)/4.\2/')
-export git_branch="cc-${arm_type}"
+function run {
+  local label="$1"
 
-if [[ ! "$arm_type" =~ ^armv[67]$ ]]; then
-  echo "Could not determine ARM type from '$1'"
-  exit 1
-fi
-if [[ ! "$gcc_version" =~ ^4\.[89](\.4)?$ ]]; then
-  echo "Could not determine ARM type from '$1'"
-  exit 1
-fi
+  export arm_type=$(echo $label | sed -E 's/^cross-compiler-(armv[67])-gcc-.*$/\1/')
+  export gcc_version=$(echo $label | sed -E 's/^cross-compiler-armv[67]-gcc-(4\.[89](\.4)?|6|8)/\1/')
+  export git_branch="cc-${arm_type}"
 
-gcc_version_safe="$(echo $gcc_version | sed -E 's/\./_/g')"
-gcc_host_version="$(echo $gcc_version | sed -E 's/\.4//g')" # 4.9.4 -> 4.9
+  if [[ ! "$arm_type" =~ ^armv[67]$ ]]; then
+    echo "Could not determine ARM type from '$label'"
+    exit 1
+  fi
+  if [[ ! "$gcc_version" =~ ^(4\.[89](\.4)?|6|8)$ ]]; then
+    echo "Could not determine ARM type from '$label'"
+    exit 1
+  fi
 
-echo "ARM type: $arm_type, GCC version: $gcc_version"
+  gcc_version_safe="$(echo $gcc_version | sed -E 's/\./_/g')"
+  gcc_host_version="$(echo $gcc_version | sed -E 's/\.4//g')" # 4.9.4 -> 4.9
 
-base_varname="base_${gcc_version_safe}_${arm_type}"
-flags_varname="flags_${arm_type}"
+  base_varname="base_${gcc_version_safe}"
+  flags_varname="flags_${arm_type}"
 
-export ARCH="${arm_type}l"
-export DESTCPU=arm
-export CC_host="ccache gcc-${gcc_host_version} -m32"
-export CXX_host="ccache g++-${gcc_host_version} -m32"
-export CC="ccache ${!base_varname}gcc ${!flags_varname}"
-export CXX="ccache ${!base_varname}g++ ${!flags_varname}"
+  echo "ARM variant:           $arm_type"
+  echo "GCC version:           $gcc_version"
+  echo "Using compiler at:     ${!base_varname}gcc"
+  echo "Using commpiler flags: ${!flags_varname}"
+
+  export ARCH="${arm_type}l"
+  export DESTCPU=arm
+  export CC_host="ccache gcc-${gcc_host_version} -m32"
+  export CXX_host="ccache g++-${gcc_host_version} -m32"
+  export CC="ccache ${!base_varname}gcc ${!flags_varname}"
+  export CXX="ccache ${!base_varname}g++ ${!flags_varname}"
+}
+
+run $1

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -32,9 +32,9 @@ def buildExclusions = [
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
   [ /^pi1-docker$/,                   releaseType, gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
-  [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
-  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   lt(10)  ],
+  [ /^cross-compiler-armv[67]-gcc-4.9/, anyType,   gte(12) ],
+  [ /^cross-compiler-armv[67]-gcc-6/, anyType,     lt(12)  ],
 
   // Windows -----------------------------------------------
   [ /vs2013/,                         anyType,     gte(6)  ],


### PR DESCRIPTION
I now have GCC 6.5.0 and GCC 8.3.0 @ https://github.com/rvagg/rpi-newer-crosstools, which is already cloned to /opt/raspberrypi/rpi-newer-crosstools/ on the cross compiler machines (it needs an update). This update allows workers with new labels like "cross-compiler-armv7-gcc-6" to select GCC 6 for ARMv7. It still allows ARMv6 even though we're dropping that for Node 12, and we also don't need GCC 8 support yet but we get some flexibility here for experimentation.

I'd appreciate some sanity checking on the VersionSelectorScript before I merge this to try and avoid the problems with centos7 that I caused yesterday. Note the labels we currently use: https://ci.nodejs.org/view/All/job/node-cross-compile/, we'll also add "cross-compiler-armv7-gcc-6" to that list.