### PR TITLE
jenkins: new "release-sources" labels for source, headers, docs

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -75,6 +75,12 @@ def buildExclusions = [
   // FreeBSD -----------------------------------------------
   [ /^freebsd10/,                     anyType,     gte(11) ],
 
+  // Source / headers / docs -------------------------------
+  [ /^osx1010-release-sources$/,      releaseType, gte(11) ],
+  [ /^osx1011-release-sources$/,      releaseType, lt(11)  ],
+  [ /^osx1011-release-sources$/,      releaseType, gte(12) ],
+  [ /^centos7-release-sources$/,      releaseType, lt(12)  ],
+
   // -------------------------------------------------------
 ]
 


### PR DESCRIPTION
Ref #1730

We need to switch to Linux for creation of our generic tarballs and 12 is the time to get it done. Here's my strategy and I'd like some sanity checking before I put it into effect for nightlies.

* Current strategy piggy-backs the `osx1010-release-tar` and `osx1011-release-tar` labels, these are also used for creating the `darwin` binary tarballs so we'll leave them as they are
* I've added labels `osx1010-release-sources` and `osx1011-release-sources` to the existing osx release machines, I've also added `centos7-release-sources` to the new centos7-64 release machine.
* I'll add all 3 of these new labels to iojs+release and VersionSelectorScript here should take care of selecting the right one.
* The iojs+release job has a dedicated block for doing this work, it comes under a label match for `osx10\d\d-release-tar` and runs 3 separate items for `tar-upload`, `doc-upload` and `tar-headers-upload`. I'll change that to `.*-release-sources` and leave the rest alone, I don't see anything that's macOS specific.

That should leave <12 working as it does now and switch to CentOS 7 x64 for making these assets for Node >= 12.

Can I get some sanity checking please?

I'm also noticing as I do this that osx1011 can be removed entirely from ci-release when we drop Node 11, assuming we get 10.13 in place in time.