### PR TITLE
ansible: gcc-6 host compiler packages for cross machines

### DIFF
--- a/ansible/roles/cross-compiler/vars/main.yml
+++ b/ansible/roles/cross-compiler/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
-packages: make,gcc-4.8-multilib,g++-4.8-multilib,gcc-4.9-multilib,g++-4.9-multilib,python2.7,python-all,python-software-properties,curl
+packages: make,gcc-4.8-multilib,g++-4.8-multilib,gcc-4.9-multilib,g++-4.9-multilib,gcc-6-multilib,g++-6-multilib,python2.7,python-all,python-software-properties,curl
 server_user: iojs


### PR DESCRIPTION
a piece missing from #1776, this has been done on the 3 cross compiler machines.