### PR TITLE
jenkins: exclude debian8 from armv7 tests for node 12+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -29,6 +29,7 @@ def buildExclusions = [
   // ARM  --------------------------------------------------
   [ /^debian7-docker-armv7$/,         anyType,     gte(10) ],
   [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
+  [ /^debian8-docker-armv7$/,         anyType,     gte(12) ],
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
   [ /^pi1-docker$/,                   releaseType, gte(10) ],
   [ /^cross-compiler-armv[67]-gcc-4.8$/, anyType,  gte(10) ],


### PR DESCRIPTION
This one will remove Debian 8 from the ARMv7 mix for Node 12+. This is for node-test-commit-arm on the Scaleway ARMv7 machines, not the Raspberry Pi machines.