### PR TITLE
ansible: default JOBS to 4 on smartos, reprovision 2 smartos18 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -37,7 +37,7 @@ hosts:
         smartos14-x64-1: {ip: 72.2.113.193}
         smartos15-x64-1: {ip: 72.2.113.195}
         smartos17-x64-1: {ip: 72.2.114.225}
-        smartos18-x64-1: {ip: 72.2.119.47}
+        smartos18-x64-1: {ip: 72.2.119.185}
         ubuntu1604_arm_cross-x64-1: {ip: 72.2.114.100, user: ubuntu}
 
     - requireio:
@@ -109,7 +109,7 @@ hosts:
         smartos17-x64-1: {ip: 72.2.113.127}
         smartos17-x64-2: {ip: 72.2.115.11}
         smartos18-x64-1: {ip: 72.2.115.192}
-        smartos18-x64-2: {ip: 72.2.119.5}
+        smartos18-x64-2: {ip: 72.2.119.47}
         ubuntu1604_docker-x64-1: {ip: 37.153.110.162, user: ubuntu}
         ubuntu1604_arm_cross-x64-1: {ip: 165.225.136.6, user: ubuntu}
         ubuntu1804-x64-1: {ip: 37.153.109.142, user: ubuntu}

--- a/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
+++ b/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
@@ -21,7 +21,7 @@
           <envvar name='NODE_TEST_DIR' value='/home/{{ server_user }}/tmp' />
           <envvar name='OSTYPE' value='solaris' />
           <envvar name='HOME' value='/home/{{ server_user }}' />
-          <envvar name='JOBS' value='{{ jobs_env|default("2") }}' />
+          <envvar name='JOBS' value='{{ jobs_env|default("4") }}' />
           <envvar name='PATH' value='/usr/local/bin:/usr/local/sbin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin' />
         </method_environment>
       </method_context>

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -144,5 +144,5 @@ jobs_variants: {
   armv6l: '1',
   armv7l: '2',
   arm64: '3',
-  smartos: '2'
+  smartos: '4'
 }


### PR DESCRIPTION
2 things in here:

1. Change the default `JOBS` on smartos to 4 since we are mostly using 4-cpu machines there (this is needed because ansible has trouble determining the number of CPUs on smartos). I've re-run ansible on smartos17 and smartos18 machines and restarted them so this is in effect. It should deal with at least some of the slowness (/cc @refack).
2. Reprovisioned test-smartos18-2 and release-smartos18-1 because, yet again, I didn't put the right ssh keys in authorized_keys and our Ansible scripts blow away the SmartConnect stuff that SmartOS uses by default so they became inaccessible.