### PR TITLE
ansible: add ARM64 Windows machines

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -34,3 +34,7 @@ ansible_python_interpreter = /usr/local/bin/python
 ansible_become             = false
 ansible_python_interpreter = /NODEJS2/python-2017-04-12-py27/python27/bin/python
 home                       = /u
+
+[hosts:win]
+ansible_connection                   = winrm
+ansible_winrm_server_cert_validation = ignore

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -143,6 +143,10 @@ hosts:
         macos10.12-x64-1: {ip: 207.254.58.162, port: 10001, user: administrator}
         macos10.12-x64-2: {ip: 207.254.58.162, port: 10002, user: administrator}
 
+    - msft:
+        win10-arm64-1: { vs: '2017' }
+        win10-arm64-2: { vs: '2017' }
+
     - osuosl:
         aix61-ppc64_be-1: {ip: 140.211.9.101}
         aix61-ppc64_be-2: {ip: 140.211.9.100}

--- a/ansible/roles/visual-studio/tasks/main.yml
+++ b/ansible/roles/visual-studio/tasks/main.yml
@@ -4,13 +4,13 @@
 # Install Visual Studio
 #
 
-- when: vs == 2013
+- when: vs == '2013'
   block:
   # TODO: Ensure no other versions are installed
   - name: install Visual Studio 2013
     include_tasks: "partials/vs2013.yml"
 
-- when: vs == 2015
+- when: vs == '2015'
   block:
   # TODO: Ensure no other versions are installed
   - name: install Visual Studio 2015
@@ -22,7 +22,7 @@
   - name: install Visual C++ Build Tools 2015
     include_tasks: "partials/vcbt2015.yml"
 
-- when: vs == 2017
+- when: vs == '2017'
   block:
   # TODO: Ensure no other versions are installed
   - name: install Visual Studio 2017

--- a/ansible/roles/visual-studio/tasks/partials/vs2017.yml
+++ b/ansible/roles/visual-studio/tasks/partials/vs2017.yml
@@ -9,7 +9,9 @@
   win_chocolatey: name=visualstudio2017community
 
 - name: install Visual Studio Community 2017 Native Desktop Workload
-  win_chocolatey: name=visualstudio2017-workload-nativedesktop
+  win_chocolatey:
+      name: visualstudio2017-workload-nativedesktop
+      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64'
 
 - name: install WiX Toolset
   import_tasks: 'wixtoolset.yml'


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/1780

This adds the public part of the inventory for two ARM64 Windows machines (secret parts already updated). This also adds two entries to the Windows configuration that previously were in `host_vars` files, changes the `vs` variable to be a string everywhere and adds ARM support to the Visual Studio 2017 installation (running on existing hosts won't add the new components to VS, `cuninst -y visualstudio2017-workload-nativedesktop` needs to be run manually first).

The machines are already online and connected to Jenkins.
