### PR TITLE
centos7: add python3

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/centos7.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/centos7.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-# centos7: python2.7 is default
+# centos7: python2.7 is default, python36 (the package name) is available
 #
 
 - name: install required packages
@@ -9,7 +9,7 @@
   loop_control:
     loop_var: package
   with_items:
-    - python-setuptools
+    - python-setuptools, python36
 
 - name: install tap2junit
   raw: easy_install tap2junit


### PR DESCRIPTION
Specifically, python3.6 (python 3.6.8 at time of this commit) from
package `python36`.