### PR TITLE
Centos7 python 3.7

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
@@ -39,3 +39,37 @@
     url: "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo"
     dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo"
     mode: 0644
+
+- stat: path=/usr/local/bin/python3.7
+  register: build_python37
+
+- name: centos7 | ppc64 | download python 3.7
+  get_url:
+    url: https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
+    dest: /tmp/
+  when: "arch == 'ppc64' and build_python37.stat.exists == False"
+
+- name: centos7 | ppc64 | unarchive python 3.7
+  unarchive:
+    src: /tmp/Python-3.7.3.tgz
+    remote_src: yes
+    dest: /tmp/
+  when: "arch == 'ppc64' and build_python37.stat.exists == False"
+
+- name: centos7 | ppc64 | configure python 3.7
+  shell: /tmp/Python-3.7.3/configure
+  args:
+    chdir: /tmp/Python-3.7.3
+  when: "arch == 'ppc64' and build_python37.stat.exists == False"
+
+- name: centos7 | ppc64 | install python 3.7
+  shell: make -j6 install
+  args:
+    chdir: /tmp/Python-3.7.3
+  when: "arch == 'ppc64' and build_python37.stat.exists == False"
+
+- name: centos7 | ppc64 | clean python 3.7
+  file:
+    state: absent
+    path: /tmp/Python-3.7
+  when: "arch == 'ppc64' and build_python37.stat.exists == False"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -44,7 +44,7 @@ packages: {
   centos7_x64: ['git2u','centos-release-scl',], # centos-release-scl is required to enable SCLo
                                                # but we do it manually in partials/repo/centos7.yml for arm64
   centos7: [
-    'ccache,gcc-c++,devtoolset-6,sudo,git,devtoolset-6-libatomic-devel',
+    'ccache,gcc-c++,devtoolset-6,sudo,git,devtoolset-6-libatomic-devel,zlib-devel,libffi-devel',
   ],
 
   aix: [

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/centos7.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/centos7.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-# centos7: python2.7 is default, python36 (the package name) is available
+# centos7: python2.7 is default
 #
 
 - name: install required packages
@@ -9,7 +9,7 @@
   loop_control:
     loop_var: package
   with_items:
-    - python-setuptools, python36
+    - python-setuptools
 
 - name: install tap2junit
   raw: easy_install tap2junit


### PR DESCRIPTION
  
    Installs python3 in /opt/python-3.7/bin, as python3:
    
            % /opt/python-3.7/bin/python3 --version
            Python 3.7.3
