### PR TITLE
aix: set jenkins TERM to a consistent value

### DIFF
--- a/setup/aix61/resources/S20jenkins
+++ b/setup/aix61/resources/S20jenkins
@@ -8,7 +8,7 @@
 
 case "$1" in
 start )
-        su - {{user}} -c 'ulimit -c 0; \
+        TERM=ansi su - {{user}} -c 'ulimit -c 0; \
               export jenkins_log_file="/home/{{user}}/jenkins_console.log"
               export PATH=/opt/freeware/bin/ccache:/usr/java71_64/jre/bin:$PATH; \
               export HOME=/home/{{user}}; \


### PR DESCRIPTION
Currently, it is inherited from the user that started Jenkins, which can
be `TERM=dumb` in some ssh environments. That value of TERM breaks some
of the terminal related tests, so ensure a consistent TERM value.

Fixes: https://github.com/nodejs/node/issues/28064