### PR TITLE
scripts: stop using ubuntu for 13.x ppcle releases

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -20,6 +20,8 @@ def buildExclusions = [
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
   [ /^centos7-64/,                    releaseType, lt(12)  ],
   [ /^centos7-ppcle/,                 anyType,     lt(12)  ],
+  [ /^centos7-ppcle/,                 releaseType, lt(13)  ],
+  [ /^ppcle-ubuntu/,                  releaseType, gte(13) ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],


### PR DESCRIPTION
Stop doing releases on ppcle-ubuntu from 13.x onwards. For now, we still
run tests on ubuntu. We'll consider switching 12.x to use centos7
instead of ubuntu for building releases once we see the nightlies
working well on 13.x.