### PR TITLE
ansible: macos python2 & python3

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -71,6 +71,21 @@ packages: {
     'ccache,git,gmake,sudo,python3,py36-pip'
   ],
 
+  'macos10.10': [
+    'python@2',
+    'python'
+  ],
+
+  'macos10.11': [
+    'python@2',
+    'python'
+  ],
+
+  'macos10.12': [
+    'python@2',
+    'python'
+  ],
+
   rhel72: [
     'gcc-c++,sudo,git,zip,unzip',
   ],

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/macos.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/macos.yml
@@ -1,10 +1,11 @@
 ---
 
 #
-# macos: python2.7
+# install tap2junit from pip
 #
 
-- name: install pip
+- name: install tap2junit
   pip:
     name: tap2junit
+    state: present
     executable: /usr/local/bin/pip2


### PR DESCRIPTION
Been trying to figure this out on macos and it's a bit of a mess. The python formulas in brew have changed so I had to do a lot of manual manipulation to get everything set up the right way. I think this config should do it properly from scratch now though. I've run this against some existing 10.12 and 10.11 and it seems to work OK.

I've also gone around and made `tap2junit` work on them all, or at least `tap2junit -h` doesn't error. They're installed against python2 though so it's going to need work.

Here's the state of `python`, `python2`, `python3`, `pip`, `pip2` and `pip3` installed under /usr/local/bin:

```
$ parallel-ssh -h /tmp/macos.hosts -t 600 -i '/usr/local/bin/python --version > /tmp/pyver 2>&1 && /usr/local/bin/python2 --version >> /tmp/pyver 2>&1 && /usr/local/bin/python3 --version >> /tmp/pyver 2>&1 && /usr/local/bin/pip --version >> /tmp/pyver 2>&1 && /usr/local/bin/pip2 --version >> /tmp/pyver 2>&1 && /usr/local/bin/pip3 --version >> /tmp/pyver 2>&1 && cat /tmp/pyver'
[1] 15:06:34 [SUCCESS] release-macstadium-macos10.11-x64-1
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[2] 15:06:35 [SUCCESS] test-macstadium-macos10.10-x64-1
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[3] 15:06:35 [SUCCESS] release-macstadium-macos10.10-x64-1
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[4] 15:06:35 [SUCCESS] test-macstadium-macos10.11-x64-2
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[5] 15:06:35 [SUCCESS] test-macstadium-macos10.11-x64-1
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[6] 15:06:35 [SUCCESS] test-macstadium-macos10.10-x64-2
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[7] 15:06:35 [SUCCESS] test-macstadium-macos10.12-x64-1
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
[8] 15:06:35 [SUCCESS] test-macstadium-macos10.12-x64-2
Python 2.7.16
Python 2.7.16
Python 3.7.3
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)
pip 19.0.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
```

So, nice and consistent! As long as we're using `python2` and `python3` from `/usr/local/bin` in all our jobs .. there is still the default `python` on these systems of course.

/cc @cclauss 