### PR TITLE
ansible: macOS tweak - disable Spotlight

### DIFF
--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -50,3 +50,7 @@
   - name: Disable Crash Reporter 2
     become_user: root
     command: launchctl unload -w /System/Library/LaunchDaemons/com.apple.ReportCrash.Root.plist
+
+  - name: Spotlight content indexing
+    become_user: root
+    command: launchctl unload -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist


### PR DESCRIPTION
It seems like a resource hog, and IIUC used main in GUI, so we don't need it.