### PR TITLE
ansible: fix AIX environment variables

### DIFF
--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -4,8 +4,8 @@ export NODE_TEST_DIR="$HOME/tmp"
 export JOBS="{{ jobs_env }}"
 
 export OSTYPE=aix
-export ARCH=ppc64le
-export DESTCPU=ppc64le
+export ARCH=ppc64
+export DESTCPU=ppc64
 
 {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \


### PR DESCRIPTION
AIX is PPC64 big endian (not little endian (LE)).

I'm not sure these even need to be set (I'd normally expect `ARCH` to come from the Jenkins job configuration). 

I've been asked to validate the AIX ansible scripts here and noticed this while re-familiarizing myself with them (and I even reviewed the original PR this landed in and missed this 😞).