### PR TITLE
ansible: remove firewalld on centos and fedora

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/centos.yml
+++ b/ansible/roles/bootstrap/tasks/partials/centos.yml
@@ -1,0 +1,8 @@
+- name: check for firewalld
+  raw: stat /usr/sbin/firewalld
+  register: has_firewalld
+  failed_when: has_firewalld.rc > 1
+
+- name: remove firewalld
+  when: has_firewalld.rc == 0
+  raw: yum remove -y firewalld

--- a/ansible/roles/bootstrap/tasks/partials/fedora.yml
+++ b/ansible/roles/bootstrap/tasks/partials/fedora.yml
@@ -31,3 +31,12 @@
   selinux: state=disabled
   # this should be done. not sure how to make it properly/gracefully
   # notify: reboot host
+
+- name: check for firewalld
+  raw: stat /usr/sbin/firewalld
+  register: has_firewalld
+  failed_when: has_firewalld.rc > 1
+
+- name: remove firewalld
+  when: has_firewalld.rc == 0
+  raw: dnf remove -y firewalld


### PR DESCRIPTION
So it doesn't interfere with multicast tests.

Refs: https://github.com/libuv/libuv/pull/2185