### PR TITLE
jenkins: release 12.x on centos7-ppcle

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -20,8 +20,8 @@ def buildExclusions = [
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
   [ /^centos7-64/,                    releaseType, lt(12)  ],
   [ /^centos7-ppcle/,                 anyType,     lt(12)  ],
-  [ /^centos7-ppcle/,                 releaseType, lt(13)  ],
-  [ /^ppcle-ubuntu/,                  releaseType, gte(13) ],
+  [ /^centos7-ppcle/,                 releaseType, lt(12)  ],
+  [ /^ppcle-ubuntu/,                  releaseType, gte(12) ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],


### PR DESCRIPTION
13.x has been releasing on centos7-ppcle for months. Start releasing
12.x on centos7-ppcle now. 10.x and below is not changed.

We get a supported operating system and expanded platform support:
1. The current release system, ubuntu14.04, has been EOL since April.
2. The devtoolset-6 compiler tools are available on centos7, and allow
building binaries that run on MORE old linux libc versions than the
current binaries build with gcc.