### PR TITLE
jenkins: 10.x/s390 building with devtoolset-6

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -58,12 +58,6 @@ elif [ "$SELECT_ARCH" = "S390X" ]; then
   echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on s390x"
 
   if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-    export PATH="/data/gcc-4.9/bin:$PATH"
-    export LD_LIBRARY_PATH="/data/gcc-4.9/lib64:$LD_LIBRARY_PATH"
-    export COMPILER_LEVEL="-4.9"
-  fi
-
-  if [ "$NODEJS_MAJOR_VERSION" -gt "11" ]; then
     # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
     . /opt/rh/devtoolset-6/enable
     export CC="ccache s390x-redhat-linux-gcc"


### PR DESCRIPTION
Start using devtoolset-6 to compile 10.x instead of gcc-4.9.

This will fix problems where gcc-4.9 builds either don't run on older
RHEL, or will run, but only after installing the gcc-4.9 runtime
libraries.

This has the effect of increasing the quality of platform coverage.