### PR TITLE
update arm jump host proxycommand

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -21,7 +21,7 @@ become_user         = root
 become_method       = sudo
 
 [hosts:requireio]
-ansible_ssh_common_args = -o ProxyCommand='ssh -i {{ ansible_ssh_private_key_file }} -W %h:%p -p 2222 jump@vagg-arm.nodejs.org'
+ansible_ssh_common_args = -o ProxyCommand='ssh -i {{ ansible_ssh_private_key_file }} -p 2222 jump@vagg-arm.nodejs.org nc -q0 %h %p'
 become_method           = sudo
 
 [hosts:smartos]


### PR DESCRIPTION
Updating the jump host command, `-W` isn't working anymore due to some restrictions I've placed on the jump host but `nc` will work just fine now. Further to #1889.

This is not replacing `{{ ansible_ssh_private_key_file }}` in the .ssh/config output of playbooks/write-ssh-config.yml and hasn't been for a while but I don't know why. Would appreciate some help tracking this down if someone has time.