### PR TITLE
tools: build parallel-ssh config files

### DIFF
--- a/tools/build-p-ssh-hosts.sh
+++ b/tools/build-p-ssh-hosts.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Build host file for parallel-ssh, they can be used like:
+#     parallel-ssh -h arm64_pi3 gcc --version
+
+set -e
+
+mkdir -p hosts
+
+# Ansible hosts look like:
+#   Host some-thing-that-is-blue  alias
+# Check that there are at least 3 "-" in the name to choose only ansible's
+# machine names, and strip off the trailing alias.
+egrep '^Host .*-.*-.*-.*' ~/.ssh/config | sed -e 's/^Host //' -e 's/ .*//' > hosts/all
+
+# Add aliases for groups of hosts. Feel free to add more aliases as useful.
+grep -- '-arm' hosts/all > hosts/arm
+grep -- 'aix61-ppc64_be' hosts/all > hosts/aix61-ppc64_be
+grep -- 'arm64_pi3' hosts/all > hosts/arm64_pi3
+grep -- 'armv6l_pi1' hosts/all > hosts/armv6l_pi1
+grep -- 'armv7l_pi2' hosts/all > hosts/armv7l_pi2
+grep -- 'centos6-x64' hosts/all > hosts/centos6-x64
+grep -- 'centos7-ppc64_le' hosts/all > hosts/centos7-ppc64_le
+grep -- 'centos7-ppc64_le' hosts/all > hosts/centos7-ppc64_le
+grep -- 'digitalocean' hosts/all > hosts/digitalocean
+grep -- 'infra-' hosts/all > hosts/infra
+grep -- 'joyent' hosts/all > hosts/joyent
+grep -- 'release-' hosts/all > hosts/release
+grep -- 'rhel72-s390x' hosts/all > hosts/rhel72-s390x
+grep -- 'smartos' hosts/all > hosts/smartos
+grep -- 'smartos14-x64' hosts/all > hosts/smartos14-x64
+grep -- 'softlayer' hosts/all > hosts/softlayer
+grep -- 'test-' hosts/all > hosts/test
+grep -- 'ubuntu1404-ppc64_be' hosts/all > hosts/ubuntu1404-ppc64_be
+grep -- 'ubuntu1404-ppc64_le' hosts/all > hosts/ubuntu1404-ppc64_le
+grep -- 'zos13' hosts/all > hosts/zos13

--- a/tools/build-p-ssh-hosts.sh
+++ b/tools/build-p-ssh-hosts.sh
@@ -33,3 +33,5 @@ grep -- 'test-' hosts/all > hosts/test
 grep -- 'ubuntu1404-ppc64_be' hosts/all > hosts/ubuntu1404-ppc64_be
 grep -- 'ubuntu1404-ppc64_le' hosts/all > hosts/ubuntu1404-ppc64_le
 grep -- 'zos13' hosts/all > hosts/zos13
+
+echo "Parallel SSH config files updated in ./hosts"


### PR DESCRIPTION
I'm exploring what of the nodejs/build inventory I can actually ssh into. I should have test and release access, but I don't have infra.

@rvagg I use parallel-ssh and hosts files pretty frequently, I suspect you do, too. I've been keeping my configs locally, but it might be worth sharing them.

1. How do you deal with hosts that throttle ssh connections? I have been seeing that a bunch... p-ssh fails to connect, but it works if I try manually :-(. Very frustrating. I'm currently attempting a work-around with `parallel-ssh -o pass -e fail -h ../release -h ../test -p 1 "echo CONNECTED && sleep 10"` which is quite slow. It occurs to me that randomizing the input host order might help, too.
2. should I replace all the `{{ ... }}` with the explicit path to my node test ssh key?
3. should I be able to ssh into any msft or windows machines?

There are lots of machines I can't ssh into. I'm not sure if that's expected or not. I'll post a gist soon.