### PR TITLE
fix: remove logo from coverage.nodejs.org

### DIFF
--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -28,7 +28,6 @@ with open('out/index.html', 'w') as out:
     <link rel="stylesheet" href="https://nodejs.org/layouts/css/styles.css" media="all">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600">
     <style>
-        #logo { margin-bottom: 1rem; }
         main { margin-bottom: 2rem; }
         .table-header,
         .table-row {
@@ -65,11 +64,6 @@ with open('out/index.html', 'w') as out:
     </style>
   </head>
   <body>
-  <header>
-    <div class="container" id="logo">
-      <img src="https://nodejs.org/static/images/logos/nodejs-new-white-pantone.png" alt="node.js">
-    </div>
-  </header>
   <div id="main">
     <div class="container">
       <h1>Node.js Nightly Code Coverage</h1>


### PR DESCRIPTION
Recent changes to the main website style sheet (which is loaded fover
coverage.nodejs.org) make the logo awfully big. The logo is superfluous
anyway, so instead of fixing it, let's just remove it so other problems
don't arise in the future.