### PR TITLE
jenkins: test 10.x on centos7-ppc

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -19,7 +19,7 @@ def buildExclusions = [
   [ /centos[67]-(arm)?(64|32)-gcc6/,  anyType,     lt(10)  ],
   [ /centos6-32-gcc6/,                releaseType, gte(10) ], // 32-bit linux for <10 only
   [ /^centos7-64/,                    releaseType, lt(12)  ],
-  [ /^centos7-ppcle/,                 anyType,     lt(12)  ],
+  [ /^centos7-ppcle/,                 anyType,     lt(10)  ],
   [ /^centos7-ppcle/,                 releaseType, lt(12)  ],
   [ /^ppcle-ubuntu/,                  releaseType, gte(12) ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only


### PR DESCRIPTION
We are intending to start building 10.x PPC releases on centos7 instead
of ubuntu. To prepare for this, start running the tests on centos7.