### PR TITLE
jenkins: use devtoolset-6 on 10.x centos7-ppcle

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -24,7 +24,7 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
 
   case $NODE_NAME in
     *centos7* )
-      if [ "$NODEJS_MAJOR_VERSION" -gt "11" ]; then
+      if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
         . /opt/rh/devtoolset-6/enable
         echo "Compiler set to devtoolset-6"


### PR DESCRIPTION
10.x uses gcc-4.9 currently on ubuntu, but devtoolset-6 is a better
choice because it creates binaries that will run on older systems than
those created by ubuntu/gcc-4.9.

Since gcc-4.9 doesn't exist on centos7, ci is failing test builds
on centos7 for 10.x. Using devtoolset-6 will fix the failing builds.