### PR TITLE
jenkins: use ccache with devtoolset on ppc64le

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -27,6 +27,9 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
         . /opt/rh/devtoolset-6/enable
+        export CC="ccache ppc64le-redhat-linux-gcc"
+        export CXX="ccache ppc64le-redhat-linux-g++"
+        export LINK="ppc64le-redhat-linux-g++"
         echo "Compiler set to devtoolset-6"
 	return
       fi

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -46,8 +46,8 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
   fi
 
   # Select the appropriate compiler
-  export CC="gcc-${COMPILER_LEVEL}"
-  export CXX="g++-${COMPILER_LEVEL}"
+  export CC="ccache gcc-${COMPILER_LEVEL}"
+  export CXX="ccache g++-${COMPILER_LEVEL}"
   export LINK="g++-${COMPILER_LEVEL}"
 
   echo "Compiler set to $COMPILER_LEVEL"


### PR DESCRIPTION
Because devtoolset setup works by putting the devtoolset bin/ on the
front of PATH the compiler is called directly instead of via the ccache
wrappers.

Change select-compiler.sh to explicitly use ccache, as it does for s390x.