### PR TITLE
ansible: improve Python 3 compatibility

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+exclude=.venv
+max-line-length=250
+import-order-style=google
+ignore=E111
+

--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,3 @@ exclude=.venv
 max-line-length=250
 import-order-style=google
 ignore=E111
-

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ setup/*/host_vars/release-*
 ansible/host_vars/*
 !ansible/host_vars/README.md
 !ansible/host_vars/*-template
+.venv
+Pipfile.lock

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -38,8 +38,8 @@ except ImportError:
 
 valid = {
     # taken from nodejs/node.git: ./configure
-    'arch': ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
-             'ppc64', 'x32', 'x64', 'x86', 'x86_64', 's390x'),
+    'arch': ('armv6l', 'armv7l', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc',
+             'ppc64', 'x32', 'x64', 'x86', 's390', 's390x'),
 
     # valid roles - add as necessary
     'type': ('infra', 'release', 'test'),

--- a/ansible/plugins/library/remmina_config.py
+++ b/ansible/plugins/library/remmina_config.py
@@ -23,15 +23,17 @@
 #
 
 from __future__ import print_function
-from ansible.module_utils.basic import *
-from jinja2 import Environment
-import os
-try:
-    import configparser # Python 3
-except ImportError:
-    import ConfigParser as configparser # Python 2
+
 import base64
+import os
+
+from ansible.module_utils.basic import AnsibleModule
 from Crypto.Cipher import DES3
+from jinja2 import Environment
+try:
+    import configparser  # Python 3
+except ImportError:
+    import ConfigParser as configparser  # Python 2
 
 
 host_template = \

--- a/ansible/plugins/library/ssh_config.py
+++ b/ansible/plugins/library/ssh_config.py
@@ -22,10 +22,12 @@
 # IN THE SOFTWARE.
 #
 
-from ansible.module_utils.basic import *
-from jinja2 import Environment
 import os
 import re
+
+from ansible.module_utils.basic import AnsibleModule
+from jinja2 import Environment
+
 
 pre_match = '# begin: node.js template'
 post_match = '# end: node.js template'
@@ -99,8 +101,7 @@ def main():
                          path)
 
     if not is_templatable(path, contents):
-        module.fail_json(msg='Your ssh config lacks template stubs. ' +
-                             'Check README.md for instructions.')
+        module.fail_json(msg='Your ssh config lacks template stubs. Check README.md for instructions.')
 
     rendered = '{}{}{}'.format(
         pre_match,

--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -6,7 +6,6 @@ import datetime
 with open('out/index.csv') as index:
   index_csv = filter(lambda line: line, index.read().split('\n'))
 
-# noqa
 with open('out/index.html', 'w') as out:
   out.write('''
 <!DOCTYPE html>

--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -6,9 +6,9 @@ import datetime
 with open('out/index.csv') as index:
   index_csv = filter(lambda line: line, index.read().split('\n'))
 
+# noqa
 with open('out/index.html', 'w') as out:
-  out.write(
-'''
+  out.write('''
 <!DOCTYPE html>
 <html>
   <head>
@@ -28,6 +28,7 @@ with open('out/index.html', 'w') as out:
     <link rel="stylesheet" href="https://nodejs.org/layouts/css/styles.css" media="all">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600">
     <style>
+        #logo { margin-bottom: 1rem; }
         main { margin-bottom: 2rem; }
         .table-header,
         .table-row {
@@ -64,6 +65,11 @@ with open('out/index.html', 'w') as out:
     </style>
   </head>
   <body>
+  <header>
+    <div class="container" id="logo">
+      <img src="https://nodejs.org/static/images/logos/nodejs-new-white-pantone.png" alt="node.js">
+    </div>
+  </header>
   <div id="main">
     <div class="container">
       <h1>Node.js Nightly Code Coverage</h1>
@@ -90,6 +96,7 @@ with open('out/index.html', 'w') as out:
               <div><div class="cell-header">JS Coverage</div><div class="cell-value"><a href="coverage-{1}/index.html">{2:05.2f}&nbsp;%</a></div></div>
               <div><div class="cell-header">C++ Coverage</div><div class="cell-value"><a href="coverage-{1}/cxxcoverage.html">{3:05.2f}&nbsp;%</a></div></div>
             </div>'''.format(date, sha, float(jscov), float(cxxcov)))
+
   out.write('''
           </div>
         </div>

--- a/setup/www/tools/metrics/country-lookup.py
+++ b/setup/www/tools/metrics/country-lookup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-import sys
 import csv
-import geoip2.database
 import os
+import sys
+
+import geoip2.database
 
 reader = geoip2.database.Reader(os.path.dirname(os.path.realpath(__file__)) + '/GeoLite2-City.mmdb')
 
@@ -28,11 +29,10 @@ for row in logFileReader:
         country = georec.country.iso_code
       if georec.subdivisions.most_specific.iso_code:
         region = georec.subdivisions.most_specific.iso_code
-  except:
+  except Exception:
     pass
 
   row.insert(1, country.encode('utf-8'))
   row.insert(2, region.encode('utf-8'))
 
   logFileWriter.writerow(row)
-


### PR DESCRIPTION
As requested at https://github.com/nodejs/build/pull/1399#issuecomment-522687404, this PR cherrypicks key modifications from #1399 to improve the Python 3 compatibility of our build process.
* __git checkout refack/pipenv+python3 -- .flake8 .gitignore ansible/plugins/library/remmina_config.py ansible/plugins/library/ssh_config.py setup/www/tools/metrics/country-lookup.py jenkins/scripts/coverage/generate-index-html.py__
* __code ansible/plugins/inventory/nodejs_yaml.py__
    * cherrypick some change but not others
    * sync __valid["arch"]__ with https://github.com/nodejs/node/blob/master/configure.py
* __flake8 .__  # placate flake8