### PR TITLE
Nodejs org redir

### DIFF
--- a/setup/www/resources/config/nodejs.org
+++ b/setup/www/resources/config/nodejs.org
@@ -355,8 +355,9 @@ server {
 
     # Asset rewrites
     rewrite ^/layouts/css/styles\.css$                            https://$server_name/static/css/styles.css permanent;
-    rewrite ^/(?!static/)?favicon\.ico$                           https://$server_name/static/images/favicons/favicon.ico permanent;
-    rewrite ^/apple-touch-icon.*\.png$                            https://$server_name/static/images/favicons/apple-touch-icon.png permanent;
+    rewrite ^/(static/)?favicon\.ico$                             https://$server_name/static/images/favicons/favicon.ico permanent;
+    rewrite ^/(static/)?favicon\.png$                             https://$server_name/static/images/favicons/favicon-32x32.png permanent;
+    rewrite ^/(static/)?apple-touch-icon.*\.png$                  https://$server_name/static/images/favicons/apple-touch-icon.png permanent;
     rewrite ^/trademark-policy.pdf$                               https://$server_name/static/documents/trademark-policy.pdf permanent;
 
     rewrite ^/logos/                                              https://$server_name/static/images/logos/ permanent;


### PR DESCRIPTION
**Needs review and #1935**

I notice we have `https://nodejs.org/static/apple-touch-icon.png` or `https://nodejs.org/static/favicon.png`. This patch attempts to handle those requests and redirect them to the existent files.