### PR TITLE
Attempt to fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/setup/www/resources/config/*.org linguist-language=Nginx


### PR DESCRIPTION
This is the recommended way of solving the issue, but AFAICT it doesn't work, at least not on my fork.

Basically, because the config filenames end with `.org` GitHub autodetects them as Org https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L3576