### PR TITLE
ansible: update debian8 support

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian8.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: "debian8 | add debian-backports" # has systemd-coredump if needed
+- name: "debian8 | add jessie-backports" # has systemd-coredump if needed
   apt_repository:
-    repo: 'deb http://ftp.debian.org/debian jessie-backports main'
+    repo: 'deb http://archive.debian.org/debian jessie-backports main'
     state: present
     update_cache: yes
   register: has_updated_package_repo

--- a/ansible/roles/bootstrap/tasks/partials/debian8.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian8.yml
@@ -12,3 +12,12 @@
 - name: install apt-transport-https
   when: has_apt_transport.rc == 1
   raw: apt-get install -y apt-transport-https
+
+- name: install dbus
+  package: name=dbus state=present
+
+- name: disable valid-until apt checks
+  lineinfile:
+    dest: /etc/apt/apt.conf.d/99no-check-valid-until
+    line: 'Acquire::Check-Valid-Until no;'
+    create: yes


### PR DESCRIPTION
I reprovisioned test-rackspace-debian8-x64-1 due to some odd descripancies pointed out in https://github.com/nodejs/citgm/pull/751, I had to fix a few minor things to get it to run fully in ansible now that debian8 is EOL. I'm unsure if the descripancies are entirely sorted out, it's difficult to determine but maybe a citgm run or two could tell.

We should probably phase debian8 out, but I wasn't brave enough to just pull the rug unanimously, so restoring support was probably worthwhile.