### PR TITLE
coverage: add the needed CSS from the main site

### DIFF
--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -3,6 +3,10 @@
 
 import datetime
 
+with open('jenkins/scripts/coverage/styles.css') as in_file:
+  with open('out/styles.css') as out_file:
+    out_file.write(in_file.read())
+
 with open('out/index.csv') as index:
   index_csv = filter(lambda line: line, index.read().split('\n'))
 

--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -25,50 +25,7 @@ with open('out/index.html', 'w') as out:
     <link rel="icon" sizes="32x32" type="image/png" href="https://nodejs.org/static/images/favicons/favicon-32x32.png">
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600&display=fallback">
-    <link rel="stylesheet" href="https://nodejs.org/static/css/styles.css">
-    <style>
-        #logo { margin-bottom: 1rem; }
-        #badge {
-          margin-top: 1rem;
-          margin-bottom: 1rem;
-        }
-        #badge, a {
-          border: none;
-        }
-        main { margin-bottom: 2rem; }
-        .table-header,
-        .table-row {
-          box-sizing: border-box;
-          display: flex;
-          width: 100%;
-          padding: 2px 10px;
-        }
-        .table-header { font-weight: bold;}
-        .table-header > div,
-        .table-row > div {
-          flex-grow: 1;
-          width: 100px;
-        }
-        .table-row:nth-child(even) { background-color: #eee; }
-        .sha .cell-value { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace; }
-        .cell-header { display: none; }
-        @media screen and (min-width: 690px) and (max-width: 850px) {
-          .table-header > div:nth-child(n+3),
-          .table-row > div:nth-child(n+3) {
-            flex-grow: 0.2;
-          }
-          .table-header > div:first-child,
-          .table-row > div:first-child {
-            flex-grow: 0.4;
-          }
-        }
-        @media screen and (max-width: 690px) {
-          .cell-header { display: block; font-weight: bold; }
-          .table-header { display: none; }
-          .table-row { display: block; }
-          .table-row > div { width: 100%; text-align: center; margin-bottom: 12px;}
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
   </head>
   <body>
   <header>

--- a/jenkins/scripts/coverage/styles.css
+++ b/jenkins/scripts/coverage/styles.css
@@ -1,0 +1,227 @@
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+body {
+  box-sizing: border-box;
+  font: 400 20px/1.5 "Source Sans Pro", "Open Sans", Roboto, "San Francisco", Helvetica, Arial, sans-serif;
+  color: #333;
+  margin: 0;
+  background-color: #fff;
+  display: -webkit-box;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header,
+#main,
+footer {
+  display: -webkit-box;
+  display: flex;
+}
+
+h1,
+h3 {
+  font-weight: 400;
+}
+
+a,
+a:link,
+a:active {
+  color: #43853d;
+  text-decoration: none;
+  border-radius: 2px;
+}
+
+a:hover {
+  color: #fff;
+  background-color: #43853d;
+}
+
+strong {
+  font-weight: 600;
+}
+
+p a {
+  padding-right: 2px;
+  padding-left: 2px;
+  margin-right: -2px;
+  margin-left: -2px;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  border: none;
+}
+
+iframe {
+  border: none;
+}
+
+#main {
+  -webkit-box-flex: 1;
+  flex: 1 0 auto;
+}
+
+header,
+footer {
+  flex-shrink: 0;
+}
+
+footer {
+  margin-top: 2em;
+  background-color: #333;
+  padding: 0;
+}
+
+.container {
+  width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+#main .container {
+  padding: 0 20px;
+}
+
+.linuxfoundation-footer {
+  padding: 1em 20px;
+  font-size: 14px;
+  color: #fff;
+  background: #333;
+}
+
+.linuxfoundation-footer p + p {
+  margin-top: 0;
+  margin-bottom: .25em;
+}
+
+.linuxfoundation-logo {
+  margin-top: .2em;
+  min-width: 1px;
+  max-width: 416px;
+}
+
+header {
+  background-color: #333;
+  text-align: center;
+  position: relative;
+}
+
+header > .container {
+  overflow: visible;
+}
+
+#logo {
+  display: block;
+  margin-bottom: 1rem; /* custom for coverage */
+}
+
+#logo img {
+  margin: .5em auto 0;
+}
+
+footer a,
+footer a:link,
+footer a:active {
+  color: #ccc;
+}
+
+footer a:hover {
+  background-color: transparent;
+  text-decoration: underline;
+}
+
+footer.no-margin-top {
+  margin-top: 0;
+}
+
+
+/* coverage.nodejs.org specific styles */
+
+main {
+  margin-bottom: 2rem;
+}
+
+#badge {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.table-header,
+.table-row {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: flex;
+  width: 100%;
+  padding: 2px 10px;
+}
+
+.table-header {
+  font-weight: 700;
+}
+
+.table-header > div,
+.table-row > div {
+  -webkit-box-flex: 1;
+  flex-grow: 1;
+  width: 100px;
+}
+
+.table-row:nth-child(even) {
+  background-color: #eee;
+}
+
+.sha .cell-value {
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+
+.cell-header {
+  display: none;
+}
+
+@media screen and (min-width: 690px) and (max-width: 850px) {
+  .table-header > div:nth-child(n+3),
+  .table-row > div:nth-child(n+3) {
+    -webkit-box-flex: .2;
+    flex-grow: .2;
+  }
+
+  .table-header > div:first-child,
+  .table-row > div:first-child {
+    -webkit-box-flex: .4;
+    flex-grow: .4;
+  }
+}
+
+@media screen and (max-width: 690px) {
+  .cell-header {
+    display: block;
+    font-weight: 700;
+  }
+
+  .table-header {
+    display: none;
+  }
+
+  .table-row {
+    display: block;
+  }
+
+  .table-row > div {
+    width: 100%;
+    text-align: center;
+    margin-bottom: 12px;
+  }
+}


### PR DESCRIPTION
This unties the site from the upstream CSS

**I need some help actually copying the CSS file. Any help welcome.**

Preview: <https://relaxed-ptolemy-556131.netlify.com/>

Refs https://github.com/nodejs/nodejs.org/pull/2635

TODO:

- [ ] Adapt the python script to copy styles.css too
- [ ] Move the other assets too like favicons, logo etc?


Note that the CSS is only the required. Which means that if more elements are added at some point, their rules should be added manually here again.