### PR TITLE
ansible: macos: /usr/localopt->/usr/local/opt & install ccache

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -95,9 +95,9 @@
     - "{{ packages[os|stripversion]|default('[]') }}"
     - "{{ common_packages|default('[]') }}"
 
-- name: Check whether /etc/paths contains "/usr/localopt/ccache/libexec" (macos)
+- name: Check whether /etc/paths contains "/usr/local/opt/ccache/libexec" (macos)
   when: os|startswith("macos")
-  command: grep -Fxq "/usr/localopt/ccache/libexec" /etc/paths
+  command: grep -Fxq "/usr/local/opt/ccache/libexec" /etc/paths
   register: ccache_mac
   check_mode: no
   ignore_errors: yes
@@ -107,7 +107,7 @@
   when: os|startswith("macos") and ccache_mac.rc == 1
   lineinfile: dest=/etc/paths
     insertbefore=BOF
-    line='/usr/localopt/ccache/libexec'
+    line='/usr/local/opt/ccache/libexec'
 
 - name: ubuntu1404 | update package alternatives
   when: os == "ubuntu1404"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -72,18 +72,15 @@ packages: {
   ],
 
   'macos10.10': [
-    'python@2',
-    'python'
+    'python@2,python,ccache'
   ],
 
   'macos10.11': [
-    'python@2',
-    'python'
+    'python@2,python,ccache'
   ],
 
   'macos10.12': [
-    'python@2',
-    'python'
+    'python@2,python,ccache'
   ],
 
   rhel72: [

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -7,6 +7,6 @@ export OSTYPE=osx
 export ARCH=x64
 export DESTCPU=x64
 
-PATH="/usr/localopt/ccache/libexec:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
+PATH="/usr/local/opt/ccache/libexec:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp


### PR DESCRIPTION
I'm not sure of the backstory here, this path was introduced in the original PRs:

Ref: https://github.com/nodejs/build/pull/971
Ref: https://github.com/nodejs/build/pull/1347

But afaik /usr/localopt has never been a thing. /usr/local/opt is where this stuff is at.

The macos machines all seem to be set up to have /usr/localopt in start.sh and /etc/paths, but because /usr/local/opt is in there I believe it just _mostly works_.

https://github.com/nodejs/build/issues/1955 reports slow release builds on macos, but that's because there's no ccache. I tried running the playbook but it failed at doing something in /home, so there's more work to be done on that. I don't even know if it installs ccache by `brew` but I did that manually for now to get it going.