### PR TITLE
jenkins: only test FreeBSD 11 on <= Node.js 12 thanks to clang 6

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -79,6 +79,7 @@ def buildExclusions = [
   
   // FreeBSD -----------------------------------------------
   [ /^freebsd10/,                     anyType,     gte(11) ],
+  [ /^freebsd11/,                     anyType,     gte(13) ],
 
   // Source / headers / docs -------------------------------
   [ /^osx1010-release-sources$/,      releaseType, gte(11) ],


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/1970
Ref: https://github.com/nodejs/node/pull/30020

FreeBSD 11 comes with clang 6.0.0. `configure.py` states we have a minimum of 8.0.0 (though not BUILDING.md). V8 7.9 @ https://github.com/nodejs/node/pull/30020 is having problems with older gcc but it compiles OK on FreeBSD 11, with just one test failing.

Two questions for this PR:

1. Is clang 8.0.0 a _real_ minimum requirement or just a guess? Should it disqualify FreeBSD 11?
2. What is the likelihood of V8 7.9 going into Node 13.x? I've crafted this PR to exclude it from >=13 because of this assumption, but maybe that's not a safe assumption if 7.9 is going to break real compiler minimums, not just what we state in BUILDING.md (i.e. someone can compile 13.x today with their gcc 5, but in a month they won't be able to because 7.9 is there and having problems).

Also we don't have anything newer than FreeBSD 11 so maybe we should ditch all our FreeBSD machines and put in some fresh new 12 ones and start from scratch?

@targos @richardlau @nodejs/build @nodejs/platform-freebsd 