### PR TITLE
jenkins: exclude Debian 8 from testing Node >= 13

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -22,6 +22,7 @@ def buildExclusions = [
   [ /^centos7-ppcle/,                 anyType,     lt(10)  ],
   [ /^ppcle-ubuntu/,                  releaseType, gte(10) ],
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
+  [ /debian8/,                        anyType,     gte(13) ],
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
   [ /^ubuntu1204/,                    anyType,     gte(10) ],
   [ /^ubuntu1404-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/1970

GCC is always really difficult to upgrade on Debian. Jessie only has less than 12 months till EOL and trying to maintainer a newer toolchain on it is just going to waste cycles. I think it's for the good of Build that we just ditch it for >= 13.x since its natural state violates our building minimums in BUILDING.md (but not our running conditions).

@nodejs/build