### PR TITLE
ansible,jenkins: install gcc-7 on ubuntu1604 machines, use on node>12

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -118,6 +118,15 @@
     - gcc
     - g++
 
+- name: ubuntu1604 | update package alternatives
+  when: os == "ubuntu1604"
+  alternatives: link=/usr/bin/{{ gcc }} name={{ gcc }} path=/usr/bin/{{ gcc }}-5
+  loop_control:
+    loop_var: gcc
+  with_items:
+    - gcc
+    - g++
+
 - name: smartos17 | update gcc symlinks
   when: os == "smartos17"
   file:

--- a/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
@@ -1,0 +1,12 @@
+---
+
+#
+# add PPA for gcc updates
+#
+
+- name: "repo : add Ubuntu Toolchain PPA"
+  apt_repository:
+    repo: 'ppa:ubuntu-toolchain-r/test'
+    state: present
+    update_cache: yes
+  register: has_updated_package_repo

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -120,7 +120,7 @@ packages: {
   ],
 
   ubuntu: [
-    'ccache,g++,gcc,git,libfontconfig1,sudo',
+    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo',
   ],
 
   ubuntu1404: [

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -14,6 +14,8 @@ if [ "$DONTSELECT_COMPILER" != "DONT" ]; then
     *ppc64*le* ) SELECT_ARCH=PPC64LE ;;
     *s390x* ) SELECT_ARCH=S390X ;;
     *aix* ) SELECT_ARCH=AIXPPC ;;
+    *x64* ) SELECT_ARCH=X64 ;;
+    *arm64* ) SELECT_ARCH=ARM64 ;;
   esac
 fi
 
@@ -112,4 +114,33 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
     # front of PATH
     echo "Compiler set to default at 4.8.5"
   fi
+
+elif [ "$SELECT_ARCH" = "X64" ]; then
+  echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on x64"
+
+
+  if test $nodes = "centos6-64-gcc48"; then
+    . /opt/rh/devtoolset-2/enable
+    echo "Compiler set to devtoolset-2"
+  elif [[ "$nodes" =~ centos[67]-64-gcc6 ]]; then
+    . /opt/rh/devtoolset-6/enable
+    echo "Compiler set to devtoolset-6"
+  elif test $nodes = "ubuntu1604-64"; then
+    if [ "$NODEJS_MAJOR_VERSION" -gt "12" ]; then
+      export CC="gcc-6"
+      export CXX="g++-6"
+      export LINK="g++-6"
+      echo "Compiler set to GCC 6 for $NODEJS_MAJOR_VERSION"
+    fi
+  fi
+
+elif [ "$SELECT_ARCH" = "ARM64" ]; then
+  echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on arm64"
+
+
+  if [[ "$nodes" =~ centos[67]-arm64-gcc6 ]]; then
+    . /opt/rh/devtoolset-6/enable
+    echo "Compiler set to devtoolset-6"
+  fi
+
 fi


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/1970

This will build Node >=13 with GCC 7 on Ubuntu 16.04 and the default GCC 5 compiler below that.

I've tried out the ansible config on one of the ubuntu1604-x64 machines and it works fine, leaves the default compiler as 5 but 7 is available.

I've not tested the select-compiler.sh script that's included here, we've not used it beyond the IBM machines but it's probably time to get some of the logic out of Jenkins and into GitHub for the other machines. Some sanity checking before I attempt to test it out would be helpful.