### PR TITLE
Add copyright notice to install-xcode.sh

### DIFF
--- a/ansible/roles/package-upgrade/files/install-xcode.sh
+++ b/ansible/roles/package-upgrade/files/install-xcode.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Copyright (c) 2013 rtrouton
-#source: https://github.com/rtrouton/rtrouton_scripts/blob/master/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
+#source: https://github.com/rtrouton/rtrouton_scripts/blob/126d22503b862d02869154b444d071382827a250/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
 
 osx_vers=$(sw_vers -productVersion | awk -F "." '{print $2}')
 cmd_line_tools_temp_file="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"

--- a/ansible/roles/package-upgrade/files/install-xcode.sh
+++ b/ansible/roles/package-upgrade/files/install-xcode.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+#Copyright (c) 2013 rtrouton
+#source: https://github.com/rtrouton/rtrouton_scripts/blob/master/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh
+
 osx_vers=$(sw_vers -productVersion | awk -F "." '{print $2}')
 cmd_line_tools_temp_file="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
 


### PR DESCRIPTION
The install-xcode script originates from this blog post - https://derflounder.wordpress.com/2015/02/02/installing-the-xcode-command-line-tools-on-10-7-x-and-later/

Which is hosted in github here - https://github.com/rtrouton/rtrouton_scripts/blob/master/rtrouton_scripts/install_xcode_command_line_tools/install_xcode_command_line_tools.sh

Under the MIT license here - https://github.com/rtrouton/rtrouton_scripts/blob/master/LICENSE

Ive edited the script to have the copyright inside and a link to the original repo. Let me know if I need to add anything else or if the format is wrong.