### PR TITLE
Proposal for major changes to (and expansion of) containerised build system

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -116,8 +116,8 @@ hosts:
         ubuntu1604-x86-2: {ip: 104.131.191.135}
         ubuntu1804_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
-        ubuntu1910_docker-x64-1: {ip: 167.71.99.4}
-        ubuntu1910_docker-x64-2: {ip: 159.203.120.157}
+        ubuntu2004_docker-x64-1: {ip: 167.71.99.4}
+        ubuntu2004_docker-x64-2: {ip: 159.203.120.157}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
 
     - ibm:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -116,6 +116,8 @@ hosts:
         ubuntu1604-x86-2: {ip: 104.131.191.135}
         ubuntu1804_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
+        ubuntu1804_docker-x64-3: {ip: 167.71.99.4}
+        ubuntu1804_docker-x64-4: {ip: 159.203.120.157}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
 
     - ibm:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -116,8 +116,8 @@ hosts:
         ubuntu1604-x86-2: {ip: 104.131.191.135}
         ubuntu1804_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
-        ubuntu1804_docker-x64-3: {ip: 167.71.99.4}
-        ubuntu1804_docker-x64-4: {ip: 159.203.120.157}
+        ubuntu1910_docker-x64-1: {ip: 167.71.99.4}
+        ubuntu1910_docker-x64-2: {ip: 159.203.120.157}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
 
     - ibm:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -23,7 +23,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu1904'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu2004'],
   ntp_package: ['ubuntu1404']
 }
 

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -23,7 +23,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu1904'],
   ntp_package: ['ubuntu1404']
 }
 

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -148,5 +148,10 @@ packages: {
 
   ubuntu1404: [
     'ntp,gcc-8,g++-8,gcc-6,g++-6,g++-4.8,gcc-4.8,g++-4.9,gcc-4.9,binutils-2.26',
-  ]
+  ],
+
+  ubuntu: [
+    'ccache,g++,gcc,g++,git,libfontconfig1,sudo,python3-pip,python-setuptools,python3-setuptools',
+  ],
+
 }

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -143,7 +143,7 @@ packages: {
   ],
 
   ubuntu: [
-    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo,python3-pip',
+    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo,python3-pip,python-setuptools,python3-setuptools',
   ],
 
   ubuntu1404: [

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -13,7 +13,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu1904'],
   ntp_package: ['ubuntu1404']
 }
 

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -13,7 +13,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu1904'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804', 'ubuntu2004'],
   ntp_package: ['ubuntu1404']
 }
 

--- a/ansible/roles/jenkins-worker/files/docker-node-exec.sh
+++ b/ansible/roles/jenkins-worker/files/docker-node-exec.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+## This script is designed to be enabled in /etc/sudoers for the `iojs` user,
+## the only privileged access that user has to Docker.
+## Since there is considerable access given by selecting arbitrary images and
+## execution commands, there are still security concerns and additions of new
+## images and changes to existing ones as well as the Bash that's executed
+## inside them should be monitored for malicious activity.
+
+set -e
+
+OPTIND=1
+image_base="rvagg/node-ci-containers"
+image_tag=
+exec_script="node-ci-exec.sh"
+
+while getopts "i:" opt; do
+    case "$opt" in
+    i)
+        if [[ "$OPTARG" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+          image_tag=$OPTARG
+        else
+          echo "Bad -i value"
+          exit 1
+        fi
+        ;;
+    *)
+        echo "Wut?"
+        exit 1
+    esac
+done
+
+if test "$image_tag" = ""; then
+  echo "Did not provide the docker image [-i]"
+  exit 1
+fi
+
+if [ ! -f "$(pwd)/$exec_script" ]; then
+  echo "Did not provide a node-ci-exec.sh script"
+  exit 1
+fi
+
+set -x
+
+image="${image_base}:${image_tag}"
+# failure to pull is acceptable if Docker Hub is offline or erroring and we have the image
+docker pull "${image}" || true
+docker run \
+  --init \
+  --rm \
+  -v $(pwd):/home/iojs/workspace \
+  -v /home/iojs/.ccache/${image_tag}:/home/iojs/.ccache \
+  -u iojs \
+  "${image}" \
+  /bin/bash -xec "cd /home/iojs/workspace && . ./$exec_script"
+

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -105,7 +105,7 @@
     creates: "/usr/local/bin/cmake"
 
 - name: run docker-host-x64 jenkins-worker setup
-  when: "'ubuntu1804_docker-x64' in inventory_hostname"
+  when: "'_docker-x64' in inventory_hostname"
   include: "{{ role_path }}/tasks/partials/docker-host-x64.yml"
 
 # @TODO(mhdawson): get tap2junit working on zOS

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -104,6 +104,10 @@
     cmd: "./bootstrap --verbose && make -j6 VERBOSE=1 && make install"
     creates: "/usr/local/bin/cmake"
 
+- name: run docker-host-x64 jenkins-worker setup
+  when: "'ubuntu1804_docker-x64' in inventory_hostname"
+  include: "{{ role_path }}/tasks/partials/docker-host-x64.yml"
+
 # @TODO(mhdawson): get tap2junit working on zOS
 - name: prepare installing tap2junit
   when: type != "release" and not os|startswith("zos")

--- a/ansible/roles/jenkins-worker/tasks/partials/docker-host-x64.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/docker-host-x64.yml
@@ -1,0 +1,30 @@
+---
+
+- name: docker-host-x64 | check if docker exists
+  shell: which docker
+  register: docker_exists
+  ignore_errors: yes
+
+- name: docker-host-x64 | install docker from docker.com
+  when: "docker_exists.stdout == ''"
+  raw: curl -fsSL get.docker.com | bash -
+
+- name: docker-host-x64 | copy docker-node-exec.sh
+  copy:
+    src: "{{ role_path }}/files/docker-node-exec.sh"
+    dest: "/usr/local/bin/docker-node-exec.sh"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: docker-host-x64 | give {{ server_user }} sudoers access to docker-exec script
+  lineinfile:
+    line: "{{ server_user }} ALL=(ALL) NOPASSWD: /usr/local/bin/docker-node-exec.sh"
+    dest: "/etc/sudoers"
+    regexp: docker-node-exec.sh$
+
+- name: docker-host-x64 | install shyaml
+  pip:
+    name: shyaml
+    state: present
+    executable: pip3

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ubuntu.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ubuntu.yml
@@ -4,8 +4,12 @@
 # ubuntu series: python 2.7
 #
 
+# TODO(@rvagg): a hack, how do we handle py3?
+
 - name: install pip
   package: name=python-pip state=present
+  when: os != "ubuntu2004"
 
 - name: install tap2junit
   pip: name=tap2junit state=present
+  when: os != "ubuntu2004"

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -12,7 +12,7 @@ init: {
   ibmi: 'ibmi72',
   macos: 'macos',
   rhel7: 'rhel7',
-  systemd: ['centos7', 'debian8', 'debian9', 'debian10', 'fedora', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['centos7', 'debian8', 'debian9', 'debian10', 'fedora', 'ubuntu1604', 'ubuntu1804', 'ubuntu1910'],
   svc: 'smartos',
   upstart: ['ubuntu12', 'ubuntu1404'],
   zos_start: 'zos'

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -12,7 +12,7 @@ init: {
   ibmi: 'ibmi72',
   macos: 'macos',
   rhel7: 'rhel7',
-  systemd: ['centos7', 'debian8', 'debian9', 'debian10', 'fedora', 'ubuntu1604', 'ubuntu1804', 'ubuntu1910'],
+  systemd: ['centos7', 'debian8', 'debian9', 'debian10', 'fedora', 'ubuntu1604', 'ubuntu1804', 'ubuntu2004'],
   svc: 'smartos',
   upstart: ['ubuntu12', 'ubuntu1404'],
   zos_start: 'zos'


### PR DESCRIPTION
This PR is part of a complex set of changes that I'm proposing. I have enough of this in place that it runs and I can demonstrate it, but not such that it's baked in. None of this touches existing Jenkins config and It would be straightforward to undo the changes I've made.

Grab a coffee, I'd like your thoughts @nodejs/build, this is much more than just node-test-commit-linux-containered.

## Basic proposal

I'm proposing that we introduce something that's more like Travis than what we have now for our containerised builds: control over what is run and how is external to Jenkins and mostly embedded in the nodejs/node repo itself. This means that the build configurations are specific to the release line and don't need VersionSelectorScript or any other mechanism to get involved. What's more, it's very simple to extend to encompasses more than what we do in node-test-commit-linux-containered, we can move anything Linux x64 into a container that we want, potentially eliminating a lot of our VMs where we are prepared to move from VM testing to container testing.

In addition to possible simplification of our infrastructure ("simplification" may be in the eye of the beholder, I'd like some objective opinions on this), we put configs in the hands of the collaborators. Issues filed in this repository to add some new test configuration (e.g. [`--ninja`](https://github.com/nodejs/build/issues/1914) & [`--debug --enable-asan`](https://github.com/nodejs/build/issues/1906)) become unnecessary in most cases as it would mean editing a YAML file to add the new build and test commands in a new entry. Adding new distro versions (e.g. Alpine, Fedora, Ubuntu non-LTS) become much easier and could mostly happen without Build WG involvement if enterprising collaborators notice the need and step up.

## Technical summary

  1. nodejs/node is equipped with a new top-level file, `.ci.yml`. You can see it here: https://github.com/nodejs/node/pull/30057. This file contains a list of tests that need to be run for that branch, each test has an "image" (mapping to a Docker container), "label" (used for reporting status back to the PR) and an "execute" block (with the required Bash to execute the test, could be as little as `make run-ci -j $JOBS`).
  2. https://github.com/rvagg/node-ci-containers/ (name & location unimportant for now) contains a set of containers that the "image" entries map to. They're published on [Docker Hub](https://hub.docker.com/r/rvagg/node-ci-containers) (rebuilds triggered on push, but new images need to be manually wired up in Docker Hub).
  3. Jenkins has a new job, https://ci.nodejs.org/job/rv-test-commit-linux-docker/ (name unimportant for now), that would replace node-test-commit-linux-containered and some of node-test-commit-linux and node-test-commit-custom-suites-freestyle too. The innards of this job are intentionally simple and can mostly be controlled outside of Jenkins.
    a. It uses a YAML Axis plugin to parse .ci.yml and use ~`CONTAINER_TEST`~ `linux_x64_container_suite` as a matrix axis, so the number of jobs run is controlled by .ci.yml.
    b. It uses `curl -sL https://raw.githubusercontent.com/rvagg/node-ci-containers/master/execute.sh | bash -` to execute the tests, which is also fairly simple and mainly just pulling out pieces of .ci.yml for each test run.
    c. It also uses the "label" property of each test to report back to the GitHub Status API, which makes it quite descriptive, see https://github.com/nodejs/node/pull/30057 for example - it might be a bit messy when you add back in the normal `node-test-commit-*` though.
  4. Our 4 existing Docker hosts, which run a Jenkins node inside each of ~8 containers each, would be reset with the configuration in this PR. The playbooks/jenkins/docker-host.yaml and some friends would be removed and the hosts become a little more like the existing Jenkins nodes, running a single node but allowing for parallelism of ~ncpus/2.
    a. docker-node-exec.sh in this PR does the "run Docker" work and is the only thing the iojs user is allowed to `sudo`. It's patterned off a docker-node-exec.sh that we use on the Raspberry Pis and on the Scaleway ARMv7 machines (but in this case it `docker run`s, not `docker exec`s).
    b. Their workspaces become fatter, and we may need to control the disk usage more carefully than I currently am (perhaps a `git clean -fdx` at the end of each build).
    c. Together, the 4 hosts (maybe we add more when we free up space by removing some other VMs) and their ~ncpu/2 workers create a pool that new builds are distributed across. The size of this pool will be dictated by the branch on nodejs/node with the most complicated .ci.yml.

You can see more documentation in .ci.yml, execute.sh, docker-node-exec.sh, and the node-ci-containers repo. I've been pretty liberal with docs so this is as clear as I can make it.

## Complexity reduction?

I'm not eliminating as much as I'd like in this, but I believe I'm lessening the maintenance burden on Build by quite a bit. Some thoughts:

* node-test-commit-linux-containered is only maintained by me, as are the Docker hosts, and its complexity is hidden inside the Jenkins job. This change pushes the complexity out of Jenkins and into .ci.yml in the hands of collaborators and other places that are open source and documented and available for tweaking. The docker hosts become a bit more "normal" and hopefully not as intimidating for other Build WG members.
* VersionSelectorScript is simplified a little because it does branch:builder, but .ci.yml is on-branch, select-compiler.sh doesn't need to get involved because it's all in Dockerfiles. However, I am introducing a third vector for selecting what gets run for what version of Node. So I'm trading different complexities here. We could extend .ci.yml too, potentially making it the source of truth for versioning?
* Dockerfiles are easier than Ansible and more approachable by the average dev. I think .ci.yml is not difficult to grok either, it's much simpler than Travis and GitHub Actions but in a similar style. It's also documented, as are the other parts of this system. The invitation to edit is right there.
* node-test-commit-custom-suites-freestyle can stop getting involved in node-test-commit, you can see in my .ci.yml I have a `--worker` test runner in there.
* Alpine can move in to .ci.yml.
* We've resisted "container all the things" in favour of trying to test closer to "native". The biggest problem with container testing everything is that you have no kernel variability, so you miss some permutation coverage. But, I think we might be at the point where we can slide that dial a bit to reduce infra complexity.
  - The most obvious targets for reduction in infra are Fedora, non-LTS Ubuntu, and even Debian. I've also added CentOS in there but am hesitant to suggest whole-hog with CentOS since we build releases on it. node-test-commit-linux could be reduced significantly in favour of containers. We retain a mix but get to control how far we go to one side.
* This could be expanded beyond x86.