### PR TITLE
jenkins: expand ubuntu1604 test to benchmark machines

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -125,7 +125,7 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
   elif [[ "$nodes" =~ centos[67]-64-gcc6 ]]; then
     . /opt/rh/devtoolset-6/enable
     echo "Compiler set to devtoolset-6"
-  elif test $nodes = "ubuntu1604-64"; then
+  elif [[ "$nodes" =~ ubuntu1604-.*64 ]]; then
     if [ "$NODEJS_MAJOR_VERSION" -gt "12" ]; then
       export CC="gcc-6"
       export CXX="g++-6"


### PR DESCRIPTION
Continuing from #1975, the select-compiler.sh addition didn't work for node-test-commit-v8-linux because `$node` is `benchmark-ubuntu1604-intel-64`, so this turns it into a regex. Also, the top of the script in Jenkins for that job had `#/bin/bash` so it was still running Dash and `[[` was causing errors. I added the missing `!` and hopefully that doesn't disrupt anything.