### PR TITLE
Remove Ubuntu 12.04 from CI

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -89,8 +89,6 @@ hosts:
         freebsd10-x64-1: {ip: 159.203.59.134, user: freebsd}
         freebsd11-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd11-x64-2: {ip: 107.170.28.213, user: freebsd}
-        ubuntu1204-x64-1: {ip: 104.236.234.182}
-        ubuntu1204-x64-2: {ip: 107.170.104.83}
         ubuntu1404-x64-1: {ip: 45.55.252.223}
         ubuntu1404-x86-1: {ip: 159.203.115.220}
         ubuntu1604-x86-1: {ip: 159.203.77.233}
@@ -164,7 +162,6 @@ hosts:
         debian8-x64-2: {ip: 104.239.140.184}
         fedora27-x64-1: {ip: 119.9.51.79}
         freebsd10-x64-1: {ip: 119.9.52.218}
-        ubuntu1204-x64-1: {ip: 119.9.51.210}
         ubuntu1604-x64-1: {ip: 119.9.51.176}
         ubuntu1604-x64-2: {ip: 104.130.124.194}
 

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -16,7 +16,6 @@ ssh_config: /etc/ssh/sshd_config
 
 sshd_service_map: {
   'ubuntu1404': 'ssh',
-  'ubuntu1204': 'ssh',
   'smartos17': 'ssh',
   'smartos18': 'ssh',
 }

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -5,11 +5,11 @@
 #
 
 - name: install add-apt-repostory
-  when: os in ("ubuntu1204", "ubuntu1404") and arch != "ppc64"
+  when: os = "ubuntu1404" and arch != "ppc64"
   package: name=software-properties-common state=present
 
 - name: add webupd8 oracle java repository
-  when: os in ("ubuntu1204", "ubuntu1404")  and arch != "ppc64"
+  when: os = "ubuntu1404" and arch != "ppc64"
   apt_repository: repo='ppa:webupd8team/java'
 
 - name: add webupd8team oracle java repository
@@ -24,7 +24,7 @@
   shell: apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
 
 - name: accept webupd8 oracle java 8 license
-  when: os in ("ubuntu1204", "ubuntu1404") and arch != "ppc64" or os == "debian8"
+  when: os = "ubuntu1404" and arch != "ppc64" or os == "debian8"
   debconf: name='oracle-java8-installer' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
 
 - name: update packages
@@ -102,7 +102,7 @@
   when: os|startswith("aix") and java_exists.stat.exists == False
 
 - name: install webupd8 oracle java 8 extras
-  when: java.rc > 0 and os in ("ubuntu1204", "ubuntu1404") and arch != "ppc64"
+  when: java.rc > 0 and os = "ubuntu1404" and arch != "ppc64"
   package: name="{{item}}" state=present
   with_items:
     - ca-certificates

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -17,7 +17,6 @@ packages: {
   'smartos': 'openjdk8',
   'ubuntu': 'openjdk-8-jre-headless',
   'ubuntu1404': 'oracle-java8-installer',
-  'ubuntu1204': 'oracle-java8-installer',
   }
 
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -6,16 +6,16 @@
 
 init: {
   aix: ['aix71', 'aix72'],
-  centos5:  'centos5',
-  centos6:  'centos6',
-  debian:  ['debian7', 'ubuntu1204'],
+  centos5: 'centos5',
+  centos6: 'centos6',
+  debian: 'debian7',
   freebsd: 'freebsd',
-  macos:   'macos',
+  macos: 'macos',
   rhel72: 'rhel72',
   systemd: ['centos7', 'debian8', 'debian9', 'fedora', 'ubuntu1604', 'ubuntu1804'],
-  svc:     'smartos',
+  svc: 'smartos',
   upstart: ['ubuntu12', 'ubuntu1404'],
-  zos_start:   'zos'
+  zos_start: 'zos'
   }
 
 jenkins_init: {

--- a/doc/node-test-commit-matrix.md
+++ b/doc/node-test-commit-matrix.md
@@ -27,7 +27,6 @@ This is assumed correct as of the date of last commit. If you notice a discrepan
     - debian9-64
     - fedora-last-latest-x64
     - fedora-latest-x64
-    - ubuntu1204-64 (Node < 10)
     - ubuntu1404-32 (Node < 10)
     - ubuntu1404-64 (Node < 12)
     - ubuntu1604-32 (Node < 10)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -24,7 +24,6 @@ def buildExclusions = [
   [ /debian8-x86/,                    anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /debian8/,                        anyType,     gte(13) ],
   [ /^ubuntu1804/,                    anyType,     lt(10)  ], // probably temporary
-  [ /^ubuntu1204/,                    anyType,     gte(10) ],
   [ /^ubuntu1404-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only


### PR DESCRIPTION
It's still active for Node 8 testing, which will cease at the end of the year. 12.04 has been out of standard support since 2017 and even left extended (paid) support earlier this year. It's not been as painful as Debian or CentOS but let's remove it anyway.