### PR TITLE
Remove SmartOS 14 from CI

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,7 +36,6 @@ hosts:
         centos7-x64-1: {ip: 138.68.12.105}
 
     - joyent:
-        smartos14-x64-1: {ip: 72.2.113.193}
         smartos15-x64-1: {ip: 72.2.113.195}
         smartos17-x64-1: {ip: 72.2.114.225}
         smartos18-x64-1: {ip: 72.2.119.185}
@@ -102,10 +101,6 @@ hosts:
     - joyent:
         freebsd10-x64-1: {ip: 72.2.115.15}
         freebsd10-x64-2: {ip: 72.2.114.23}
-        smartos14-x64-1: {ip: 72.2.114.47}
-        smartos14-x64-2: {ip: 72.2.115.156}
-        smartos14-x86-1: {ip: 72.2.112.239}
-        smartos14-x86-2: {ip: 72.2.112.29}
         smartos15-x64-1: {ip: 165.225.137.117}
         smartos15-x64-2: {ip: 165.225.139.77}
         smartos16-x64-1: {ip: 72.2.115.252}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -6,7 +6,7 @@
 
 binary_dest: '/usr/local/bin/ccache'
 
-ccache_no_binpkg: ['smartos14', 'smartos15', 'smartos16', 'smartos17']
+ccache_no_binpkg: ['smartos15', 'smartos16', 'smartos17']
 ccache_version: 3.3.2
 
 git_no_binpkg: ['debian7']
@@ -93,11 +93,6 @@ packages: {
     'gmake',
     'xz',
     'sudo',
-  ],
-
-  smartos14: [
-    'gcc48',
-    'gcc48-libs'
   ],
 
   smartos15: [

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -96,7 +96,6 @@ java_path: {
   'macos10.10': 'java',
   'macos10.11': 'java',
   'macos10.12': 'java',
-  'smartos14': '/opt/local/java/openjdk8/bin/java',
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',

--- a/doc/node-test-commit-matrix.md
+++ b/doc/node-test-commit-matrix.md
@@ -41,8 +41,6 @@ This is assumed correct as of the date of last commit. If you notice a discrepan
     - ppcbe-ubuntu1404 (Node < 8)
     - ppcle-ubuntu1404 (Node < 13)
   - **node-test-commit-smartos**
-    - smartos14-32 (Node < 8)
-    - smartos14-64 (Node < 8)
     - smartos15-64 (Node >= 8 < 10)
     - smartos16-64 (Node >= 8 < 12)
     - smartos17-64 (Node >= 10 < 12)

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -46,7 +46,6 @@ def buildExclusions = [
   [ /vs2017/,                         anyType,     lt(10)  ],
 
   // SmartOS -----------------------------------------------
-  [ /^smartos14/,                     anyType,     gte(8)  ],
   [ /^smartos15/,                     anyType,     lt(8)   ],
   [ /^smartos15/,                     anyType,     gte(10) ],
   [ /^smartos16/,                     anyType,     lt(8)   ],

--- a/tools/build-p-ssh-hosts.sh
+++ b/tools/build-p-ssh-hosts.sh
@@ -27,7 +27,6 @@ grep -- 'joyent' hosts/all > hosts/joyent
 grep -- 'release-' hosts/all > hosts/release
 grep -- 'rhel72-s390x' hosts/all > hosts/rhel72-s390x
 grep -- 'smartos' hosts/all > hosts/smartos
-grep -- 'smartos14-x64' hosts/all > hosts/smartos14-x64
 grep -- 'softlayer' hosts/all > hosts/softlayer
 grep -- 'test-' hosts/all > hosts/test
 grep -- 'ubuntu1404-ppc64_be' hosts/all > hosts/ubuntu1404-ppc64_be


### PR DESCRIPTION
Hasn't been needed since Node 6. The last 32-bit SmartOS and saves 5 machines.