### PR TITLE
www: add foundation.nodejs.org redir

### DIFF
--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -169,6 +169,21 @@ server {
 
 server {
     listen *:80;
+    server_name foundation.nodejs.org;
+
+    return 301 https://openjsf.org/;
+}
+
+server {
+    listen *:443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name foundation.nodejs.org;
+
+    return 301 https://openjsf.org/;
+}
+
+server {
+    listen *:80;
     server_name newsletter.nodejs.org;
 
     return 301 http://us14.campaign-archive2.com/home/?u=c7c2e114a827812354112c23b&id=f006b61f29;


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/1953

sanity check please!

We currently have a CNAME for this domain pointing to some LF server that manages it. The plan here is to change it to an A to point to our main server (also proxying via Cloudflare so they'll actually do all the redirecting). Then we get to redirect `foundation.nodejs.org/*` and not worry about redirecting dangling links. i.e. all old /whatever.html URLs will go to openjsf.org/.