### PR TITLE
ansible: prepare jenkins-workspace machines for linting duty

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -225,7 +225,7 @@ hosts:
         ubuntu1604-arm64-2: {ip: 147.75.74.174}
 # when adding, removing or changing the IPs below,
 # remember to update Jenkins worker IP whitelist in github-bot
-        ubuntu1604-x64-1: {ip: 147.75.70.237, alias: jenkins-workspace-1}
+        ubuntu1604-x64-1: {ip: 147.75.70.41, alias: jenkins-workspace-1}
         ubuntu1604-x64-2: {ip: 147.75.73.189, alias: jenkins-workspace-2}
 
     - nearform:

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -68,42 +68,13 @@
   roles:
     - linux-perf
 
-#
-# Set up linter servers
-#
-
-- hosts:
-   - test-joyent-freebsd10-x64-2
-   - test-rackspace-freebsd10-x64-1
-
-  tasks:
-    - name: install lint-related packages
-      package:
-        name: "{{ package }}"
-        state: present
-      loop_control:
-        loop_var: package
-      with_items: [ "node", "npm" ]
-
-    - name: install core-validate-commit
-      npm:
-        name: "core-validate-commit"
-        global: yes
-        state: present
-        production: yes
-
-    - name: periodically update core-validate-commit
-      cron:
-        special_time: daily
-      # ksh does different stdout/err routing
-        job: "npm update -g core-validate-commit > & /dev/null"
-
 # Ensure node is not installed anywhere but the linter servers
 - hosts:
   - test
   - release
-  - "!test-joyent-freebsd10-x64-2"
-  - "!test-rackspace-freebsd10-x64-1"
+  - "!test-packetnet-ubuntu1604-x64-1"
+  - "!test-packetnet-ubuntu1604-x64-2"
+  - "!test-softlayer-ubuntu1604-x64-1"
   tasks:
     - name: remove node and npm packages
       when: not os|startswith("win") and not os|startswith("zos")

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -114,7 +114,7 @@ packages: {
   ],
 
   ubuntu: [
-    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo',
+    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo,python3-pip',
   ],
 
   ubuntu1404: [

--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -106,3 +106,31 @@
   command: "git config gc.auto 0"
   args:
     chdir: "~binary_tmp/binary_tmp.git/"
+
+- name: Add nodesource signing key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Add nodesource repo
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_12.x xenial main
+    state: present
+
+- name: Install node
+  package:
+    name: nodejs
+    state: present
+
+- name: Upgrade pip2
+  pip:
+    name: pip
+    executable: pip2
+    state: latest
+
+- name: Upgrade pip3
+  pip:
+    name: pip
+    executable: pip3
+    state: latest
+


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/2001

Also included this is a reprovisioned jenkins-workspace-1, it started having problems 2 weeks back and has locked up twice now. I just made a new one and re-attached the big network block device we're using for /home from the old one so it's good to go.

I've run this against the hosts, I've also switched the label for the linter job in Jenkins from `linter` to `jenkins-workspace` so they've already taken over duty from the FreeBSD 10 machines which we need to retire.

The script has changed, a few old bits are removed and the BSD-compatibility is gone too:

```sh
#!/bin/bash -ex

# Lint with python3 in new branches
# Refs: https://github.com/nodejs/build/issues/1631
if [[ "$NODEJS_MAJOR_VERSION" -ge "12" ]]; then
  make lint-py-build PYTHON=python3 || true
  make lint-py PYTHON=python3
fi
    
make lint-py-build PYTHON=python2 || true
make lint-ci PYTHON=python2 || { 
  cat test-eslint.tap | grep -v '^ok\|^TAP version 13\|^1\.\.' | sed '/^\s*$/d' && 
  exit 1; }
```