### PR TITLE
ansible,jenkins: remove freebsd10

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -85,7 +85,6 @@ hosts:
         fedora27-x64-1: {ip: 159.203.117.50}
         fedora30-x64-1: {ip: 178.62.236.249}
         fedora30-x64-2: {ip: 159.203.98.84}
-        freebsd10-x64-1: {ip: 159.203.59.134, user: freebsd}
         freebsd11-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd11-x64-2: {ip: 107.170.28.213, user: freebsd}
         ubuntu1404-x64-1: {ip: 45.55.252.223}
@@ -97,8 +96,6 @@ hosts:
         ubuntu1804-x64-1: {ip: 178.128.181.213}
 
     - joyent:
-        freebsd10-x64-1: {ip: 72.2.115.15}
-        freebsd10-x64-2: {ip: 72.2.114.23}
         smartos15-x64-1: {ip: 165.225.137.117}
         smartos15-x64-2: {ip: 165.225.139.77}
         smartos16-x64-1: {ip: 72.2.115.252}
@@ -156,7 +153,6 @@ hosts:
         debian8-x64-1: {ip: 23.253.109.216}
         debian8-x64-2: {ip: 104.239.140.184}
         fedora27-x64-1: {ip: 119.9.51.79}
-        freebsd10-x64-1: {ip: 119.9.52.218}
         ubuntu1604-x64-1: {ip: 119.9.51.176}
         ubuntu1604-x64-2: {ip: 104.130.124.194}
 


### PR DESCRIPTION
Really just in the inventory here, also need to remove from Jenkins jobs, remove the Jenkins node configs and unprovision the resources.