### PR TITLE
www: dist-perms cron.daily script to fix ~dist permissions

### DIFF
--- a/ansible/www-standalone/resources/scripts/dist-perms
+++ b/ansible/www-standalone/resources/scripts/dist-perms
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+find /home/dist/nodejs/ \( -type f -o -type d \) -user dist -mtime +7 -exec chown root.root '{}' \;

--- a/ansible/www-standalone/tasks/site-setup.yaml
+++ b/ansible/www-standalone/tasks/site-setup.yaml
@@ -117,3 +117,12 @@
     - '*  *    * * *   root    /home/nodejs/cdn-purge.sh'
     - '* */4   * * *   nodejs  /home/nodejs/sync-benchmarking.sh'
   tags: setup
+
+- name: Site Setup | Add dist-perms script in cron.daily
+  copy:
+    src: ./resources/scripts/dist-perms
+    dest: /etc/cron.daily/dist-perms
+    mode: 0755
+    owner: root
+    group: root
+  tags: setup


### PR DESCRIPTION
After 5 days change ownership of downloadable resources to `root`, this locks them down and they can't be modified in any way by releasers. I'd like to change this to a shorter window but will wait till after Node 8 is EOL since Node 8 still has a Raspberry Pi builder so has reasonable delays in getting all assets promoted.