### PR TITLE
ansible: metrics server (WIP) & removal of Cloudflare cache bypass

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -14,6 +14,7 @@ hosts:
         ubuntu1604-x64-1: {ip: 138.197.224.240, alias: www}
         ubuntu1804-x64-1: {ip: 178.128.202.158, alias: gzemnid}
         ubuntu1804-x64-2: {ip: 45.55.45.227, alias: unofficial-builds}
+        ubuntu1804-x64-3: {ip: 157.245.7.159, alias: metrics}
 
     - joyent:
         smartos15-x64-1: {ip: 165.225.151.21, alias: backup}

--- a/ansible/playbooks/create-metrics.yml
+++ b/ansible/playbooks/create-metrics.yml
@@ -1,0 +1,12 @@
+---
+
+#
+# sets up the host that runs metrics collection and storage
+#
+
+- hosts: infra-digitalocean-ubuntu1804-x64-3
+  roles:
+    - bootstrap
+    - package-upgrade
+    - baselayout
+    - metrics

--- a/ansible/roles/metrics/README.md
+++ b/ansible/roles/metrics/README.md
@@ -1,0 +1,3 @@
+* Copy secrets/build/infra/gcp-metrics-service-acct-key.json to ~nodejs/
+* As user `nodejs` run `gcloud auth activate-service-account --key-file gcp-metrics-service-acct-key.json`
+* Set up new SSH key with access to root@direct.nodejs.org and root@backup-www.nodejs.org under user `nodejs`

--- a/ansible/roles/metrics/files/process-cloudflare/Dockerfile
+++ b/ansible/roles/metrics/files/process-cloudflare/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-slim
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . ./
+
+CMD ["npm", "run", "processLogs"]

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -4,11 +4,13 @@
   "description": "",
   "main": "process-cloudflare.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "processLogs": "node -e 'require(\"./process-cloudflare.js\").processLogs()'"
   },
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/storage": "^4.7.0",
     "split2": "~3.1.1",
     "strftime": "~0.10.0"
   }

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -5,13 +5,21 @@
   "main": "process-cloudflare.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "processLogs": "node -e 'require(\"./process-cloudflare.js\").processLogs()'"
+    "processLogs": "node process-cloudflare.js"
   },
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
+  "contributors": [
+    "Ash <email@ashleycripps.co.uk>"
+  ],
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/storage": "^4.7.0",
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
     "split2": "~3.1.1",
     "strftime": "~0.10.0"
+  },
+  "devDependencies": {
+    "eslint": "^7.8.1"
   }
 }

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/storage": "^4.7.0",
+    "@google-cloud/storage": "^5.0.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "split2": "~3.1.1",

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "process-cloudflare",
+  "version": "1.0.0",
+  "description": "",
+  "main": "process-cloudflare.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "split2": "~3.1.1",
+    "strftime": "~0.10.0"
+  }
+}

--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+const { pipeline, Transform } = require('stream')
+const split2 = require('split2')
+const strftime = require('strftime').timezone(0)
+
+const jsonStream = new Transform({
+  readableObjectMode: true,
+  transform (chunk, encoding, callback) {
+    try {
+      this.push(JSON.parse(chunk.toString()))
+      callback()
+    } catch (e) {
+      callback(e)
+    }
+  }
+})
+
+const extensionRe = /\.(tar\.gz|tar\.xz|pkg|msi|exe|zip|7z)$/
+const uriRe = /(\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9.]+)[.-]([^? ]+))))/
+const versionRe = /^v[0-9.]+$/
+
+function determineOS (path, file, fileType) {
+  if (/node\.exe$/.test(file)) {
+    return 'win'
+  } else if (/\/node-latest\.tar\.gz$/.test(path)) {
+    return 'src'
+  } else if (fileType == null) {
+    return ''
+  } else if (/msi$/.test(fileType) || /^win-/.test(fileType)) {
+    return 'win'
+  } else if (/^tar\..z$/.test(fileType)) {
+    return 'src'
+  } else if (/^headers\.tar\..z$/.test(fileType)) {
+    return 'headers'
+  } else if (/^linux-/.test(fileType)) {
+    return 'linux'
+  } else if (fileType === 'pkg' || /^darwin-/.test(fileType)) {
+    return 'osx'
+  } else if (/^sunos-/.test(fileType)) {
+    return 'sunos'
+  } else if (/^aix-/.test(fileType)) {
+    return 'aix'
+  } else {
+    return ''
+  }
+}
+
+function determineArch (fileType, winArch, os) {
+  if (fileType != null) {
+    if (fileType.indexOf('x64') >= 0 || fileType === 'pkg') {
+      // .pkg for Node.js <= 0.12 were universal so may be used for either x64 or x86
+      return 'x64'
+    } else if (fileType.indexOf('x86') >= 0) {
+      return 'x86'
+    } else if (fileType.indexOf('armv6') >= 0) {
+      return 'armv6l'
+    } else if (fileType.indexOf('armv7') >= 0) { // 4.1.0 had a misnamed binary, no 'l' in 'armv7l'
+      return 'armv7l'
+    } else if (fileType.indexOf('arm64') >= 0) {
+      return 'arm64'
+    } else if (fileType.indexOf('ppc64le') >= 0) {
+      return 'ppc64le'
+    } else if (fileType.indexOf('ppc64') >= 0) {
+      return 'ppc64'
+    } else if (fileType.indexOf('s390x') >= 0) {
+      return 's390x'
+    }
+  }
+
+  if (os === 'win') {
+    // we get here for older .msi files and node.exe files
+    if (winArch && winArch.indexOf('x64') >= 0) {
+      // could be 'x64' or 'win-x64'
+      return 'x64'
+    } else {
+      // could be 'win-x86' or ''
+      return 'x86'
+    }
+  }
+
+  return ''
+}
+
+const logTransformStream = new Transform({
+  writableObjectMode: true,
+  transform (chunk, encoding, callback) {
+    if (chunk.ClientRequestMethod !== 'GET' ||
+        chunk.EdgeResponseStatus < 200 ||
+        chunk.EdgeResponseStatus >= 300) {
+      return callback()
+    }
+
+    if (chunk.EdgeResponseBytes < 1024) { // unreasonably small for something we want to measure
+      return callback()
+    }
+
+    if (!extensionRe.test(chunk.ClientRequestPath)) { // not a file we care about
+      return callback()
+    }
+
+    const requestPath = chunk.ClientRequestPath.replace(/\/\/+/g, '/')
+    const uriMatch = requestPath.match(uriRe)
+    if (!uriMatch) { // what is this then?
+      return callback()
+    }
+
+    const path = uriMatch[1]
+    const pathVersion = uriMatch[4]
+    const file = uriMatch[5]
+    const winArch = uriMatch[6]
+    const fileVersion = uriMatch[8]
+    const fileType = uriMatch[9]
+
+    let version = ''
+    // version can come from the filename or the path, filename is best
+    // but it may not be there (e.g. node.exe) so fall back to path version
+    if (versionRe.test(fileVersion)) {
+      version = fileVersion
+    } else if (versionRe.test(pathVersion)) {
+      version = pathVersion
+    }
+
+    const os = determineOS(path, file, fileType)
+    const arch = determineArch(fileType, winArch, os)
+
+    const line = []
+    line.push(strftime('%Y-%m-%d', new Date(chunk.EdgeStartTimestamp / 1000 / 1000))) // date
+    line.push(chunk.ClientCountry.toUpperCase()) // country
+    line.push('') // state/province, derived from chunk.EdgeColoCode probably
+    line.push(chunk.ClientRequestPath) // URI
+    line.push(version) // version
+    line.push(os) // os
+    line.push(arch) // arch
+    line.push(chunk.EdgeResponseBytes)
+
+    this.push(`${line.join(',')}\n`)
+
+    callback()
+  }
+})
+
+pipeline(
+  process.stdin,
+  split2(),
+  jsonStream,
+  logTransformStream,
+  process.stdout,
+  (err) => {
+    if (err) {
+      console.error('ERROR', err)
+      process.exit(1)
+    }
+  }
+)

--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -4,6 +4,11 @@ const { pipeline, Transform } = require('stream')
 const split2 = require('split2')
 const strftime = require('strftime').timezone(0)
 const {Storage} = require('@google-cloud/storage');
+const express = require('express');
+const bodyParser = require('body-parser');
+const app = express();
+
+app.use(bodyParser.json());
 
 const storage = new Storage({keyFilename: "metrics-processor-service-key.json"});
 
@@ -144,32 +149,77 @@ const logTransformStream = new Transform({
 })
 
 
-exports.processLogs = (data, context, callback) => {
+async function processLogs (bucket, filename) {
   console.log('Node version is: ' + process.version);
-  const file = data;
-  bucketName = file.bucket;
-  fileName = file.name;
-  console.log("DATA " + data);
-  console.log("BUCKET " + bucketName);
-  console.log("FILENAME " + fileName);
-  processedFile = fileName.split(".")[0];
+  console.log("BUCKET " + bucket);
+  console.log("FILENAME " + filename);
+  let processedFile = filename.split(".")[0];
   processedFile = processedFile.split("_")[0].concat("_", processedFile.split("_")[1]); 
   console.log("PROCESSEDFILENAME " + processedFile);
 
-  pipeline(
-    storage.bucket(bucketName).file(file.name).createReadStream(),
-    split2(),
-    jsonStream,
-    logTransformStream,
-    storage.bucket('processed-logs-nodejs').file(processedFile).createWriteStream({resumable: false}),
-    (err) => {
-      if (err) {
-        console.log("PIPELINE HAS FAILED", err)
-        callback(err)
-      } else {
-        console.log("PIPELINE SUCCESS")
-        callback()
-      }
-    }
-  )
-}
+
+  return new Promise((resolve, reject) => {
+      pipeline(
+        storage.bucket(bucket).file(filename).createReadStream()
+        .on("close", () => {
+          console.log("Stream closed");
+        }),
+        split2(),
+        jsonStream,
+        logTransformStream,
+        storage.bucket('processed-logs-nodejs').file(processedFile).createWriteStream({ resumable: false }),
+        (err) => {
+          if (err) {
+            console.log("PIPELINE HAS FAILED", err)
+            reject();
+          } else {
+            console.log("PIPELINE SUCCESS")
+            resolve();
+          }
+        }
+      )
+    })
+  }
+
+
+app.post('/', async (req, res) => {
+
+  if (!req.body) {
+    const msg = "No Pub/Sub Message received";
+    console.error(msg);
+    res.status(400).send("Bad Request: " + msg);
+    return;
+  }
+  if (!req.body.message) {
+    const msg = 'invalid Pub/Sub message format';
+    console.error(`error: ${msg}`);
+    res.status(400).send(`Bad Request: ${msg}`);
+    return;
+  }
+
+  const eventType = req.body.message.attributes.eventType;
+
+  if (eventType != "OBJECT_FINALIZE"){
+    const msg = `Event type is ${eventType} not OBJECT_FINALIZE`;
+    console.error(`error ${msg}`);
+    res.status(400).send(`Bad Request: ${msg}`);
+    return;
+  }
+
+  const bucket = req.body.message.attributes.bucketId;
+  const filename = req.body.message.attributes.objectId;
+  
+  console.log("EVENT TYPE: ", eventType);
+
+  await processLogs(bucket, filename);
+
+  res.status(204).send();
+  
+});
+
+const port = process.env.PORT || 8080;
+app.listen(port, () => {
+  console.log("Listening on port: ", port);
+});
+
+module.exports = app;

--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -161,7 +161,7 @@ async function processLogs (bucket, filename) {
 
   return new Promise((resolve, reject) => {
     pipeline(
-      storage.bucket(bucket).file(filename).createReadStream()
+      storage.bucket(bucket).file(filename).createReadStream({ emitClose: true })
       .on("close", () => {
         console.log("Stream closed");
       })
@@ -171,8 +171,8 @@ async function processLogs (bucket, filename) {
       split2(),
       jsonStream,
       logTransformStream,
-      //storage.bucket('processed-logs-nodejs').file(processedFile).createWriteStream({ resumable: false }),
-      process.stdout
+      storage.bucket('processed-logs-nodejs').file(processedFile).createWriteStream({ resumable: false })
+      //process.stdout
       .on("end", () => {
         console.log("FINISHED");
       }),

--- a/ansible/roles/metrics/files/process-cloudflare/summaries.js
+++ b/ansible/roles/metrics/files/process-cloudflare/summaries.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+// data example:
+//
+// day,country,region,path,version,os,arch,bytes
+// 2019-10-31,US,,/dist/v13.0.1/node-v13.0.1-linux-x64.tar.xz,v13.0.1,linux,x64,20102340
+//
+
+const { pipeline, Transform } = require('stream')
+const split2 = require('split2')
+
+const csvStream = new Transform({
+  readableObjectMode: true,
+  transform (chunk, encoding, callback) {
+    try {
+      const schunk = chunk.toString()
+      if (!schunk.startsWith('day,country')) { // ignore header
+        this.push(schunk.split(','))
+      }
+      callback()
+    } catch (e) {
+      callback(e)
+    }
+  }
+})
+
+const counts = { bytes: 0, total: 0 }
+function increment (type, key) {
+  if (!key) {
+    key = 'unknown'
+  }
+
+  if (!counts[type]) {
+    counts[type] = {}
+  }
+
+  if (counts[type][key] === undefined) {
+    counts[type][key] = 1
+  } else {
+    counts[type][key]++
+  }
+}
+
+function prepare () {
+  function sort (type) {
+    const ca = Object.entries(counts[type])
+    ca.sort((e1, e2) => e2[1] > e1[1] ? 1 : e2[1] < e1[1] ? -1 : 0)
+    counts[type] = ca.reduce((p, c) => {
+      p[c[0]] = c[1]
+      return p
+    }, {})
+  }
+
+  'country version os arch'.split(' ').forEach(sort)
+}
+
+const summaryStream = new Transform({
+  writableObjectMode: true,
+  transform (chunk, encoding, callback) {
+    const [date, country, region, path, version, os, arch, bytes] = chunk
+    increment('country', country)
+    increment('version', version)
+    increment('os', os)
+    increment('arch', arch)
+    counts.bytes += parseInt(bytes, 10)
+    counts.total++
+    callback()
+  }
+})
+
+pipeline(
+  process.stdin,
+  split2(),
+  csvStream,
+  summaryStream,
+  (err) => {
+    prepare()
+    console.log(JSON.stringify(counts, null, 2))
+    if (err) {
+      console.error('ERROR', err)
+      process.exit(1)
+    }
+  }
+)

--- a/ansible/roles/metrics/files/sync-backup-www-periodic.service
+++ b/ansible/roles/metrics/files/sync-backup-www-periodic.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic log sync from backup-www.nodejs.org
+
+[Service]
+Type=oneshot
+User=nodejs
+ExecStart=/usr/bin/rsync -e "ssh" -aqz root@backup-www.nodejs.org:/var/log/nginx/ /home/nodejs/logs/backup-www.nodejs.org/
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/files/sync-backup-www-periodic.timer
+++ b/ansible/roles/metrics/files/sync-backup-www-periodic.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Schedule periodic backup-www sync
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=true
+OnBootSec=300
+RandomizedDelaySec=300
+OnUnitActiveSec=3600
+Unit=sync-backup-www-periodic.service
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/files/sync-cloudflare-periodic.service
+++ b/ansible/roles/metrics/files/sync-cloudflare-periodic.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic log sync from cloudflare
+
+[Service]
+Type=oneshot
+User=nodejs
+ExecStart=/usr/bin/gsutil rsync -d -r gs://cloudflare-logs-nodejs/ /home/nodejs/logs/cloudflare/
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/files/sync-cloudflare-periodic.timer
+++ b/ansible/roles/metrics/files/sync-cloudflare-periodic.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Schedule periodic cloudflare sync
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=true
+OnBootSec=300
+RandomizedDelaySec=300
+OnUnitActiveSec=3600
+Unit=sync-cloudflare-periodic.service
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/files/sync-www-periodic.service
+++ b/ansible/roles/metrics/files/sync-www-periodic.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic log sync from nodejs.org
+
+[Service]
+Type=oneshot
+User=nodejs
+ExecStart=/usr/bin/rsync -e "ssh" -aqz root@direct.nodejs.org:/var/log/nginx/ /home/nodejs/logs/nodejs.org/
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/files/sync-www-periodic.timer
+++ b/ansible/roles/metrics/files/sync-www-periodic.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Schedule periodic www sync
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=true
+OnBootSec=300
+RandomizedDelaySec=300
+OnUnitActiveSec=3600
+Unit=sync-www-periodic.service
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/metrics/tasks/main.yml
+++ b/ansible/roles/metrics/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+
+- name: Bootstrap | Add nodesource signing key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Bootstrap | Add nodesource repo
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_12.x bionic main
+    state: present
+
+- name: GCP | Install GCP APT key
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    keyring: /usr/share/keyrings/cloud.google.gpg
+
+- name: GCP | Install GCP APT repository
+  apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main"
+    state: present
+
+- name: Bootstrap | APT Update and upgrade
+  apt:
+    update_cache: yes
+    upgrade: full
+
+- name: Bootstrap | Install packages
+  package:
+    name: "{{ package }}"
+    state: present
+  loop_control:
+    loop_var: package
+  with_items: "{{ packages }}"
+
+- name: Bootstrap | Enable time syncing
+  service:
+    name: systemd-timesyncd
+    state: started
+    enabled: yes
+
+- name: Boostrap | Add nodejs user
+  user:
+    name: "nodejs"
+    shell: /bin/bash
+
+- name: Init | Create required directories
+  file:
+    path: "/home/nodejs/{{ item }}"
+    state: directory
+    mode: 0755
+    owner: "nodejs"
+  with_items:
+    - logs/nodejs.org/
+    - logs/backup-www.nodejs.org/
+    - logs/cloudflare/
+    - bin/process-cloudflare/
+
+- name: Cloudflare | Copy process-cloudflare
+  copy:
+    src: "{{ role_path }}/files/process-cloudflare/{{ item }}"
+    dest: /home/nodejs/bin/process-cloudflare/
+    owner: "nodejs"
+    group: "nodejs"
+    mode: 0755
+  with_items:
+    - process-cloudflare.js
+    - package.json
+
+- name: Cloudflare | Install process-cloudflare dependencies
+  command: npm install
+  args:
+    chdir: /home/nodejs/bin/process-cloudflare/
+
+- name: Periodic | Copy periodic service unit
+  copy:
+    src: "{{ role_path }}/files/sync-{{ item }}-periodic.service"
+    dest: /lib/systemd/system/sync-{{ item }}-periodic.service
+    owner: "nodejs"
+    group: "nodejs"
+  with_items:
+    - www
+    - backup-www
+    - cloudflare
+
+- name: Periodic | Copy periodic timer unit
+  copy:
+    src: "{{ role_path }}/files/sync-{{ item }}-periodic.timer"
+    dest: /lib/systemd/system/sync-{{ item }}-periodic.timer
+    owner: "nodejs"
+    group: "nodejs"
+  with_items:
+    - www
+    - backup-www
+    - cloudflare
+
+- name: Periodic | Register periodic runner
+  systemd:
+    name: sync-{{ item }}-periodic.timer
+    state: started
+    enabled: yes
+  with_items:
+    - www
+    - backup-www
+    - cloudflare
+
+- name: End
+  debug:
+    msg: SEE roles/metrics/README.md FOR ADDITIONAL STEPS TO AUTHORIZED `gsutil` TO FETCH CLOUDFLARE LOGS

--- a/ansible/roles/metrics/vars/main.yml
+++ b/ansible/roles/metrics/vars/main.yml
@@ -1,0 +1,4 @@
+---
+packages:
+  - nodejs
+  - google-cloud-sdk


### PR DESCRIPTION
(This is a WIP and may not end up being merged, explained below)

## Background

https://github.com/nodejs/build/issues/1993 - we need to ditch our CDN bypasses on nodejs.org. We bypass for most /dist and /download URIs so we can serve fully from Cloudflare. Our primary server has been having problems serving the content (apparently, and it could have been specific hardware, our droplet has been migrated to new hardware but we won't be able to try out a new peak traffic until Monday or Tuesday US time).

We have bypasses in place so we can collect download metrics. I made a major push to get log collection from Cloudflare a couple of years ago but I could never get it stable enough to have assurance that we were going to reliably collect all of the logs and not miss out. See https://github.com/nodejs/build/pull/987 for some of that work.

Cloudflare now have a "logpush" service where they take care of offloading log files onto a block storage service you manage. We've enabled this and @jbergstroem has set up a GCP Storage bucket we control which is collecting logs (he's currently donating this personally but we should try and get donation of credits from either GCP or Azure at some point).

## What this is

I've been working to verify that the logs we are collecting replace what we have now and we're not missing out on any fields or having any other weirdness that might surprise us later when we dig in properly.

This config is for a dedicated metrics server that I have running. It's collecting all logs from both of or servers and from the GCP bucket. I've translated some of my [original AWK scripts](https://github.com/nodejs/build/tree/master/ansible/www-standalone/tools/metrics) to JavaScript and have some very basic processing utilities in this PR. I can process the Cloudflare logs and produce the same data as in https://nodejs.org/metrics/logs/ and there's a utility in here to print a basic JSON summary of a given set of input. This is a precursor to what's needed to start producing the summaries @ https://nodejs.org/metrics/summaries/, but can come later.

## Comparing our logs to Cloudflare logs

So, regarding assurance that we're collecting the data we need so we can make a switch. Comparing the log summaries for both the 29th and the 30th of October I have discrepancies, but they are not massive. We show _more_ downloads and even more bytes from our servers than Cloudflare is recording.

The total download count for Cloudflare are 99.76% of that we have on our servers, the total bytes is 96.07%. The count differential could be accounted for by cancels I think. Perhaps it's connections that hit CF, CF downloads from one of our servers but the client cancels and our server has sent the data to CF before it can cancel on our side. Date differences could play a small role too, the timestamp we're using from CF is the original connection time of the client. I'm not sure what nginx uses but it'd be slightly delayed in any case so we might not have the day boundaries quite right. The bytes differential could perhaps be accounted for by compression but that's a wild guess, I don't know what CF does with already-compressed resources.

The days I'm comparing were days with outages reported by users so there's a good chance that's having an impact on discrepancies.

## Next steps

I _think_ I'm satisfied that the data is good enough to make a switch and get rid of the bypass. I wouldn't mind collecting a clean (outage free) day over the weekend and making another comparison just to reassure myself. I can share results if anyone's particularly interested. It would also be good to make a switch-over before the US work week. So please interject if you'd like to participate in this decision.

Metrics generation for https://nodejs.org/metrics/ will have to pause, we won't have the pieces hooked up. I don't think that's critical as any problems with that site don't tend to get reported quickly so I don't think many people keep a keen eye on it. But the scripts here are part way to restoring that. The cut-over point will have to be carefully calibrated though so we don't get double-ups.

@jbergstroem has suggested we do at least some of this log processing on GCP workers (or Cloudflare workers? I'm not sure exactly what the idea here is). That would be great because the logs we're collecting have way more data than we need for just /dist/ and /download/ right now. So maybe we modernise this while we're messing with it and make a small step toward getting specialised work off our primary server. So this PR doesn't necessarily have to be merged, it could be a temporary arrangement until we get the rest sorted out.