### PR TITLE
ansible: Remove reference to ubuntu-ppcbe

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -52,9 +52,6 @@ def buildExclusions = [
   [ /^smartos17/,                     anyType,     gte(12) ],
   [ /^smartos18/,                     anyType,     lt(12)  ],
 
-  // PPC BE ------------------------------------------------
-  [ /^ppcbe-ubuntu/,                  anyType,     gte(8)  ],
-
   // s390x -------------------------------------------------
   [ /s390x/,                          anyType,     lt(6)   ],
 


### PR DESCRIPTION
VersionSelectorScript references to ppcbe-ubuntu but I cant seem to find any machines that are be on [the ci](https://ci.nodejs.org/view/Node.js%20Daily/search/?q=ppc&Jenkins-Crumb=694d0b10d1b3d22c4e1a15a0786364c7773582a58c4a2bc274c17773926aa0b6) only le.

so can this line be removed?