### PR TITLE
www: fix /dist permissions fixer, ignore top-level directories

### DIFF
--- a/ansible/www-standalone/resources/scripts/dist-perms
+++ b/ansible/www-standalone/resources/scripts/dist-perms
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-find /home/dist/nodejs/ \( -type f -o -type d \) -user dist -mtime +7 -exec chown root.root '{}' \;
+find /home/dist/nodejs/ -mindepth 2 \( -type f -o -type d \) -user dist -mtime +7 -exec chown root.root '{}' \;


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/pull/2020#issuecomment-549964893

`-mindepth 2` excludes the top directories, including `/home/dist/nodejs/release/` which is what's caused the problem with 13.1.0.