### PR TITLE
www: don't change perms of index.(tab|json)

### DIFF
--- a/ansible/www-standalone/resources/scripts/dist-perms
+++ b/ansible/www-standalone/resources/scripts/dist-perms
@@ -1,3 +1,10 @@
 #!/bin/sh
 
-find /home/dist/nodejs/ -mindepth 2 \( -type f -o -type d \) -user dist -mtime +7 -exec chown root.root '{}' \;
+find /home/dist/nodejs/ \
+  -mindepth 2 \
+  \( -type f -o -type d \) \
+  -regextype posix-extended \
+  ! -regex '/home/dist/nodejs/[a-z0-9-]*/index.(tab|json)' \
+  -user dist \
+  -mtime +7 \
+  -exec chown root.root '{}' \;


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/2032

Getting a little complicated but hopefully that's enough. There's symlinks that are changed with `nodejs-latest-linker` but this should just match files and directories so they should be fine.
