### PR TITLE
Python: Avoid bare exceptions in country-lookup.py

### DIFF
--- a/ansible/www-standalone/tools/metrics/country-lookup.py
+++ b/ansible/www-standalone/tools/metrics/country-lookup.py
@@ -28,7 +28,7 @@ for row in logFileReader:
         country = georec.country.iso_code
       if georec.subdivisions.most_specific.iso_code:
         region = georec.subdivisions.most_specific.iso_code
-  except:
+  except Exception:
     pass
 
   row.insert(1, country.encode('utf-8'))


### PR DESCRIPTION
The problem with these is that you can put a syntax error in between the try: and except: and it will be extremely difficult to spot.  This is discussed in PEP8, Zen of Python, and many other places.