### PR TITLE
jenkins: edit test-commit-diagnostics.sh to solve missing pgrep

### DIFF
--- a/jenkins/scripts/node-test-commit-diagnostics.sh
+++ b/jenkins/scripts/node-test-commit-diagnostics.sh
@@ -39,4 +39,11 @@ mv ${DIAGFILE} ${DIAGFILE}-OLD || true
 tail -c 20000000 ${DIAGFILE}-OLD > ${DIAGFILE} || true
 rm ${DIAGFILE}-OLD || true
 set -x
-pgrep node || true
+perl -MFile::Basename -e '
+  my @r = ();
+  for (qx[ps ax]) {
+    my @F = split;
+    push @r, $F[0] if $F[4] && basename($F[4]) eq "node"
+  }
+  print "@r\n" if @r
+' || true

--- a/jenkins/scripts/node-test-commit-diagnostics.sh
+++ b/jenkins/scripts/node-test-commit-diagnostics.sh
@@ -46,4 +46,4 @@ perl -MFile::Basename -e '
     push @r, $F[0] if $F[4] && basename($F[4]) eq "node"
   }
   print "@r\n" if @r
-' || true
+'


### PR DESCRIPTION
resolves https://github.com/nodejs/build/issues/1859 using https://github.com/nodejs/build/issues/1859#issuecomment-507563309

This gets around AIX not having pgrep but does imply that all other build machines that use this script have perl installed which me and @sam-github are not sure of.
