### PR TITLE
fix select-compiler.sh for V8 CI

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -133,7 +133,7 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       . /opt/rh/devtoolset-6/enable
       echo "Compiler set to devtoolset-6"
       ;;
-    ubuntu1604-*64 )
+    *ubuntu1604-*64 )
       if [ "$NODEJS_MAJOR_VERSION" -gt "12" ]; then
         export CC="gcc-6"
         export CXX="g++-6"


### PR DESCRIPTION
Fix the `select-compiler.sh` script for `node-test-commit-v8-linux` which runs on
`benchmark-ubuntu1604-intel-64`.

Refs: https://github.com/nodejs/build/pull/1985
Refs: https://github.com/nodejs/build/pull/1994

Seen in https://ci.nodejs.org/view/All/job/node-test-commit-v8-linux/nodes=benchmark-ubuntu1604-intel-64,v8test=v8test/2622/console that gcc 6 wasn't picked:
```console
09:50:09 ++ echo 'Setting compiler for Node version 14 on x64'
09:50:09 Setting compiler for Node version 14 on x64
09:50:09 ++ case $nodes in
09:50:09 + rm deps/v8/test/mjsunit/d8-os.js
09:50:09 rm: cannot remove 'deps/v8/test/mjsunit/d8-os.js': No such file or directory
09:50:09 + true
09:50:09 + ./configure
09:50:11 Node configure: Found Python 3.5.2...
09:50:11 WARNING: C++ compiler (CXX=g++, 5.5.0) too old, need g++ 6.3.0 or clang++ 8.0.0
```