### PR TITLE
add `benchmark` to select-compiler.sh

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -133,7 +133,7 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       . /opt/rh/devtoolset-6/enable
       echo "Compiler set to devtoolset-6"
       ;;
-    *ubuntu1604-*64 )
+    *ubuntu1604-*64|benchmark )
       if [ "$NODEJS_MAJOR_VERSION" -gt "12" ]; then
         export CC="gcc-6"
         export CXX="g++-6"


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/30363

Guesswork, as I don't have access to [infra-softlayer-ubuntu1404-x64-2](https://ci.nodejs.org/computer/infra-softlayer-ubuntu1404-x64-2/).
Doesn't work yet: https://github.com/nodejs/node/issues/30363#issuecomment-553926151