### PR TITLE
ansible: add new AIX7.1 machines to CI

### DIFF
--- a/ansible/aix61-standalone/manualBootstrap.md
+++ b/ansible/aix61-standalone/manualBootstrap.md
@@ -9,7 +9,7 @@ modules will be installed.
 ```bash
 chfs -a size=+1300000 /opt
 chfs -a size=+250000 /
-chfs -a size=+917504 /tmp
+chfs -a size=917504 /tmp
 ```
 
 For the systems without ramdisks `/home` needs to be set to the same size as `/home/iojs/build` would be on a ramdisk machine
@@ -62,9 +62,8 @@ Most packages should be installed via ansible.
 
 If there are any missing they should be installed via yum
 
-What you do need to install manually is **gcc** and **ccache**
+What you do need to install manually is **ccache**
 
-## gcc 6.3.x on AIX 7.2
 
 ```bash
 mkdir -p /opt/gcc-6.3 && cd /opt/gcc-6.3
@@ -79,7 +78,7 @@ curl -L https://ci.nodejs.org/downloads/aix/ccache-3.7.4.aix7.2.ppc.tar.gz | /op
 ```
 ## Enable the AHA fs
 
-For AIX 7.2 and 6.1, needed for the file watcher unit tests.
+For AIX 7 and 6.1, needed for the file watcher unit tests.
 
 Add the following to /etc/filesystems:
 
@@ -115,24 +114,6 @@ installp -aXgd ./ -e /tmp/install.log all
 4. Find compilers in `/opt/IBM/xl[cC]/16.1.0/bin/`
 
 
-
-#### tap2junit
-
-Should be installed via ansible but if needed to be done manually use the following:
-
-AIX72:
-```
-  python  -m pip install --upgrade pip pipenv git+https://github.com/nodejs/tap2junit
-  python3 -m pip install --upgrade pip pipenv git+https://github.com/nodejs/tap2junit
-  ln -s /opt/freeware/bin/tap2junit /usr/bin/tap2junit
-```
-
-Note: probably only the py3 was needed
-
-```bash
-python -m pip install --upgrade pip pipenv git+https://github.com/nodejs/tap2junit.git
-ln -s /opt/freeware/bin/tap2junit /usr/bin/tap2junit
-```
 
 
 # AIX 6.1 Install

--- a/ansible/aix61-standalone/manualBootstrap.md
+++ b/ansible/aix61-standalone/manualBootstrap.md
@@ -76,6 +76,7 @@ curl -L https://ci.nodejs.org/downloads/aix/gcc-6.3-aix7.2.ppc.tar.gz | /opt/fre
 mkdir -p /opt/ccache-3.7.4 && cd /opt/ccache-3.7.4
 curl -L https://ci.nodejs.org/downloads/aix/ccache-3.7.4.aix7.2.ppc.tar.gz | /opt/freeware/bin/tar -xzf -
 ```
+
 ## Enable the AHA fs
 
 For AIX 7 and 6.1, needed for the file watcher unit tests.
@@ -333,8 +334,6 @@ tar -xf gmake-dep.tar
 
 
 ## Install python3
-
-AIX72: uneeded, installed by yum
 
 ```bash
 mkdir /tmp/i-files

--- a/ansible/aix61-standalone/manualBootstrap.md
+++ b/ansible/aix61-standalone/manualBootstrap.md
@@ -35,6 +35,27 @@ it with a cron job, use `crontab -e`, and add one line:
 0 12 * * * /usr/bin/rm -f /etc/security/failedlogin
 ```
 
+## Fix "Missing" shared objects
+
+On the 7.1 machines we were facing this issues when yum installed packages were not able to find some of the shared objects they needed
+
+```sh
+bash-5.0$ gmake -v
+exec(): 0509-036 Cannot load program gmake because of the following errors:
+        0509-022 Cannot load module /opt/freeware/lib/libintl.a(libintl.so.8).
+        0509-150   Dependent module /usr/lib/libiconv.a(libiconv.so.2) could not be loaded.
+        0509-152   Member libiconv.so.2 is not found in archive
+        0509-022 Cannot load module make_64.
+        0509-150   Dependent module /opt/freeware/lib/libintl.a(libintl.so.8) could not be loaded.
+        0509-022 Cannot load module .
+```
+
+The fix is as following:
+
+```sh
+sudo rm /usr/lib/libiconv.a && sudo ln -s /opt/freeware/bin/libiconv.a /usr/lib
+```
+
 # AIX 7.2 Install
 
 Most packages should be installed via ansible.

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -71,7 +71,7 @@ hosts:
     - marist:
         zos13-s390x-1: {ip: 148.100.36.135, user: Unix1}
 
-    - pcc:
+    - ibm:
         aix71-ppc64_be-1: {ip: 129.33.196.199, user: b9s010a}
 
   - test:
@@ -134,7 +134,7 @@ hosts:
         win10-arm64-1: { vs: '2017' }
         win10-arm64-2: { vs: '2017' }
 
-    - pcc:
+    - ibm:
         aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
         aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -135,7 +135,7 @@ hosts:
         aix72-ppc64_be-1: {ip: 129.33.196.193, user: b9s010a}
         aix72-ppc64_be-2: {ip: 129.33.196.194, user: b9s010a}
         aix72-ppc64_be-3: {ip: 129.33.196.195, user: b9s010a}
-        #aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
+        aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
 
     - osuosl:
 # secret for -1 was compromised, do not use -1 name

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -71,6 +71,9 @@ hosts:
     - marist:
         zos13-s390x-1: {ip: 148.100.36.135, user: Unix1}
 
+    - pcc:
+        aix71-ppc64_be-1: {ip: 129.33.196.199, user: b9s010a}
+
   - test:
 
     - azure:
@@ -131,14 +134,9 @@ hosts:
         win10-arm64-1: { vs: '2017' }
         win10-arm64-2: { vs: '2017' }
 
-    - ibm:
-        aix72-ppc64_be-1: {ip: 129.33.196.193, user: b9s010a}
-        aix72-ppc64_be-2: {ip: 129.33.196.194, user: b9s010a}
-        aix72-ppc64_be-3: {ip: 129.33.196.195, user: b9s010a}
-        aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
+    - pcc:
         aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
         aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
-        aix71-ppc64_be-3: {ip: 129.33.196.199, user: b9s010a}
 
 
     - osuosl:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -131,6 +131,12 @@ hosts:
         win10-arm64-1: { vs: '2017' }
         win10-arm64-2: { vs: '2017' }
 
+    - ibm:
+        aix72-ppc64_be-1: {ip: 129.33.196.193, user: b9s010a}
+        aix72-ppc64_be-2: {ip: 129.33.196.194, user: b9s010a}
+        aix72-ppc64_be-3: {ip: 129.33.196.195, user: b9s010a}
+        aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
+
     - osuosl:
 # secret for -1 was compromised, do not use -1 name
         aix72-ppc64_be-2: {ip: 140.211.9.30}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -34,6 +34,9 @@ hosts:
         centos6-x86-1: {ip: 162.243.248.28}
         centos7-x64-1: {ip: 138.68.12.105}
 
+    - ibm:
+        aix71-ppc64_be-1: {ip: 129.33.196.199, user: b9s010a}
+
     - joyent:
         smartos15-x64-2: {ip: 165.225.148.139}
         smartos17-x64-2: {ip: 165.225.149.208}
@@ -71,9 +74,6 @@ hosts:
     - marist:
         zos13-s390x-1: {ip: 148.100.36.135, user: Unix1}
 
-    - ibm:
-        aix71-ppc64_be-1: {ip: 129.33.196.199, user: b9s010a}
-
   - test:
 
     - azure:
@@ -94,6 +94,10 @@ hosts:
         ubuntu1804_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
+
+    - ibm:
+        aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
+        aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
 
     - joyent:
         smartos15-x64-3: {ip: 165.225.148.128}
@@ -133,10 +137,6 @@ hosts:
     - msft:
         win10-arm64-1: { vs: '2017' }
         win10-arm64-2: { vs: '2017' }
-
-    - ibm:
-        aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
-        aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
 
 
     - osuosl:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -135,7 +135,7 @@ hosts:
         aix72-ppc64_be-1: {ip: 129.33.196.193, user: b9s010a}
         aix72-ppc64_be-2: {ip: 129.33.196.194, user: b9s010a}
         aix72-ppc64_be-3: {ip: 129.33.196.195, user: b9s010a}
-        aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
+        #aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
 
     - osuosl:
 # secret for -1 was compromised, do not use -1 name

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -136,6 +136,10 @@ hosts:
         aix72-ppc64_be-2: {ip: 129.33.196.194, user: b9s010a}
         aix72-ppc64_be-3: {ip: 129.33.196.195, user: b9s010a}
         aix72-ppc64_be-4: {ip: 129.33.196.196, user: b9s010a}
+        aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
+        aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
+        aix71-ppc64_be-3: {ip: 129.33.196.199, user: b9s010a}
+
 
     - osuosl:
 # secret for -1 was compromised, do not use -1 name

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -48,7 +48,7 @@ valid = {
     'provider': ('azure', 'digitalocean', 'joyent', 'linuxonecc',
                  'macstadium', 'marist', 'mininodes', 'msft', 'osuosl',
                  'rackspace', 'requireio', 'scaleway', 'softlayer', 'voxer',
-                 'packetnet', 'pcc', 'nearform')
+                 'packetnet', 'ibm', 'nearform')
 }
 DECRYPT_TOOL = "gpg"
 INVENTORY_FILENAME = "inventory.yml"

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -45,10 +45,10 @@ valid = {
     'type': ('infra', 'release', 'test'),
 
     # providers - validated for consistency
-    'provider': ('azure', 'digitalocean', 'joyent', 'ibm', 'linuxonecc',
+    'provider': ('azure', 'digitalocean', 'joyent', 'linuxonecc',
                  'macstadium', 'marist', 'mininodes', 'msft', 'osuosl',
                  'rackspace', 'requireio', 'scaleway', 'softlayer', 'voxer',
-                 'packetnet', 'nearform')
+                 'packetnet', 'pcc', 'nearform')
 }
 DECRYPT_TOOL = "gpg"
 INVENTORY_FILENAME = "inventory.yml"

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -45,10 +45,10 @@ valid = {
     'type': ('infra', 'release', 'test'),
 
     # providers - validated for consistency
-    'provider': ('azure', 'digitalocean', 'joyent', 'linuxonecc',
+    'provider': ('azure', 'digitalocean', 'ibm', 'joyent', 'linuxonecc',
                  'macstadium', 'marist', 'mininodes', 'msft', 'osuosl',
                  'rackspace', 'requireio', 'scaleway', 'softlayer', 'voxer',
-                 'packetnet', 'ibm', 'nearform')
+                 'packetnet', 'nearform')
 }
 DECRYPT_TOOL = "gpg"
 INVENTORY_FILENAME = "inventory.yml"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -47,7 +47,7 @@ packages: {
   ],
 
   aix: [
-    'gcc-c++,tar,unzip,git,make,sudo',
+    'bash,gcc-c++,tar,unzip,git,make,sudo',
   ],
 
   debian7: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -47,7 +47,7 @@ packages: {
   ],
 
   aix: [
-    'gcc-c++,sudo',
+    'gcc-c++,tar,unzip,git,make,sudo',
   ],
 
   debian7: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -47,7 +47,7 @@ packages: {
   ],
 
   aix: [
-    'bash,gcc-c++,tar,unzip,git,make,sudo',
+    'bash,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo',
   ],
 
   debian7: [

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -103,9 +103,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
         return
       fi
       ;;
-  esac
-
-  case $NODE_NAME in
+    
     *aix71* )
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.1"
 
@@ -121,6 +119,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       ;;
   esac
 
+  
   echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX61"
 
   if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -110,7 +110,6 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.1"
 
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-        #export LIBPATH=/opt/freeware/lib:/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.1.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
         export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/gcc6/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
         echo "Compiler set to 6.3"

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -110,8 +110,8 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.1"
 
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-        export LIBPATH=/opt/freeware/lib:/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
-        export PATH="/opt/ccache-3.7.4/libexec:/opt/gcc-6.3/bin:$PATH"
+        #export LIBPATH=/opt/freeware/lib:/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.1.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
+        export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/gcc6/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
         echo "Compiler set to 6.3"
         return

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -90,10 +90,27 @@ elif [ "$SELECT_ARCH" = "S390X" ]; then
 elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
   case $NODE_NAME in
     *aix72* )
-      echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX72"
+      echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.2"
 
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         export LIBPATH=/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
+        export PATH="/opt/ccache-3.7.4/libexec:/opt/gcc-6.3/bin:$PATH"
+        export CC="gcc" CXX="g++" CXX_host="g++"
+        echo "Compiler set to 6.3"
+        return
+      else
+        echo "Compiler left as system default:" `g++ -dumpversion`
+        return
+      fi
+      ;;
+  esac
+
+  case $NODE_NAME in
+    *aix71* )
+      echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.1"
+
+      if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
+        export LIBPATH=/opt/freeware/lib:/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
         export PATH="/opt/ccache-3.7.4/libexec:/opt/gcc-6.3/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
         echo "Compiler set to 6.3"


### PR DESCRIPTION
This is a draft pass at adding new AIX72 to our test ci.

Ive edited the anisble to install the packages that use to be done manually.

One machine is commented out as I dont have access atm and so its not currently ansibled yet

Finally Ive cleaned up and edited the manual steps .md with additions needed and ive also split it into 6.1 and 7.2 install steps as both have some differences.

These machines aren't ready yet as I dont have CI access so they are missing the jenkins secret.