### PR TITLE
doc: add mmarchini's build health webpage to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Build and test orchestration is performed by [Jenkins][21].
 - A summary of build and test jobs can be found at: <https://ci.nodejs.org>
 - A listing of connected servers for testing, building and benchmarking
   can be found at: <https://ci.nodejs.org/computer/>
-- A summary of the general health of the last 100 can be found at: <https://nodejs-ci-health.mmarchini.me/#/job-summary>
+- A summary of the general health of the last 100 jobs can be found at: <https://nodejs-ci-health.mmarchini.me/#/job-summary>
 
 The Build WG will keep build configuration required for a release line for 6
 months after the release goes End-of-Life, in case further build or test runs

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Build and test orchestration is performed by [Jenkins][21].
 - A summary of build and test jobs can be found at: <https://ci.nodejs.org>
 - A listing of connected servers for testing, building and benchmarking
   can be found at: <https://ci.nodejs.org/computer/>
+- A summary of the general health of the last 100 can be found at: <https://nodejs-ci-health.mmarchini.me/#/job-summary>
 
 The Build WG will keep build configuration required for a release line for 6
 months after the release goes End-of-Life, in case further build or test runs


### PR DESCRIPTION
@sam-github and I think that @mmarchini's webpage showing the health of the last 100 builds should be linked in the top level readme (providing they are ok with it being there) to have more visibility to the general health of our CI.