### PR TITLE
ansible: set JOBS to 4 for AIX

### DIFF
--- a/ansible/aix61-standalone/resources/S20jenkins
+++ b/ansible/aix61-standalone/resources/S20jenkins
@@ -15,6 +15,7 @@ start )
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
               export OSTYPE=AIX61; \
+              export JOBS=4; \
               export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
               export SSL_CERT_FILE="$HOME/ca-bundle.crt"; \
         java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \


### PR DESCRIPTION
Some of the builds were taking the 20 CPUS to mean run with JOBS=20, but
the machines don't have enough memory to run at that kind of build
concurrency. Throttle to 4. Some jobs were doing this already, but by
setting it in the global env, it should be inherited by all jobs.