### PR TITLE
ansible: reprovision all scaleway test hosts

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -199,9 +199,9 @@ hosts:
         osx1010-x64-1: {ip: 192.168.2.210, user: iojs}
 
     - scaleway:
-        ubuntu1804-armv7l-1: {ip: 163.172.186.154}
-        ubuntu1804-armv7l-2: {ip: 51.15.200.62}
-        ubuntu1804-armv7l-3: {ip: 51.15.218.201}
+        ubuntu1804-armv7l-1: {ip: 212.47.233.202}
+        ubuntu1804-armv7l-2: {ip: 212.47.246.3}
+        ubuntu1804-armv7l-3: {ip: 212.47.227.202}
 
     - softlayer:
         centos6-x64-1: {ip: 169.61.75.51}

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -17,9 +17,9 @@
 - name: set jobs_env from server_jobs or ansible_processor_vcpus
   set_fact:
     jobs_env: "{{ server_jobs|default(ansible_processor_vcpus) }}"
-  when: server_jobs is defined or ansible_processor_vcpus is defined
+  when: jobs_env is undefined and (server_jobs is defined or ansible_processor_vcpus is defined)
 
-- name: set jobs_env from server_jobs or ansible_processor_vcpus
+- name: set jobs_env to fall-back value of 2
   set_fact:
     jobs_env: "2"
   when: jobs_env is undefined

--- a/ansible/roles/jenkins-worker/tasks/partials/scaleway-armv7.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/scaleway-armv7.yml
@@ -1,5 +1,35 @@
 ---
 
+- name: scaleway armv7 | check for swapfile
+  stat:
+    path: /swapfile
+  register: swapfile_stat
+
+- name: scaleway armv7 | make swap file
+  shell: fallocate -l 4G /swapfile
+  when: swapfile_stat.stat.exists == False
+
+- name: scaleway armv7 | set swap file permissions
+  file:
+    path: /swapfile
+    mode: '0600'
+  when: swapfile_stat.stat.exists == False
+
+- name: scaleway armv7 | mkswap
+  shell: mkswap /swapfile
+  when: swapfile_stat.stat.exists == False
+
+- name: scaleway armv7 | set swap in fstab
+  lineinfile:
+    dest: /etc/fstab
+    state: present
+    regexp: '^/swapfile'
+    line: '/swapfile none swap sw 0 0'
+
+- name: scaleway armv7 | swapon
+  shell: swapon -a
+  when: swapfile_stat.stat.exists == False
+
 - name: scaleway armv7 | configure containers
   set_fact:
     docker_containers: "{{ scaleway_armv7.containers }}"

--- a/ansible/roles/package-upgrade/tasks/partials/apt.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/apt.yml
@@ -5,7 +5,16 @@
 #
 
 - name: upgrade installed packages
+  when: "'scaleway-ubuntu1804-armv7l' not in inventory_hostname"
   apt: upgrade=dist update_cache=yes
+
+  # kernel upgrades on the scaleway hosts are dicey
+  # see https://github.com/scaleway/image-ubuntu/issues/132 for kernel woes
+- name: upgrade installed packages (safe)
+  when: "'scaleway-ubuntu1804-armv7l' in inventory_hostname"
+  apt: upgrade=safe update_cache=yes
+  environment:
+    FLASH_KERNEL_SKIP: true
 
   # don't know how to use autoremove=yes for all packages
 - name: clean unwanted packages


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/2066

This adds a 4G swap and does a safe-upgrade instead of a dist-upgrade in an attempt to avoid too much tinkering with the kernel. I've also "fixed" the `jobs_env` logic, it's been overwriting the `jobs_variants` setting in roles/jenkins-worker/tasks/main.yml.