### PR TITLE
doc: clean up GCC tarball notes on AIX

### DIFF
--- a/doc/non-ansible-configuration-notes.md
+++ b/doc/non-ansible-configuration-notes.md
@@ -170,13 +170,14 @@ how they were created.
 ### Preparing gcc distributables
 
 1. download gcc-c++ (with dependencies) from bullfreeware.com
-2. scp 15412gcc-c++-6.3.0-1.aix7.2.ppc.rpm-with-deps.zip TARGET:/ramdisk0
+2. `scp 15412gcc-c++-6.3.0-1.aix7.2.ppc.rpm-with-deps.zip TARGET:/ramdisk0`
    - Note: / is too small
-3. unzip 15412gcc-c++-6.3.0-1.aix7.2.ppc.rpm-with-deps.zip
+3. `unzip 15412gcc-c++-6.3.0-1.aix7.2.ppc.rpm-with-deps.zip`
 4. contained wrong libstdc++-9.1, so downloaded bundle for libstdc++ 6.3.0-1
 5. unpack the RPMs:
-        $ for f in *gcc* *stdc*; do rpm2cpio $f | /opt/freeware/bin/cpio_64 -idmv; done
+        `$ for f in *gcc* *stdc*; do rpm2cpio $f | /opt/freeware/bin/cpio_64 -idmv; done`
 5. Find absolute symlinks, and make them relative, example:
+	```
 	$ find . -type l | xargs file
 	./opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/ppc64/libatomic.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/libatomic.a.
 	./opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/ppc64/libgcc_s.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/libgcc_s.a.
@@ -186,9 +187,15 @@ how they were created.
 	./opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64/libgcc_s.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libgcc_s.a.
 	./opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64/libstdc++.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libstdc++.a.
 	./opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64/libsupc++.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libsupc++.a.
+	```
+	```
 	bash-5.0# pwd
 	/ramdisk0/aixtoolbox/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/ppc64
+	```
+	```
 	bash-5.0# ln -fs ../libatomic.a ../libgcc_s.a ../libstdc++.a ../libsupc++.a ./
+	```
+	```
 	bash-5.0# find . -type l | xargs file
 	./ppc64/libatomic.a: archive (big format)
 	./ppc64/libgcc_s.a: archive (big format)
@@ -198,8 +205,14 @@ how they were created.
 	./pthread/ppc64/libgcc_s.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libgcc_s.a.
 	./pthread/ppc64/libstdc++.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libstdc++.a.
 	./pthread/ppc64/libsupc++.a: symbolic link to /opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/libsupc++.a.
+	```
+	```
 	bash-5.0# cd pthread/ppc64/
+	```
+	```
 	bash-5.0# ln -fs ../libatomic.a ../libgcc_s.a ../libstdc++.a ../libsupc++.a ./
+	```
+	```
 	bash-5.0# file *.a
 	libatomic.a: archive (big format)
 	libgcc.a: archive (big format)
@@ -208,12 +221,16 @@ how they were created.
 	libgcov.a: archive (big format)
 	libstdc++.a: archive (big format)
 	libsupc++.a: archive (big format)
+	```
+
 6. Move to target location and create a tarball with no assumptions on leading
 path prefix:
-        $ mkdir /opt/gcc-6.3
+    ```
+    $ mkdir /opt/gcc-6.3
 	$ cd /opt/gcc-6.3
 	$ mv .../opt/freeware/* ./
 	$ tar -cvf ../gcc-6.3-aix7.2.ppc.tar *
+	```
 
 
 Example above was for 6.3.0, but process for 4.8.5 is identical, other than
@@ -229,6 +246,7 @@ Notes:
 - Build tools create 32-bit binaries by default, so explicitly create 64-bit
   ones.
 
+    ```
 	$ curl -L -O https://github.com/ccache/ccache/releases/download/v3.7.4/ccache-3.7.4.tar.gz
 	  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 					 Dload  Upload   Total   Spent    Left  Speed
@@ -247,6 +265,7 @@ Notes:
 	$ ln -s ../bin/ccache gcov
 	$ cd cd /opt/ccache-3.7.4
 	$ tar -cf /opt/ccache-3.7.4.aix7.2.ppc.tar.gz *
+	```
 
 
 [`ansible.intro_windows`]: http://docs.ansible.com/ansible/intro_windows.html


### PR DESCRIPTION
Tried to use the notes in non-ansible-configuration-notes.md and couldn't make heads or tails of it, so decided to format them first to make them readable