### PR TITLE
feat: add link to codecov.io

### DIFF
--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -28,6 +28,13 @@ with open('out/index.html', 'w') as out:
     <link rel="stylesheet" href="https://nodejs.org/static/css/styles.css">
     <style>
         #logo { margin-bottom: 1rem; }
+        #badge {
+          margin-top: 1rem;
+          margin-bottom: 1rem;
+        }
+        #badge, a {
+          border: none;
+        }
         main { margin-bottom: 2rem; }
         .table-header,
         .table-row {
@@ -72,8 +79,13 @@ with open('out/index.html', 'w') as out:
   <div id="main">
     <div class="container">
       <h1>Node.js Nightly Code Coverage</h1>
+      Nightly combined JavaScript coverage, across Windows, Linux, and a variety of runtimes,
+      can be found on <a href="https://codecov.io/gh/nodejs/node">codecov.io</a>:
+      <a href="https://codecov.io/gh/nodejs/node">
+        <img id="badge" alt="Combined coverage" src="https://codecov.io/gh/nodejs/node/branch/master/graph/badge.svg" />
+      </a>
       <h3>
-        Node.js Core&nbsp;&nbsp;<a href="https://github.com/nodejs/node">&rarr;</a>
+        Nightly Linux Coverage&nbsp;&nbsp;<a href="https://github.com/nodejs/node">&rarr;</a>
       </h3>
       <main>
         <div class="page-content">

--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -79,13 +79,13 @@ with open('out/index.html', 'w') as out:
   <div id="main">
     <div class="container">
       <h1>Node.js Nightly Code Coverage</h1>
-      Nightly combined JavaScript coverage, across Windows, Linux, and a variety of runtimes,
-      can be found on <a href="https://codecov.io/gh/nodejs/node">codecov.io</a>:
+      Nightly combined JavaScript coverage for Windows and Linux can be found
+      on <a href="https://codecov.io/gh/nodejs/node">codecov.io</a>:
       <a href="https://codecov.io/gh/nodejs/node">
         <img id="badge" alt="Combined coverage" src="https://codecov.io/gh/nodejs/node/branch/master/graph/badge.svg" />
       </a>
       <h3>
-        Nightly Linux Coverage&nbsp;&nbsp;<a href="https://github.com/nodejs/node">&rarr;</a>
+        Nightly Linux Branch Coverage&nbsp;&nbsp;<a href="https://github.com/nodejs/node">&rarr;</a>
       </h3>
       <main>
         <div class="page-content">


### PR DESCRIPTION
## What is this?

We are now collecting combined coverage on codecov.io for Windows and Linux (@Trott plans to also add additional coverage for other Linux runtimes).

What's nice about this project, is that it will allow us to eventually hit 100% coverage on the Node.js project, despite some code paths being conditional on platform.

<img width="1042" alt="codecov" src="https://user-images.githubusercontent.com/194609/69922310-3063af80-1450-11ea-88e5-6c7283791e60.png">
