### PR TITLE
pi: reprovision all Pi's with Raspbian Buster, add docs

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -23,6 +23,7 @@ become_method       = sudo
 [hosts:requireio]
 ansible_ssh_common_args = -o ProxyCommand='ssh -i {{ ansible_ssh_private_key_file }} -p 2222 jump@vagg-arm.nodejs.org nc -q0 %h %p'
 become_method           = sudo
+ansible_python_interpreter = /usr/bin/python3
 
 [hosts:smartos]
 ansible_python_interpreter = /opt/local/bin/python

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -41,8 +41,8 @@ hosts:
         ubuntu1604_arm_cross-x64-1: {ip: 165.225.151.28, user: ubuntu}
 
     - requireio:
-        rvagg-debian9-armv6l_pi1p-1: {ip: 192.168.2.40, user: pi}
-        andineck-debian9-armv6l_pi1p-1: {ip: 192.168.2.41, user: pi}
+        rvagg-debian10-armv6l_pi1p-1: {ip: 192.168.2.40, user: pi, alias: iojs-ns-pi1p-1 }
+        andineck-debian10-armv6l_pi1p-1: {ip: 192.168.2.41, user: pi, alias: iojs-ns-pi1p-2 }
         osx1010-x64-1: {ip: 192.168.2.211, user: iojs}
 
     - osuosl:
@@ -154,43 +154,43 @@ hosts:
         ubuntu1604-x64-2: {ip: 104.130.124.194}
 
     - requireio:
-        andineck-debian9-armv6l_pi1p-1:         {ip: 192.168.2.42, user: pi}
-        bengl-debian9-armv6l_pi1p-1:            {ip: 192.168.2.43, user: pi}
-        bengl-debian9-armv6l_pi1p-2:            {ip: 192.168.2.44, user: pi}
-        continuationlabs-debian9-armv6l_pi1p-1: {ip: 192.168.2.45, user: pi}
-        ceejbot-debian9-armv6l_pi1p-1:          {ip: 192.168.2.46, user: pi}
-        mininodes-debian9-armv6l_pi1p-1:        {ip: 192.168.2.47, user: pi}
-        indieisaconcept-debian9-armv6l_pi1p-1:  {ip: 192.168.2.48, user: pi}
-        mhdawson-debian9-armv6l_pi1p-1:         {ip: 192.168.2.49, user: pi}
-        securogroup-debian9-armv6l_pi1p-1:      {ip: 192.168.2.50, user: pi}
-        securogroup-debian9-armv6l_pi1p-2:      {ip: 192.168.2.51, user: pi}
-        chrislea-debian9-armv6l_pi1p-1:         {ip: 192.168.2.52, user: pi}
-        davglass-debian9-armv6l_pi1p-1:         {ip: 192.168.2.53, user: pi}
+        andineck-debian10-armv6l_pi1p-1:         {ip: 192.168.2.42, user: pi, alias: iojs-ns-pi1p-3 }
+        bengl-debian10-armv6l_pi1p-1:            {ip: 192.168.2.43, user: pi, alias: iojs-ns-pi1p-4 }
+        bengl-debian10-armv6l_pi1p-2:            {ip: 192.168.2.44, user: pi, alias: iojs-ns-pi1p-5}
+        continuationlabs-debian10-armv6l_pi1p-1: {ip: 192.168.2.45, user: pi, alias: iojs-ns-pi1p-6 }
+        ceejbot-debian10-armv6l_pi1p-1:          {ip: 192.168.2.46, user: pi, alias: iojs-ns-pi1p-7 }
+        mininodes-debian10-armv6l_pi1p-1:        {ip: 192.168.2.47, user: pi, alias: iojs-ns-pi1p-8 }
+        indieisaconcept-debian10-armv6l_pi1p-1:  {ip: 192.168.2.48, user: pi, alias: iojs-ns-pi1p-9 }
+        mhdawson-debian10-armv6l_pi1p-1:         {ip: 192.168.2.49, user: pi, alias: iojs-ns-pi1p-10 }
+        securogroup-debian10-armv6l_pi1p-1:      {ip: 192.168.2.50, user: pi, alias: iojs-ns-pi1p-11 }
+        securogroup-debian10-armv6l_pi1p-2:      {ip: 192.168.2.51, user: pi, alias: iojs-ns-pi1p-12 }
+        chrislea-debian10-armv6l_pi1p-1:         {ip: 192.168.2.52, user: pi, alias: iojs-ns-pi1p-13 }
+        davglass-debian10-armv6l_pi1p-1:         {ip: 192.168.2.53, user: pi, alias: iojs-ns-pi1p-14 }
 
-        rvagg-debian9-armv7l_pi2-1:        {ip: 192.168.2.60, user: pi}
-        joeyvandijk-debian9-armv7l_pi2-1:  {ip: 192.168.2.61, user: pi}
-        joeyvandijk-debian9-armv7l_pi2-2:  {ip: 192.168.2.62, user: pi}
-        svincent-debian9-armv7l_pi2-1:     {ip: 192.168.2.63, user: pi}
-        mcollina-debian9-armv7l_pi2-1:     {ip: 192.168.2.64, user: pi}
-        ceejbot-debian9-armv7l_pi2-1:      {ip: 192.168.2.65, user: pi}
-        mininodes-debian9-armv7l_pi2-1:    {ip: 192.168.2.66, user: pi}
-        sambthompson-debian9-armv7l_pi2-1: {ip: 192.168.2.67, user: pi}
-        louiscntr-debian9-armv7l_pi2-1:    {ip: 192.168.2.68, user: pi}
-        svincent-debian9-armv7l_pi2-2:     {ip: 192.168.2.69, user: pi}
-        svincent-debian9-armv7l_pi2-3:     {ip: 192.168.2.70, user: pi}
-        jasnell-debian9-armv7l_pi2-1:      {ip: 192.168.2.71, user: pi}
+        rvagg-debian10-armv7l_pi2-1:        {ip: 192.168.2.60, user: pi, alias: iojs-ns-pi2-1 }
+        joeyvandijk-debian10-armv7l_pi2-1:  {ip: 192.168.2.61, user: pi, alias: iojs-ns-pi2-2 }
+        joeyvandijk-debian10-armv7l_pi2-2:  {ip: 192.168.2.62, user: pi, alias: iojs-ns-pi2-3 }
+        svincent-debian10-armv7l_pi2-1:     {ip: 192.168.2.63, user: pi, alias: iojs-ns-pi2-4 }
+        mcollina-debian10-armv7l_pi2-1:     {ip: 192.168.2.64, user: pi, alias: iojs-ns-pi2-5 }
+        ceejbot-debian10-armv7l_pi2-1:      {ip: 192.168.2.65, user: pi, alias: iojs-ns-pi2-6 }
+        mininodes-debian10-armv7l_pi2-1:    {ip: 192.168.2.66, user: pi, alias: iojs-ns-pi2-7 }
+        sambthompson-debian10-armv7l_pi2-1: {ip: 192.168.2.67, user: pi, alias: iojs-ns-pi2-8 }
+        louiscntr-debian10-armv7l_pi2-1:    {ip: 192.168.2.68, user: pi, alias: iojs-ns-pi2-9 }
+        svincent-debian10-armv7l_pi2-2:     {ip: 192.168.2.69, user: pi, alias: iojs-ns-pi2-10 }
+        svincent-debian10-armv7l_pi2-3:     {ip: 192.168.2.70, user: pi, alias: iojs-ns-pi2-11 }
+        jasnell-debian10-armv7l_pi2-1:      {ip: 192.168.2.71, user: pi, alias: iojs-ns-pi2-12 }
 
-        williamkapke-debian9-arm64_pi3-1:      {ip: 192.168.2.80, user: pi}
-        williamkapke-debian9-arm64_pi3-2:      {ip: 192.168.2.81, user: pi}
-        williamkapke-debian9-arm64_pi3-3:      {ip: 192.168.2.82, user: pi}
-        davglass-debian9-arm64_pi3-1:          {ip: 192.168.2.83, user: pi}
-        pivotalagency-debian9-arm64_pi3-1:     {ip: 192.168.2.84, user: pi}
-        pivotalagency-debian9-arm64_pi3-2:     {ip: 192.168.2.85, user: pi}
-        securogroup-debian9-arm64_pi3-1:       {ip: 192.168.2.86, user: pi}
-        securogroup-debian9-arm64_pi3-2:       {ip: 192.168.2.87, user: pi}
-        notthetup_sayanee-debian9-arm64_pi3-1: {ip: 192.168.2.88, user: pi}
-        piccoloaiutante-debian9-arm64_pi3-1:   {ip: 192.168.2.89, user: pi}
-        kahwee-debian9-arm64_pi3-1:            {ip: 192.168.2.90, user: pi}
+        williamkapke-debian10-arm64_pi3-1:      {ip: 192.168.2.80, user: pi, alias: iojs-ns-pi3-1 }
+        williamkapke-debian10-arm64_pi3-2:      {ip: 192.168.2.81, user: pi, alias: iojs-ns-pi3-2 }
+        williamkapke-debian10-arm64_pi3-3:      {ip: 192.168.2.82, user: pi, alias: iojs-ns-pi3-3 }
+        davglass-debian10-arm64_pi3-1:          {ip: 192.168.2.83, user: pi, alias: iojs-ns-pi3-4 }
+        pivotalagency-debian10-arm64_pi3-1:     {ip: 192.168.2.84, user: pi, alias: iojs-ns-pi3-5 }
+        pivotalagency-debian10-arm64_pi3-2:     {ip: 192.168.2.85, user: pi, alias: iojs-ns-pi3-6 }
+        securogroup-debian10-arm64_pi3-1:       {ip: 192.168.2.86, user: pi, alias: iojs-ns-pi3-7 }
+        securogroup-debian10-arm64_pi3-2:       {ip: 192.168.2.87, user: pi, alias: iojs-ns-pi3-8 }
+        notthetup_sayanee-debian10-arm64_pi3-1: {ip: 192.168.2.88, user: pi, alias: iojs-ns-pi3-9 }
+        piccoloaiutante-debian10-arm64_pi3-1:   {ip: 192.168.2.89, user: pi, alias: iojs-ns-pi3-10 }
+        kahwee-debian10-arm64_pi3-1:            {ip: 192.168.2.90, user: pi, alias: iojs-ns-pi3-11 }
 
         rvagg-ubuntu1404-arm64_odroidxu3-1: {ip: 192.168.2.10, user: odroid}
         rvagg-ubuntu1404-arm64_odroidxu-1: {ip: 192.168.2.15}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -23,7 +23,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804'],
   ntp_package: ['ubuntu1404']
 }
 
@@ -60,6 +60,10 @@ packages: {
 
   debian9: [
     'gcc-6,g++-6,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo',
+  ],
+
+  debian10: [
+    'gcc-8,g++-8,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-pip',
   ],
 
   fedora: [

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -13,7 +13,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  systemd: ['debian8', 'debian9', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804'],
   ntp_package: ['ubuntu1404']
 }
 

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: install java
   when:
-    - java.rc > 0 and not os|startswith("zos") and arch != "ppc64" and not inventory_hostname|regex_search('-arm(v6l|v7l|64)_pi')
+    - java.rc > 0 and not os|startswith("zos") and arch != "ppc64"
     - java.rc > 0 and not os|startswith("macos")
   package: name="{{ java_package_name }}" state=present
 
@@ -107,11 +107,3 @@
   with_items:
     - ca-certificates
     - oracle-java8-set-default
-
-- name: pi | uninstall stock java
-  when: "inventory_hostname|regex_search('-arm(v6l|v7l|64)_pi')"
-  package: name="openjdk-8-jre-headless" state=absent
-
-- name: pi | install java
-  when: "inventory_hostname|regex_search('-arm(v6l|v7l|64)_pi')"
-  package: name="oracle-java8-jdk" state=present

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -9,6 +9,7 @@ packages: {
   'debian7': 'openjdk-7-jre-headless',
   'debian8': 'oracle-java8-installer',
   'debian9': 'openjdk-8-jre-headless',
+  'debian10': 'openjdk-8-jre-headless',
   'fedora': 'java-1.8.0-openjdk-headless',
   'freebsd': 'openjdk8-jre',
   'macos': 'adoptopenjdk-openjdk8',

--- a/ansible/roles/jenkins-worker/templates/rpi_wheezy.Dockerfile.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_wheezy.Dockerfile.j2
@@ -15,7 +15,8 @@ ENV LC_ALL=C \
     CCACHE_TEMPDIR=/home/{{ server_user }}/.ccache/{{ inventory_hostname }} \
     DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
+RUN sed -i 's/archive/legacy/' /etc/apt/sources.list && \
+    apt-get update && apt-get dist-upgrade -y && apt-get install -y \
       g++-4.8 \
       gcc-4.8 \
       git \

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -11,7 +11,7 @@ init: {
   freebsd: 'freebsd',
   macos: 'macos',
   rhel72: 'rhel72',
-  systemd: ['centos7', 'debian8', 'debian9', 'fedora', 'ubuntu1604', 'ubuntu1804'],
+  systemd: ['centos7', 'debian8', 'debian9', 'debian10', 'fedora', 'ubuntu1604', 'ubuntu1804'],
   svc: 'smartos',
   upstart: ['ubuntu12', 'ubuntu1404'],
   zos_start: 'zos'


### PR DESCRIPTION
Raspbian Stretch to Raspbian Buster. I also discovered that a sound driver update sometime this year was the cause of boot instability, so that's now disabled at boot and they're running much smoother now.

Have updated the additional docs in here for Pi's to be current and make the setup (somewhat) reproducable.

arm-fanned is back online now after its hiatus, still ironing out some minor hiccups though.

Ref: https://github.com/nodejs/build/issues/1840
Ref: https://github.com/nodejs/node/issues/30786