### PR TITLE
ansible: fix up release-centos6

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -56,7 +56,7 @@ hosts:
         ubuntu1604-armv7l-2: {ip: 212.47.234.107}
 
     - softlayer:
-        centos6-x64-1: {ip: 169.62.77.228}
+        centos6-x64-1: {ip: 50.97.245.10}
 
     - linuxonecc:
         rhel72-s390x-1: {ip: 148.100.110.65}

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -146,7 +146,7 @@
   when: "os == 'centos6'"
   yum:
     disable_gpg_check: true
-    name: "devtoolset-2-gcc,devtoolset-2-gcc-c++"
+    name: "devtoolset-2-gcc,devtoolset-2-gcc-c++,devtoolset-2-binutils"
     state: present
 
 - name: remove fortune from login shells

--- a/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos6.yml
@@ -7,7 +7,12 @@
 
 - name: centos6 | install ius
   yum:
-    name: "https://centos{{ ansible_distribution_major_version }}.iuscommunity.org/ius-release.rpm"
+    name: "https://repo.ius.io/ius-release-el{{ ansible_distribution_major_version }}.rpm "
+    state: present
+
+- name: centos6 | install scl for devtoolset-6
+  yum:
+    name: centos-release-scl
     state: present
 
 - name: centos6 | install devtoolset-2 repo


### PR DESCRIPTION
I had to rebuild this machine, it wasn't connected to Jenkins and I couldn't ssh into it and force reboot didn't do anything.. Later I noticed the IP address we had wasn't the one for the machine. I don't _think_ it got changed when I ordered a rebuild in SoftLayer, but I'm also not sure what the deal is with this new address anyway because it wasn't in ci-release's firewall.

Anyway, rebuild resulted in yaks to shave, see ansible changes here.