### PR TITLE
ansible: remove hardcoded cert location for AIX jenkins

### DIFF
--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -20,7 +20,7 @@ start )
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
-              export OSTYPE=AIX7; \
+              export OSTYPE=AIX72; \
         /home/{{server_user}}/jdk8u192-b12-jre/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl {{jenkins_url}}/computer/{{inventory_hostname}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -20,9 +20,7 @@ start )
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
-              export OSTYPE=AIX72; \
-              export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
-              export SSL_CERT_FILE="$HOME/ca-bundle.crt"; \
+              export OSTYPE=AIX7; \
         /home/{{server_user}}/jdk8u192-b12-jre/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl {{jenkins_url}}/computer/{{inventory_hostname}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'


### PR DESCRIPTION
This was causing build failures on the new AIX 7.1 machines as they couldnt perform a git pull.

ive updated the machines with this and have restarted the agents but will need someone to kick off a test build of node-test-commit-aix71 to ensure it worked.