### PR TITLE
Proposal to add AshCripps as member of build-wg

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ to the resources we manage.
 <!-- ncu-team-sync.team(nodejs/build) -->
 
 - [@addaleax](https://github.com/addaleax) - Anna Henningsen
+- [@AshCripps](https://github.com/AshCripps) - Ashley Cripps
 - [@bnoordhuis](https://github.com/bnoordhuis) - Ben Noordhuis
 - [@gdams](https://github.com/gdams) - George Adams
 - [@gireeshpunathil](https://github.com/gireeshpunathil) - Gireesh Punathil


### PR DESCRIPTION
He is employed full-time by IBM in my team to work on Node.js community build infrastructure, and I am mentoring him.

He has setup and has ongoing "special access" to maintain 3 sets of build machines:
- https://github.com/nodejs/build/issues/2054
- https://github.com/nodejs/build/issues/2081
- https://github.com/nodejs/build/issues/1695

He doesn't have the ability to run CI jobs (much less configure CI jobs), so he can't complete the rhel7-s390x or aix7.1-ppc64 setup or nearform macmini setup, I have to run all the jobs for him.

Criteria: https://github.com/nodejs/build/blob/master/doc/access.md#build-working-group-membership

History:
- Continous involvement in build-wg since joining our team
- nodejs/build PRs: 10 close, 2 open: https://github.com/nodejs/build/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3AAshCripps+
- nodejs/node PRs: 3 closed: https://github.com/nodejs/node/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3AAshCripps+
- ansibilization of 3 systems to prep them for joining to CI (aix, rhel, and os x)
- Has also opened some issues related to our failing nightly builds, and testing of whether recent Xcode on recent OS X machines can build binaries that run on old OS X (they can)