### PR TITLE
ansible: add back the firewall rules for rhel7_s390x

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -87,7 +87,7 @@ packages: {
   ],
 
   rhel7: [
-    'gcc-c++,sudo,git,zip,unzip',
+    'gcc-c++,sudo,git,zip,unzip,iptables-services',
   ],
 
   smartos: [

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -73,6 +73,31 @@
         - "{{ role_path }}/tasks/partials/tap2junit/pip.yml"
       skip: true
 
+- name: Firewall | add rule to allow accepting multicast
+  lineinfile:
+    dest: /etc/sysconfig/iptables
+    insertafter: ":OUTPUT ACCEPT.*]"
+    line: "-A INPUT -m pkttype --pkt-type multicast -j ACCEPT"
+  when: "'rhel7-s390x' in inventory_hostname"
+
+- name: Firewall | add basic rule to allow communication locally
+  lineinfile:
+    dest: /etc/sysconfig/iptables
+    insertafter: ":OUTPUT ACCEPT.*]"
+    line: "-A INPUT -s 127.0.0.1/32 -d 127.0.0.1/32 -j ACCEPT"
+  when: "'rhel7-s390x' in inventory_hostname"
+
+- name: Firewall | add additional rule to allow communication from 127.0.0.2
+  lineinfile:
+    dest: /etc/sysconfig/iptables
+    insertafter: ":OUTPUT ACCEPT.*]"
+    line: "-A INPUT -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT"
+  when: "'rhel7-s390x' in inventory_hostname"
+
+- name: Firewall | make the new firewall rules take effect
+  command: systemctl restart iptables
+  when: "'rhel7-s390x' in inventory_hostname"
+
 - name: download slave.jar
   when: not os|startswith("zos")
   get_url:

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -73,6 +73,21 @@
         - "{{ role_path }}/tasks/partials/tap2junit/pip.yml"
       skip: true
 
+- name: Firewall | enable iptables
+  command: systemctl enable iptables
+  when: "'rhel7-s390x' in inventory_hostname"
+
+- name: Firewall | check for firewalld
+  raw: stat /usr/sbin/firewalld
+  register: has_firewalld
+  failed_when: has_firewalld.rc > 1
+  when: "'rhel7-s390x' in inventory_hostname"
+
+- name: Firewall | remove firewalld
+  when: has_firewalld.rc == 0
+  raw: yum remove -y firewalld
+  when: "'rhel7-s390x' in inventory_hostname"
+
 - name: Firewall | add rule to allow accepting multicast
   lineinfile:
     dest: /etc/sysconfig/iptables


### PR DESCRIPTION
fixes: https://github.com/nodejs/build/issues/2080#issuecomment-567280766

Not ready for merging yet - not able to update the iptables on the machines themselves.
They don't have a running iptables.service so I don't know how to restart iptables to apply the rules