### PR TITLE
ansible: manual AIX7.2 install instructions moved

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -16,3 +16,65 @@ to
 ```bash
 sudo systemsetup -setremotelogin on
 ```
+
+## AIX 7.2 Install
+
+Most packages should be installed via ansible.
+
+If there are any missing they should be installed via yum
+
+What you do need to install manually is **ccache**
+
+
+```bash
+mkdir -p /opt/gcc-6.3 && cd /opt/gcc-6.3
+curl -L https://ci.nodejs.org/downloads/aix/gcc-6.3-aix7.2.ppc.tar.gz | /opt/freeware/bin/tar -xzf -
+```
+
+## ccache 3.7.4 on AIX 7.2
+
+```bash
+mkdir -p /opt/ccache-3.7.4 && cd /opt/ccache-3.7.4
+curl -L https://ci.nodejs.org/downloads/aix/ccache-3.7.4.aix7.2.ppc.tar.gz | /opt/freeware/bin/tar -xzf -
+```
+
+## Enable the AHA fs
+
+For AIX 7 and 6.1, needed for the file watcher unit tests.
+
+Add the following to /etc/filesystems:
+
+```
+/aha:
+        dev             = /aha
+        vfs             = ahafs
+        mount           = true
+        vol             = /aha
+```
+
+and then:
+
+```bash
+mkdir /aha
+mount /aha
+```
+
+## Install XL compilers
+
+1. Download 16.1.0 packages from: https://testcase.boulder.ibm.com (username:
+   xlcomp4, password: ask @mhdawson)
+2. scp them to target:/opt/ibm-xlc
+3. on target:
+```bash
+cd /opt/ibm-xlc
+uncompress 16.1.0.3-IBM-xlCcmp-AIX-FP003.tar.Z
+uncompress IBM_XL_C_CPP_V16.1.0.0_AIX.tar.Z
+installp -aXYgd ./usr/sys/inst.images -e /tmp/install.log all
+inutoc
+installp -aXgd ./ -e /tmp/install.log all
+```
+4. Find compilers in `/opt/IBM/xl[cC]/16.1.0/bin/`
+
+
+
+

--- a/ansible/aix61-standalone/manualBootstrap.md
+++ b/ansible/aix61-standalone/manualBootstrap.md
@@ -56,67 +56,6 @@ The fix is as following:
 sudo rm /usr/lib/libiconv.a && sudo ln -s /opt/freeware/bin/libiconv.a /usr/lib
 ```
 
-# AIX 7.2 Install
-
-Most packages should be installed via ansible.
-
-If there are any missing they should be installed via yum
-
-What you do need to install manually is **ccache**
-
-
-```bash
-mkdir -p /opt/gcc-6.3 && cd /opt/gcc-6.3
-curl -L https://ci.nodejs.org/downloads/aix/gcc-6.3-aix7.2.ppc.tar.gz | /opt/freeware/bin/tar -xzf -
-```
-
-## ccache 3.7.4 on AIX 7.2
-
-```bash
-mkdir -p /opt/ccache-3.7.4 && cd /opt/ccache-3.7.4
-curl -L https://ci.nodejs.org/downloads/aix/ccache-3.7.4.aix7.2.ppc.tar.gz | /opt/freeware/bin/tar -xzf -
-```
-
-## Enable the AHA fs
-
-For AIX 7 and 6.1, needed for the file watcher unit tests.
-
-Add the following to /etc/filesystems:
-
-```
-/aha:
-        dev             = /aha
-        vfs             = ahafs
-        mount           = true
-        vol             = /aha
-```
-
-and then:
-
-```bash
-mkdir /aha
-mount /aha
-```
-
-## Install XL compilers
-
-1. Download 16.1.0 packages from: https://testcase.boulder.ibm.com (username:
-   xlcomp4, password: ask @mhdawson)
-2. scp them to target:/opt/ibm-xlc
-3. on target:
-```bash
-cd /opt/ibm-xlc
-uncompress 16.1.0.3-IBM-xlCcmp-AIX-FP003.tar.Z
-uncompress IBM_XL_C_CPP_V16.1.0.0_AIX.tar.Z
-installp -aXYgd ./usr/sys/inst.images -e /tmp/install.log all
-inutoc
-installp -aXgd ./ -e /tmp/install.log all
-```
-4. Find compilers in `/opt/IBM/xl[cC]/16.1.0/bin/`
-
-
-
-
 # AIX 6.1 Install
 
 ## Install required packages


### PR DESCRIPTION
They used to be part of the legacy AIX6.1 manualBootstrap.md. Since
AIX7.2 is current, and runs from top-level ansible playbooks, move
them to MANUAL_STEPS.md.