### PR TITLE
ansible: aix6.1 ccache needs recreation on ramdisk

### DIFF
--- a/ansible/aix61-standalone/manualBootstrap.md
+++ b/ansible/aix61-standalone/manualBootstrap.md
@@ -418,7 +418,8 @@ Device /dev/ramdisk1:
   Standard empty filesystem
   Size:           22908776 512-byte (DEVBLKSIZE) blocks
 # mount -V jfs2 -o log=/dev/ramdisk1 /dev/ramdisk1 /home/iojs/build
-# chown iojs:staff /home/iojs/build
+# mkdir /home/iojs/build/.ccache
+# chown iojs:staff /home/iojs/build /home/iojs/build/.ccache
 # ls -l /dev/*ramdisk*
 brw-------    1 root     system       36,  0 Jun 18 12:13 /dev/ramdisk0
 brw-------    1 root     system       36,  1 Jun 18 12:14 /dev/ramdisk1


### PR DESCRIPTION
This might not ever be done again, since AIX6.1 isn't needed for 10.x and up, https://github.com/nodejs/node/blob/v10.x/BUILDING.md#supported-platforms-1, but worth documenting anyway.