### PR TITLE
jenkins: use AIX7.1 for 13.x and 14.x

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -61,8 +61,9 @@ def buildExclusions = [
 
   // AIX ppc64 ---------------------------------------------
   [ /aix61/,                          anyType,     lt(6)   ],
-  [ /aix71/,                          anyType,     lt(14)  ],
-  [ /aix71/,                          releaseType, lt(15)  ],
+  [ /aix61/,                          anyType,     gt(13)  ],
+  [ /aix71/,                          anyType,     lt(13)  ],
+  [ /aix71/,                          releaseType, lt(14)  ],
 
   // Shared libs docker containers -------------------------
   [ /sharedlibs_openssl111/,          anyType,     lt(11)  ],


### PR DESCRIPTION
v14 testing is looking green so this pr will enable testing on v13.

Ive also included changes to allow for releasing 14 from 7.1. LMT if anyone feels this is too soon/incorrect.

refs: #2110 