### PR TITLE
ansible: rhel: add gconf2-devel package to ansible scripts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -87,7 +87,7 @@ packages: {
   ],
 
   rhel7: [
-    'gcc-c++,sudo,git,zip,unzip,iptables-services',
+    'gcc-c++,sudo,git,zip,unzip,iptables-services,GConf2-devel',
   ],
 
   smartos: [


### PR DESCRIPTION
This installs a dependency needed by V8

refs: https://github.com/nodejs/build/issues/2080#issuecomment-569428811