### PR TITLE
use adoptopenjdk on Linux/s390x as it has a JIT

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -67,7 +67,7 @@
     url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
     dest: /tmp/
 - name: unarchive java s390x
-  when: os == "rhel7" arch == "s390x"
+  when: os == "rhel7" and arch == "s390x"
   unarchive:
     src: /tmp/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
     remote_src: yes

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -61,6 +61,26 @@
     dest: "/usr/bin/java"
     state: link
 
+- name: download java on s390x
+  when: os == "rhel7" and arch == "s390x"
+  get_url:
+    url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
+    dest: /tmp/
+- name: unarchive java s390x
+  when: os == "rhel7" arch == "s390x"
+  unarchive:
+    src: /tmp/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
+    remote_src: yes
+    dest: /opt
+  tags: java
+
+- name: symlink java s390x
+  when: os == "rhel7" and arch == "s390x"
+  file:
+    src: "/opt/jdk8u242-b08/bin/java"
+    dest: "/usr/bin/java"
+    state: link
+
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.
 


### PR DESCRIPTION
The java being used for the jenkins agent is a java 8 with a HotSpot JVM which does not have JIT compiler. In order to speed up the jenkins processes running on the machine I propose switching to an AdoptOpenJDK/OpenJ9 JVM which does have a JIT. This PR will make that change.

(May require further adjustments to the `jenkins-worker` directories if the full path has to be encoded somewhere)

Current output from one of the build machines shows it using the Zero VM

```
[linux1@test-ibm-rhel7-s390x-3 ~]$ /usr/bin/java -version
openjdk version "1.8.0_232"
OpenJDK Runtime Environment (build 1.8.0_232-b09)
OpenJDK 64-Bit Zero VM (build 25.232-b09, interpreted mode)
[linux1@test-ibm-rhel7-s390x-3 ~]$
```

Looking for reviews on the concept - the code hasn't been tested yet ;-) Am tempted to do a bit of an overhaul of this to put the JVMs that are downloaded outside the repos into `/usr/lib/jvm` and standardise the two builds that we will now have from adoptopenjdk but that can wait until later ...
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>