### PR TITLE
coverage: remove copy of styles

### DIFF
--- a/jenkins/scripts/coverage/generate-index-html.py
+++ b/jenkins/scripts/coverage/generate-index-html.py
@@ -3,10 +3,6 @@
 
 import datetime
 
-with open('jenkins/scripts/coverage/styles.css') as in_file:
-  with open('out/styles.css') as out_file:
-    out_file.write(in_file.read())
-
 with open('out/index.csv') as index:
   index_csv = filter(lambda line: line, index.read().split('\n'))
 


### PR DESCRIPTION
Remove copy of styles from script, added it instead to
the job that runs/generates the coverage output