### PR TITLE
jenkins: use ccache with devtoolset on ppc64le

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -42,6 +42,9 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
         . /opt/rh/devtoolset-6/enable
+        export CC="ccache ppc64le-redhat-linux-gcc"
+        export CXX="ccache ppc64le-redhat-linux-g++"
+        export LINK="ppc64le-redhat-linux-g++"
         echo "Compiler set to devtoolset-6"
         return
       fi


### PR DESCRIPTION
Relands the first commit from https://github.com/nodejs/build/pull/1927 for `centos7-ppcle` to reenable ccache. The other commit is not required as on `ppcle-ubuntu1404` we use `ccache` via the symbolic links in `/usr/lib/ccache`.

This is blocked on https://github.com/nodejs/node/pull/31628 landing on all supported release lines to avoid breaking https://ci.nodejs.org/job/node-test-commit-v8-linux/.

Refs: https://github.com/nodejs/node/pull/31628
Refs: https://github.com/nodejs/build/issues/1940

cc @nodejs/platform-ppc 