### PR TITLE
workflow: update job names, use checkout@v2

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,14 +1,14 @@
-name: on push or pull_request
+name: Lint
 on: [push, pull_request]
 jobs:
-  build:
+  Python:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 2
       matrix:
         python-version: [2.7, 3.7]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
Renames jobs in the current GitHub Actions workflow to be more descriptive. The plan is to add a further job to lint yaml (continuation of https://github.com/nodejs/build/pull/1476 but as a workflow instead of Travis CI) but this is a standalone change.