### PR TITLE
ansible: update link to metrics directory

### DIFF
--- a/ansible/www-standalone/tools/metrics/public-index.html
+++ b/ansible/www-standalone/tools/metrics/public-index.html
@@ -378,7 +378,7 @@ pre code, pre tt {
 <p>Plot:</p>
 <p><a href="./summaries/version.png"><img src="./summaries/version.png"></a></p>
 <h2 id="additional-stuff">Additional stuff</h2>
-<p>The source of this file along with the various scripts used to generate the data files and graphs can be found in the <a href="https://github.com/nodejs/build">nodejs/build</a> GitHub repository in the <a href="https://github.com/nodejs/build/tree/master/setup/www/tools/metrics">setup/www/tools/metrics</a> directory. Questions, suggestions and pull requests are welcome in that repository.</p>
+<p>The source of this file along with the various scripts used to generate the data files and graphs can be found in the <a href="https://github.com/nodejs/build">nodejs/build</a> GitHub repository in the <a href="https://github.com/nodejs/build/tree/master/ansible/www-standalone/tools/metrics">ansible/www-standalone/tools/metrics</a> directory. Questions, suggestions and pull requests are welcome in that repository.</p>
 </div>
     </div>
   </body>


### PR DESCRIPTION
The directory for metrics was moved in 0a1b2e9ad35ba7aab215e799529781a3522e00ce.