### PR TITLE
ansible: add container for UBI 8.1

### DIFF
--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -1,0 +1,50 @@
+FROM registry.access.redhat.com/ubi8:8.1
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV SHELL /bin/bash
+ENV PATH /usr/lib64/ccache:/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
+ENV DESTCPU x64
+ENV ARCH x64
+
+# ccache is not in the default repositories so get it from EPEL 8.
+RUN dnf install --disableplugin=subscription-manager -y \
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf update --disableplugin=subscription-manager -y \
+    && dnf install --disableplugin=subscription-manager -y \
+      ccache \
+      gcc-c++ \
+      git \
+      java-1.8.0-openjdk-headless \
+      make \
+      python3 \
+      openssl-devel \
+      procps-ng \
+    && dnf --disableplugin=subscription-manager clean all
+
+RUN groupadd -r -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }} \
+    && adduser -r -m -d /home/{{ server_user }}/ \
+      -g {{ server_user_gid.stdout_lines[0] }} \
+      -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }} 
+
+# Relax crypto policies to allow Node.js tests to pass
+RUN update-crypto-policies --set LEGACY
+
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
+
+USER iojs:iojs
+RUN pip3 install tap2junit --user
+
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
+CMD cd /home/iojs \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java -Xmx{{ server_ram|default('128m') }} \
+          -jar /home/{{ server_user }}/slave.jar \
+          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
+          -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -37,8 +37,9 @@ RUN update-crypto-policies --set LEGACY
 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
+RUN pip3 install tap2junit
+
 USER iojs:iojs
-RUN pip3 install tap2junit --user
 
 ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -90,6 +90,7 @@ def buildExclusions = [
   [ /aix71/,                          anyType,     lt(10)  ],
 
   // Shared libs docker containers -------------------------
+  [ /ubi81_sharedlibs/,               anyType,     lt(13)  ],
   [ /sharedlibs_openssl111/,          anyType,     lt(11)  ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     gte(12) ],


### PR DESCRIPTION
Adds a dockerfile for UBI 8.1.

From what I can tell the ansible changes would all be to the test inventory.xml in secrets (and not here in this repo). @nodejs/build-infra do I need to cleanly shutdown all the running containers (as per https://github.com/nodejs/build/blob/97b004a672d17820976ea8eac91b4dde8a6a4697/ansible/MANUAL_STEPS.md#Docker-hosts) in a container host before re-ansibling it (once I've added the new container to the inventory)?

Refs: https://github.com/nodejs/build/issues/2176