### PR TITLE
workflow: add stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-issue-label: 'stale'
+        exempt-issue-label: 'never stale'
+        days-before-stale: 300
+        days-before-close: 30


### PR DESCRIPTION
Setup to mark stale after 90 days, and close 15 days after marked stale
unless the issue is commented on, or has the `stale` label removed.

Fixes: https://github.com/nodejs/build/issues/2190

-----

Draft - awaiting some comment on https://github.com/nodejs/build/issues/2190 to agree this is useful. I've never configured a GH action before, I'd appreciate a review by someone who has!