### PR TITLE
 jenkins: osx10.15 release for 13.x 

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -103,8 +103,8 @@ def buildExclusions = [
   // OSX ---------------------------------------------------
   [ /^osx1010/,                       anyType,     gte(11) ],
   [ /^osx1011/,                       releaseType, lt(11)  ],
-  [ /^osx1011/,                       releaseType, gte(14)  ],
-  [ /^osx1015/,                       releaseType, lt(14)  ],
+  [ /^osx1011/,                       releaseType, gte(13)  ],
+  [ /^osx1015/,                       releaseType, lt(13)  ],
 
   // FreeBSD -----------------------------------------------
   [ /^freebsd10/,                     anyType,     gte(11) ],


### PR DESCRIPTION
This lands on top of #2199, after we get that one landed landed, https://github.com/nodejs/node/pull/31459 landed and a few nightlies out without any problems.

See timeline in https://github.com/nodejs/build/pull/2199#issuecomment-594253577