### PR TITLE
jenkins: osx10.15 release for all versions 

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -101,11 +101,11 @@ def buildExclusions = [
   [ /sharedlibs_shared/,              anyType,     lt(9)   ],
 
   // OSX ---------------------------------------------------
-  [ /^osx1010/,                       anyType,     gte(11) ],
-  [ /^osx1011/,                       releaseType, lt(11)  ],
-  [ /^osx1011/,                       releaseType, gte(13) ],
+  [ /^osx1010/,                       testType,    gte(11) ],
+  [ /^osx1010/,                       releaseType, allVer  ],
   [ /^osx1011/,                       testType,    gte(14) ],
-  [ /^osx1015/,                       releaseType, lt(13)  ],
+  [ /^osx1011/,                       releaseType, allVer  ],
+  // osx1015 enabled for all, and builds all releases to support notarization
 
   // FreeBSD -----------------------------------------------
   [ /^freebsd10/,                     anyType,     gte(11) ],


### PR DESCRIPTION
This lands on top of #2202, after we get https://github.com/nodejs/node/pull/31459 backported to 12.x and 10.x which happens after we successfully get a 13.x release or two out.

See timeline in https://github.com/nodejs/build/pull/2199#issuecomment-594253577