### PR TITLE
alpine: remove Alpine 3.9, add 3.11

### DIFF
--- a/ansible/roles/docker/templates/alpine311.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine311.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 
 ENV LC_ALL C
 ENV USER {{ server_user }}


### PR DESCRIPTION
Haven't actually done anything with this beyond messing with the files, so just a heads-up for now (and invitation if someone else wants to do this, @richardlau?). I don't even know if these will build properly, but the last couple of versions of Alpine have been stable enough that we haven't had to change anything so I'm hopeful.

Next steps:

 * [x] (optional) Test that these actually build. locally, tweak accordingly
 * [x] Change tags of the 3.10 containers in Jenkins to "alpine-last-latest"
 * [x] Set up 3.11 containers in Jenkins, tagging them "alpine-latest"
 * [x] Delete 3.9 Jenkins nodes  (I think what I'd do is just rename the 3.9 Jenkins nodes to 3.11 and change the tags accordingly, they'd get new secrets in the process and wouldn't leave 3.9's connected as "alpine-last-latest" during testing).
 * [ ] Set up inventory.yml in secrets with the secrets for these new 3.11 hosts and remove the 3.9 hosts in the process.
 * [x] Run the playbook against the 3 docker hosts to set these containers up
 * [x] Run CI jobs against all supported release lines and master to make sure no surprises pop up with 3.11 (we've had a lot of surprises with new Alpine versions). If there are surprises, consider getting things marked as flaky or fixed before properly enabling 3.11 in CI (probably remove "alpine-latest" from the node-test-commit-linux job).
 * [x] Manually remove the 3.9 containers from the 3 Docker hosts:
   - Stop containers via systemd
   - Remove systemd unit, then run `systemctl daemon-reload`
   - Remove images (`docker rmi ...`)
   - Run `docker system prune -fa` to clean up dangling images.