### PR TITLE
ansible: add cmake for AIX

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -47,7 +47,7 @@ packages: {
   ],
 
   aix: [
-    'bash,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo',
+    'bash,cmake,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo',
   ],
 
   debian7: [

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -97,7 +97,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
 
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         export LIBPATH=/opt/gcc-6.3/lib/gcc/powerpc-ibm-aix7.2.0.0/6.3.0/pthread/ppc64:/opt/gcc-6.3/lib
-        export PATH="/opt/ccache-3.7.4/libexec:/opt/gcc-6.3/bin:$PATH"
+        export PATH="/opt/ccache-3.7.4/libexec:/opt/gcc-6.3/bin:/opt/freeware/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
         echo "Compiler set to 6.3"
         return
@@ -111,7 +111,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.1"
 
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-        export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/gcc6/bin:$PATH"
+        export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/gcc6/bin:/opt/freeware/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
         echo "Compiler set to 6.3"
         return


### PR DESCRIPTION
Install `cmake` on AIX from the [AIX Toolbox for Linux Applications](https://www.ibm.com/support/pages/aix-toolbox-linux-applications-downloads-alpha).

Refs: https://github.com/nodejs/build/issues/2097
Refs: https://github.com/libuv/libuv/pull/2731

cc @AshCripps @sam-github 