### PR TITLE
ansible: fix typo in libiconv fixup

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -191,7 +191,7 @@ exec(): 0509-036 Cannot load program gmake because of the following errors:
 The fix is as follows:
 
 ```sh
-sudo rm /usr/lib/libiconv.a && sudo ln -s /opt/freeware/bin/libiconv.a /usr/lib
+sudo rm /usr/lib/libiconv.a && sudo ln -s /opt/freeware/lib/libiconv.a /usr/lib
 ```
 
 ### Preparing gcc distributables


### PR DESCRIPTION
libiconv.a is not in ../bin, its in ../lib/ (of course). Found this on
ci-release, where symlink pointed to the non-existent ../bin/libiconv.a