### PR TITLE
ansible: add cmake to macos

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -97,7 +97,7 @@ packages: {
 
 
   'macos10.15': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
   rhel7: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -75,24 +75,24 @@ packages: {
   ],
 
   'macos10.10': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
   'macos10.11': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
   'macos10.12': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
   'macos10.13': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
 
   'macos10.14': [
-    'python,ccache'
+    'cmake,python,ccache'
   ],
 
 


### PR DESCRIPTION
refs: https://github.com/nodejs/build/issues/2175

So far ive only added it to 10.15 as older macs can build libuv on gyp whereas 10.15 can't at this time.

Tested on test-nearform-macos10.15-x64-3 and its working

```
administrator@test-nearform-macos10 ~ % cmake -version
cmake version 3.16.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
administrator@test-nearform-macos10 ~ %
```