### PR TITLE
jenkins: exclude new jenkins-workspace machines from removing `node`

### DIFF
--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -86,8 +86,8 @@
   - "!test-packetnet-ubuntu1604-x64-1"
   - "!test-packetnet-ubuntu1604-x64-2"
   - "!test-softlayer-ubuntu1604-x64-1"
-  - "!test-softlayer-ubuntu1804-x64-1"
-  - "!test-softlayer-ubuntu1804-x64-2"
+  - "!test-packetnet-ubuntu1804-x64-1"
+  - "!test-packetnet-ubuntu1804-x64-2"
   tasks:
     - name: remove node and npm packages
       when: not os|startswith("win") and not os|startswith("zos")

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -86,6 +86,8 @@
   - "!test-packetnet-ubuntu1604-x64-1"
   - "!test-packetnet-ubuntu1604-x64-2"
   - "!test-softlayer-ubuntu1604-x64-1"
+  - "!test-softlayer-ubuntu1804-x64-1"
+  - "!test-softlayer-ubuntu1804-x64-2"
   tasks:
     - name: remove node and npm packages
       when: not os|startswith("win") and not os|startswith("zos")


### PR DESCRIPTION
forgot this second bit, it's needed so `node` doesn't get removed after it's installed, we need it on these workspace machines to run the linter

we need to find a better way of doing this than listing the machines, using the label might be good if we can work out a way to