### PR TITLE
jenkins: stop testing 14.x on OSX10.11

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -103,7 +103,8 @@ def buildExclusions = [
   // OSX ---------------------------------------------------
   [ /^osx1010/,                       anyType,     gte(11) ],
   [ /^osx1011/,                       releaseType, lt(11)  ],
-  [ /^osx1011/,                       releaseType, gte(13)  ],
+  [ /^osx1011/,                       releaseType, gte(13) ],
+  [ /^osx1011/,                       testType,    gte(14) ],
   [ /^osx1015/,                       releaseType, lt(13)  ],
 
   // FreeBSD -----------------------------------------------


### PR DESCRIPTION
I think ive got this right, once https://github.com/nodejs/node/pull/32454 lands it doesnt make
sense to test master on 10.11 anymore with the deployment target set to
10.13. So setting the versionselector to not test 14.x+ on osx10.11

refs: https://github.com/nodejs/node/pull/32454