### PR TITLE
ansible: add tasks to install cmake on z/OS

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -198,6 +198,57 @@
   when: os|startswith("smartos")
   raw: "svccfg import {{ jenkins.dest }}"
 
+- name: install cmake - create directory - part 1
+  when: os|startswith("zos")
+  file:
+    owner: "{{ server_user }}"
+    path: "{{ home }}/{{ server_user }}/cmake"
+    state: directory
+
+- name: install cmake - download tarball - part 2
+  when: os|startswith("zos")
+  shell:
+    chdir: "{{ home }}/{{ server_user }}/cmake"
+    cmd: "su -s {{ server_user }} -c 'curl -sL -o cmake-v3.5.1-zos.tar.gz https://github.com/fjeremic/CMake/archive/v3.5.1-zos.tar.gz'"
+    creates: "{{ home }}/{{ server_user }}/cmake/cmake-v3.5.1-zos.tar.gz"
+
+- name: install cmake - extract tarball - part 3
+  when: os|startswith("zos")
+  shell:
+    chdir: "{{ home }}/{{ server_user }}/cmake"
+    cmd: "su -s {{ server_user }} -c 'gzip -dc < cmake-v3.5.1-zos.tar.gz | pax -r -o from=iso8859-1,to=ibm-1047'"
+    creates: "{{ home }}/{{ server_user }}/cmake/CMake-3.5.1-zos"
+
+- name: install cmake - create temp directory - part 4
+  when: os|startswith("zos")
+  file:
+    owner: "{{ server_user }}"
+    path: "{{ home }}/{{ server_user }}/temp"
+    state: directory
+
+- name: install cmake - create install directory - part 5
+  when: os|startswith("zos")
+  file:
+    owner: "{{ server_user }}"
+    path: "{{ home }}/{{ server_user }}/local"
+    state: directory
+
+- name: install cmake - build - part 6
+  when: os|startswith("zos")
+  environment:
+    _C89_CCMODE: 1
+    _CC_CCMODE: 1
+    _CXX_CCMODE: 1
+    _TAG_REDIR_ERR: txt
+    _TAG_REDIR_IN: txt
+    _TAG_REDIR_OUT: txt
+    PATH: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
+    TMPDIR: "{{ home }}/{{ server_user }}/temp"
+  shell:
+    chdir: "{{ home }}/{{ server_user }}/cmake/CMake-3.5.1-zos"
+    cmd: "su -s {{ server_user }} -c './bootstrap --prefix={{ home }}/{{ server_user }}/local --verbose && make -j8 VERBOSE=1 && make install'"
+    creates: "{{ home }}/{{ server_user }}/local/bin/cmake"
+
 - name: render gyp into place - Create directory - part 1
   when: os|startswith("zos")
   file:


### PR DESCRIPTION
Add ansible tasks to install cmake on z/OS.

Downloads z/OS cmake port from https://github.com/fjeremic/CMake, unpacks, builds and installs into `/u/iojs/local`.

Ran the new tasks on both `test-marist-zos13-s390x-1` and `test-marist-zos13-s390x-2` via
```
ansible-playbook --limit test-marist-zos13-s390x-* playbooks/jenkins/worker/create.yml --start-at-task "install cmake - create directory - part 1"
```

Updated the paths in [libuv-test-commit-zos-cmake](https://ci.nodejs.org/job/libuv-test-commit-zos-cmake/) to point to `/u/iojs/local/bin` and ran a test build: https://ci.nodejs.org/job/libuv-test-commit-zos-cmake/63/ (ran on both `test-marist-zos13-s390x-1` and `test-marist-zos13-s390x-2`).

I'm not able to run the entire unaltered `playbooks/jenkins/worker/create.yml` playbook on z/OS. I've raised https://github.com/nodejs/build/issues/2258 to cover that so that this PR can focus on the tasks to install cmake.