### PR TITLE
www: less agressive nightly promotion & CDN cache purge

### DIFF
--- a/ansible/www-standalone/tasks/site-setup.yaml
+++ b/ansible/www-standalone/tasks/site-setup.yaml
@@ -110,11 +110,9 @@
     dest: /etc/crontab
     line: "{{ item }}"
   with_items:
-    - '*/5 *   * * *   dist    /home/staging/tools/promote/promote_nightly.sh nodejs'
-    - '*/5 *   * * *   dist    /home/staging/tools/promote/promote_nightly.sh iojs'
-    - '*  *    * * *   nodejs  /home/nodejs/check-build-site.sh nodejs'
-    - '*  *    * * *   nodejs  /home/nodejs/check-build-site.sh iojs'
-    - '*  *    * * *   root    /home/nodejs/cdn-purge.sh'
+    - '*/30 *    * * *   dist    /home/staging/tools/promote/promote_nightly.sh nodejs'
+    - '*/5  *    * * *   nodejs  /home/nodejs/check-build-site.sh nodejs'
+    - '*/5  *    * * *   root    /home/nodejs/cdn-purge.sh'
     - '* */4   * * *   nodejs  /home/nodejs/sync-benchmarking.sh'
   tags: setup
 


### PR DESCRIPTION
Ref: #2264

Just slowing things down a bit. Not fixing anything specific but being more cautious because a hypothetical potential for cache invalidation _every minute_. I can't see a means by which this could be caused, but slowing down the checks in cron will help. Will comment about implications of each thing inline.

This is active on nodejs.org right now but can be easily changed if there's feedback here.