### PR TITLE
www: log cdn purge calls

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -44,6 +44,7 @@ docker run \
   -v /home/nodejs/.npm:/npm/ \
   node:latest \
   bash -c " \
+    apt-get update && apt-get install -y rsync && \
     addgroup nodejs --gid ${nodeuid} && \
     adduser nodejs --uid ${nodeuid} --gid ${nodegid} --gecos nodejs --disabled-password && \
     su nodejs -c ' \
@@ -57,4 +58,4 @@ docker run \
 
 rsync -avz --delete --exclude .git ${clonedir}/${rsync_from} /home/www/${site}/
 
-/home/nodejs/queue-cdn-purge.sh $site
+/home/nodejs/queue-cdn-purge.sh $site build-site

--- a/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2
+++ b/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2
@@ -38,7 +38,7 @@ rm -f /tmp/cdnpurge.$site
 #  -H "X-Auth-Email: ${api_email}" \
 #  -H "X-Auth-Key: ${api_key}"
 
-echo "$(date -u --iso-8601=s), ${zone_id}, ${reason}" >> /home/nodejs/cdn-purge.log
+echo "$(date -u --iso-8601=s), ${site}, ${reason}" >> /home/nodejs/cdn-purge.log
 
 # purge full cache
 curl -X DELETE \

--- a/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2
+++ b/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2
@@ -27,6 +27,8 @@ if ! [ -f /tmp/cdnpurge.$site ]; then
   exit 0
 fi
 
+reason="$(cat /tmp/cdnpurge.$site | tr '\n' ' ')"
+
 rm -f /tmp/cdnpurge.$site
 
 # list zones:
@@ -35,6 +37,8 @@ rm -f /tmp/cdnpurge.$site
 #  "https://api.cloudflare.com/client/v4/zones/" \
 #  -H "X-Auth-Email: ${api_email}" \
 #  -H "X-Auth-Key: ${api_key}"
+
+echo "$(date -u --iso-8601=s), ${zone_id}, ${reason}" >> /home/nodejs/cdn-purge.log
 
 # purge full cache
 curl -X DELETE \

--- a/ansible/www-standalone/resources/scripts/queue-cdn-purge.sh
+++ b/ansible/www-standalone/resources/scripts/queue-cdn-purge.sh
@@ -5,9 +5,9 @@ set -e
 site=$1
 
 if [ "X$site" != "Xiojs" ] && [ "X$site" != "Xnodejs" ]; then
-  echo "Usage: queue-cdn-purge.sh < iojs | nodejs >"
+  echo "Usage: queue-cdn-purge.sh < iojs | nodejs > [reason]"
   exit 1
 fi
 
 umask 000
-touch /tmp/cdnpurge.$site
+echo ${2:-unknown} >> /tmp/cdnpurge.$site

--- a/ansible/www-standalone/tools/promote/_promote.sh
+++ b/ansible/www-standalone/tools/promote/_promote.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ -z ${srcdir+x} ]; then
@@ -19,6 +21,7 @@ fi
 
 site=$1
 version=$2
+purge=no
 
 for subdir in $(cd $srcdir && ls); do
 
@@ -39,6 +42,7 @@ for subdir in $(cd $srcdir && ls); do
         cp -a "${srcdir}/${subdir}/${doneref}" "${dstdir}/${subdir}/${doneref}"
         rm -rf "${srcdir}/${subdir}/${doneref}"
         resha=yes
+        purge=yes
       fi
 
       rm -f "${srcdir}/${subdir}/${donefile}"
@@ -49,7 +53,10 @@ for subdir in $(cd $srcdir && ls); do
       ${__dirname}/_resha.sh $site $dstdir $subdir
     fi
 
-    /home/nodejs/queue-cdn-purge.sh $site
   fi
 
 done
+
+if [ "$purge" == "yes" ]; then
+  /home/nodejs/queue-cdn-purge.sh $site promote
+fi

--- a/ansible/www-standalone/tools/promote/resha_release.sh
+++ b/ansible/www-standalone/tools/promote/resha_release.sh
@@ -25,4 +25,4 @@ fi
 
 ${__dirname}/_resha.sh $site $dstdir $2
 
-/home/nodejs/queue-cdn-purge.sh $site
+/home/nodejs/queue-cdn-purge.sh $site resha_release


### PR DESCRIPTION
Ref: #2264

We don't have logs of our calls to Cloudflare's cache purge API calls we make when we promote new /download/ assets or publish new website content, so this is adding such logging. Along the way, I think I've found one possible "bug" that may provide a partial explanation to our outage problems, but I'll explain that in #2249 

Additional comments inline.