### PR TITLE
Use system python3 on centos7-ppc64

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/centos7.yml
@@ -32,37 +32,25 @@
     dest: "/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo"
     mode: 0644
 
-- stat:
-    path: /usr/local/bin/python3.7
-  register: build_python37
-
-- name: centos7 | ppc64 | download python 3.7
-  get_url:
-    url: https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
-    dest: /tmp/
-  when: "arch == 'ppc64' and build_python37.stat.exists == False"
-
-- name: centos7 | ppc64 | unarchive python 3.7
-  unarchive:
-    src: /tmp/Python-3.7.3.tgz
-    remote_src: yes
-    dest: /tmp/
-  when: "arch == 'ppc64' and build_python37.stat.exists == False"
-
-- name: centos7 | ppc64 | configure python 3.7
-  shell: /tmp/Python-3.7.3/configure
-  args:
-    chdir: /tmp/Python-3.7.3
-  when: "arch == 'ppc64' and build_python37.stat.exists == False"
-
-- name: centos7 | ppc64 | install python 3.7
-  shell: make -j6 install
-  args:
-    chdir: /tmp/Python-3.7.3
-  when: "arch == 'ppc64' and build_python37.stat.exists == False"
-
+# Clean up from when Python 3 was installed from source
 - name: centos7 | ppc64 | clean python 3.7
   file:
     state: absent
-    path: /tmp/Python-3.7
-  when: "arch == 'ppc64' and build_python37.stat.exists == False"
+    path: "{{ item }}"
+  with_items:
+    - /tmp/Python-3.7
+    - /usr/local/bin/2to3
+    - /usr/local/bin/2to3-3.7
+    - /usr/local/bin/idle3
+    - /usr/local/bin/idle3.7
+    - /usr/local/bin/pydoc3
+    - /usr/local/bin/pydoc3.7
+    - /usr/local/bin/python3
+    - /usr/local/bin/python3.7
+    - /usr/local/bin/python3.7-config
+    - /usr/local/bin/python3.7m
+    - /usr/local/bin/python3.7m-config
+    - /usr/local/bin/python3-config
+    - /usr/local/bin/pyvenv
+    - /usr/local/bin/pyvenv-3.7
+  when: "arch == 'ppc64'"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -43,7 +43,7 @@ packages: {
   # partials/repo/centos7.yml for arm64
   centos7_arm64: ['git'], # git2u not available for aarch64 (yet)
   centos7_x64: ['devtoolset-6-libatomic-devel,git2u,centos-release-scl'],
-  centos7_ppc64: ['devtoolset-6-libatomic-devel,git'],
+  centos7_ppc64: ['devtoolset-6-libatomic-devel,git,python3'],
 
   centos7: [
     'bzip2-devel,openssl-devel,ccache,gcc-c++,devtoolset-6,sudo,zlib-devel,libffi-devel,devtoolset-8,devtoolset-8-libatomic-devel',


### PR DESCRIPTION
It install python 3.6.8.

Ansible's previously built python3 wasn't capable of running node's
./configure, it lacked sufficient capabilities (like bzip2).