### PR TITLE
ansible: add new expected docs asset for v12.x

### DIFF
--- a/ansible/www-standalone/tools/promote/expected_assets/v12.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v12.x
@@ -1,6 +1,7 @@
 docs/
 docs/apilinks.json
 docs/api/
+docs/previous-versions.json
 node-{VERSION}-aix-ppc64.tar.gz
 node-{VERSION}-darwin-x64.tar.gz
 node-{VERSION}-darwin-x64.tar.xz


### PR DESCRIPTION
Closes https://github.com/nodejs/build/issues/2276.

Updates expected assets on `v12.x` to include `docs/previous-versions.json`.

cc @rvagg 