### PR TITLE
jenkins: don't skip osx release sources build for 10.x

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -106,7 +106,7 @@ def buildExclusions = [
 
   // OSX ---------------------------------------------------
   [ /^osx1010/,                       testType,    gte(11) ],
-  [ /^osx1010/,                       releaseType, allVer  ],
+  [ /^osx1010(?!-release-sources)/,   releaseType, allVer  ],
   [ /^osx1011/,                       testType,    gte(14) ],
   [ /^osx1011/,                       releaseType, allVer  ],
   // osx1015 enabled for all, and builds all releases to support notarization
@@ -116,8 +116,6 @@ def buildExclusions = [
 
   // Source / headers / docs -------------------------------
   [ /^osx1010-release-sources$/,      releaseType, gte(11) ],
-  [ /^osx1011-release-sources$/,      releaseType, lt(11)  ],
-  [ /^osx1011-release-sources$/,      releaseType, gte(12) ],
   [ /^centos7-release-sources$/,      releaseType, lt(12)  ],
 
   // -------------------------------------------------------


### PR DESCRIPTION
Also remove redundant release sources for Node 10

Ref: https://github.com/nodejs/node/issues/32755

Explanation:

Hello foot-gun.

#2203 switched our release builds for osx to 10.15, which changed this whole block to prevent 10.10 and 10.11 for release builds.

Unfortunately, we have overlapping regexes that weren't noticed. Below this section is the "release-sources" labels. We used to build tarballs with osx all the way up to Node 11 when we switched to centos for Node 12. Node 10 is osx1010 and Node 11 was osx1011, so we have "release-sources" labels for those.

When we excluded `^osx1010` and `^osx1011` from `releaseType` we also excluded `osx1010-release-sources` from Node 10.

So the 10.20.0 iojs+release build has this:

```
20:27:22 Skipping centos7-release-sources for Node.js 10
20:27:22 Skipping osx1011-release-sources for Node.js 10
20:27:22 Skipping osx1010-release-sources for Node.js 10
```

No release-sources! So this PR uses a negative look-ahead to allow osx1010-release-sources back in to Node 10, the release-sources block below should do the right thing to select the right release-sources builder for each of them. I've also removed osx1011-release-sources from the list, that was only for Node 11.

Regarding https://github.com/nodejs/node/issues/32755 and the successful release of 10.20.0 and the headers and source files it has (see https://nodejs.org/download/release/v10.20.0/): I don't have the complete explanation because unfortunately the 26th of March is ~2 days too far beyond our ci-release build logs pruning date and I'm not sure if we store those as backups anywhere. But my guess is that a test 10.20.0 build was done on the 26th with an earlier version of the source and those files sat in staging. The change to VersionSelectorScript to switch to osx1015 was done on the 4th of April, so the 26th of May was before and it would have done a release-sources run. Then when the actual one was done, all of the assets were overwritten with new versions except for source and headers files, and the expected-assets check gave a green tick! If there weren't files in staging to make up the difference then it would have given a red cross.

So now we have a mismatch between sources, headers and the binaries. So 10.20.0 should probably be considered broken.