### PR TITLE
jenkins: drop smartos builds from release for 14+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -88,6 +88,7 @@ def buildExclusions = [
   [ /^smartos17/,                     anyType,     lt(10)  ],
   [ /^smartos17/,                     anyType,     gte(12) ],
   [ /^smartos18/,                     anyType,     lt(12)  ],
+  [ /^smartos18/,                     releaseType, gte(14) ],
 
   // AIX PPC64 ---------------------------------------------
   [ /aix61/,                          anyType,     gte(10) ],


### PR DESCRIPTION
Ref: #2168