### PR TITLE
jenkins: fix compiler selection for ppcle Linux

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -47,10 +47,7 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
         export LINK="ppc64le-redhat-linux-g++"
         echo "Compiler set to devtoolset-8"
         return
-      fi
-      ;;
-    *centos7* )
-      if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
+      elif [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         # Setup devtoolset-6, sets LD_LIBRARY_PATH, PATH, etc.
         . /opt/rh/devtoolset-6/enable
         export CC="ccache ppc64le-redhat-linux-gcc"


### PR DESCRIPTION
https://github.com/nodejs/build/pull/2262 mistakenly added a
duplicated case that prevented the previously existing logic from
being executed. Merge the two centos cases for ppcle Linux.

Refs: https://github.com/nodejs/node/pull/32768#issuecomment-612156432