### PR TITLE
jenkins: remove aix61-ppc64 and ppcle-ubuntu1404

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -36,8 +36,6 @@ def buildExclusions = [
 
   // Linux PPC LE ------------------------------------------
   [ /^centos7-ppcle/,                 anyType,     lt(10)  ],
-  [ /^ppcle-ubuntu/,                  releaseType, gte(10) ],
-  [ /^ppcle-ubuntu/,                  anyType,     gte(14) ],
 
   // Linux S390X --------------------------------------------
   [ /s390x/,                          anyType,     lt(6)   ],
@@ -91,7 +89,6 @@ def buildExclusions = [
   [ /^smartos18/,                     releaseType, gte(14) ],
 
   // AIX PPC64 ---------------------------------------------
-  [ /aix61/,                          anyType,     gte(10) ],
   [ /aix71/,                          anyType,     lt(10)  ],
 
   // Shared libs docker containers -------------------------

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -59,22 +59,6 @@ if [ "$SELECT_ARCH" = "PPC64LE" ]; then
       ;;
    esac
 
-  if [ "$NODEJS_MAJOR_VERSION" -gt "11" ]; then
-    # See: https://github.com/nodejs/build/pull/1723#discussion_r265740122
-    export PATH=/usr/lib/binutils-2.26/bin/:$PATH
-    export COMPILER_LEVEL="6"
-  elif [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-    export PATH=/usr/lib/binutils-2.26/bin/:$PATH
-    export COMPILER_LEVEL="4.9"
-  fi
-
-  # Select the appropriate compiler
-  export CC="gcc-${COMPILER_LEVEL}"
-  export CXX="g++-${COMPILER_LEVEL}"
-  export LINK="g++-${COMPILER_LEVEL}"
-
-  echo "Compiler set to $COMPILER_LEVEL"
-
 elif [ "$SELECT_ARCH" = "S390X" ]; then
 
   # Set default
@@ -136,23 +120,6 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       fi
       ;;
   esac
-
-  
-  echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX61"
-
-  if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
-    export LIBPATH=/home/iojs/gmake/opt/freeware/lib:/home/iojs/gcc-6.3.0-1/opt/freeware/lib/gcc/powerpc-ibm-aix6.1.0.0/6.3.0/pthread/ppc64:/home/iojs/gcc-6.3.0-1/opt/freeware/lib
-    export PATH="/home/iojs/gcc-6.3.0-1/opt/freeware/bin:$PATH"
-    export CC="ccache `which gcc`" CXX="ccache `which g++`" CXX_host="ccache `which g++`"
-    # TODO(sam-github): configure ccache by pushing /opt/freeware/bin/ccache on
-    # front of PATH
-    echo "Compiler set to 6.3"
-  else
-    export CC="ccache `which gcc`" CXX="ccache `which g++`" CXX_host="ccache `which g++`"
-    # TODO(sam-github): configure ccache by pushing /opt/freeware/bin/ccache on
-    # front of PATH
-    echo "Compiler set to default at 4.8.5"
-  fi
 
 elif [ "$SELECT_ARCH" = "X64" ]; then
   echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on x64"


### PR DESCRIPTION
All references to `aix61-ppc64` and `ppcle-ubuntu1404` have been removed 
from the test and release CI's so it should be safe to remove them from the
`select-compiler.sh` and `VersionSelectorScript.groovy` scripts.

Refs: https://github.com/nodejs/build/issues/2159
Refs: https://github.com/nodejs/build/issues/2273

cc @nodejs/platform-aix @nodejs/platform-ppc 