### PR TITLE
doc: Update the CI health dashboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Build and test orchestration is performed by [Jenkins][21].
 - A summary of build and test jobs can be found at: <https://ci.nodejs.org>
 - A listing of connected servers for testing, building and benchmarking
   can be found at: <https://ci.nodejs.org/computer/>
-- A summary of the general health of the last 100 jobs can be found at: <https://nodejs-ci-health.mmarchini.me/#/job-summary>
+- A summary of the general health of the last 100 jobs can be found at: <https://ci-health.nodejs.org/#/job-summary>
 
 The Build WG will keep build configuration required for a release line for 6
 months after the release goes End-of-Life, in case further build or test runs


### PR DESCRIPTION
Since changing it to run on nodejs.org the link doesn't work anymore