### PR TITLE
ansible: remove ubuntu1404 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -56,8 +56,6 @@ hosts:
 
     - osuosl:
         aix61-ppc64_be-1: {ip: 140.211.9.99}
-        ubuntu1404-ppc64_be-1: {ip: 140.211.168.76}
-        ubuntu1404-ppc64_le-1: {ip: 140.211.168.66}
         centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
 
     - orka:
@@ -174,11 +172,6 @@ hosts:
         aix61-ppc64_be-1: {ip: 140.211.9.101}
         aix61-ppc64_be-2: {ip: 140.211.9.100}
         aix61-ppc64_be-3: {ip: 140.211.9.77}
-        ubuntu1404-ppc64_be-1: {ip: 140.211.168.74}
-        ubuntu1404-ppc64_be-2: {ip: 140.211.168.75}
-        ubuntu1404-ppc64_le-1: {ip: 140.211.168.106}
-        ubuntu1404-ppc64_le-2: {ip: 140.211.168.94}
-        ubuntu1404-ppc64_le-4: {ip: 140.211.168.140}
         centos7-ppc64_le-1: {ip: 140.211.168.193, user: centos}
         centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos}
 


### PR DESCRIPTION
They have already been removed from ci and ci-release.