### PR TITLE
ansible: add iinthecloud provider

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -45,10 +45,10 @@ valid = {
     'type': ('infra', 'release', 'test'),
 
     # providers - validated for consistency
-    'provider': ('azure', 'digitalocean', 'ibm', 'joyent', 'linuxonecc',
-                 'macstadium', 'marist', 'mininodes', 'msft', 'osuosl',
-                 'orka', 'rackspace', 'requireio', 'scaleway', 'softlayer', 'voxer',
-                 'packetnet', 'nearform')
+    'provider': ('azure', 'digitalocean', 'ibm', 'iinthecloud', 'joyent',
+                 'linuxonecc', 'macstadium', 'marist', 'mininodes', 'msft',
+                 'nearform', 'orka', 'osuosl', 'packetnet', 'rackspace',
+                 'requireio', 'scaleway', 'softlayer', 'voxer')
 }
 DECRYPT_TOOL = "gpg"
 INVENTORY_FILENAME = "inventory.yml"


### PR DESCRIPTION
Add new provider [`iinthecloud`](https://iinthecloud.com/) and sort providers alphabetically.

I've split this out of https://github.com/nodejs/build/pull/1923 because we need to add the new provider
before we can add the secrets for the IBM i machines to the secrets 
repo (refs https://github.com/nodejs/build/pull/2253#discussion_r411809473 for when we added `orka`).
