### PR TITLE
jenkins: call checked out script if available

### DIFF
--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -39,5 +39,10 @@ if [ -n "${POST_REBASE_SHA1_CHECK}" ]; then
   fi
 fi
 
-# TODO(gib): Run locally once we're cloning the whole git repo.
-curl https://raw.githubusercontent.com/nodejs/build/master/jenkins/scripts/node-test-commit-diagnostics.sh | bash -ex -s before
+# Run the local copy, if we have one, or fetch the latest from GitHub.
+LOCAL_SCRIPT="${WORKSPACE}/build/jenkins/scripts/node-test-commit-diagnostics.sh"
+if [ -e "${LOCAL_SCRIPT}" ]; then
+  bash -ex "${LOCAL_SCRIPT}" before
+else
+  curl https://raw.githubusercontent.com/nodejs/build/master/jenkins/scripts/node-test-commit-diagnostics.sh | bash -ex -s before
+fi


### PR DESCRIPTION
If `node-test-commit-diagnostics.sh` exists locally (e.g. we are in
a checked out copy of the build repository then call the local version
from `node-test-commit-pre.sh`, otherwise download and execute the
latest from GitHub (as we had been doing before this change).

Refs: https://github.com/nodejs/build/issues/2330