### PR TITLE
jenkins: move 10.x release sources off osx

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -113,8 +113,7 @@ def buildExclusions = [
   [ /^freebsd10/,                     anyType,     gte(11) ],
 
   // Source / headers / docs -------------------------------
-  [ /^osx1010-release-sources$/,      releaseType, gte(11) ],
-  [ /^centos7-release-sources$/,      releaseType, lt(12)  ],
+  [ /^centos7-release-sources$/,      releaseType, lt(10)  ],
 
   // -------------------------------------------------------
 ]


### PR DESCRIPTION
I want to propose moving the build of 10.x release sources off osx onto linux with the rest of the release lines.

This will allow us to migrate off of our old macstadium vsphere (https://github.com/nodejs/build/issues/2315) as this is our only dependency upon osx 10.10.

Im not 100% sure if this is possible to test before merging.