### PR TITLE
Container upgrade: Alpine 3.12, OpenSSL 1.1.1g, remove OpenSSL 1.0.2 and FIPS

### DIFF
--- a/ansible/roles/docker/templates/alpine312.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine312.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
@@ -27,25 +27,26 @@ RUN apk add --no-cache --virtual .build-deps \
         libgcc \
         linux-headers \
         make \
-        paxctl \
-        python \
+        python3 \
         tar \
         ccache \
         openjdk8 \
         git \
         procps \
         openssh-client \
-        py2-pip \
+        py3-pip \
         bash \
         automake \
         libtool \
         autoconf
 
-RUN pip install tap2junit
+RUN pip3 install tap2junit
 
 RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser -G {{ server_user }} -D -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
+
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -34,45 +34,25 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
-ENV OPENSSL102DIR /opt/openssl-1.0.2r
+ENV OPENSSL110DIR /opt/openssl-1.1.0l
 
-RUN mkdir -p /tmp/openssl_1.0.2r && \
-    cd /tmp/openssl_1.0.2r && \
-    curl -sL https://www.openssl.org/source/openssl-1.0.2r.tar.gz | tar zxv --strip=1 && \
-    ./Configure shared linux-x86_64 --prefix=$OPENSSL102DIR -fPIC && \
-    make -j 6 && \
-    make install && \
-    rm -rf /tmp/openssl_1.0.r
-
-ENV OPENSSL110DIR /opt/openssl-1.1.0j
-
-RUN mkdir -p /tmp/openssl_1.1.0j && \
-    cd /tmp/openssl_1.1.0j && \
-    curl -sL https://www.openssl.org/source/openssl-1.1.0j.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.0l && \
+    cd /tmp/openssl_1.1.0l && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.0l.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL110DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.0j
+    rm -rf /tmp/openssl_1.1.0l
 
-ENV OPENSSL111DIR /opt/openssl-1.1.1b
+ENV OPENSSL111DIR /opt/openssl-1.1.1g
 
-RUN mkdir -p /tmp/openssl_1.1.1b && \
-    cd /tmp/openssl_1.1.1b && \
-    curl -sL https://www.openssl.org/source/openssl-1.1.1b.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.1g && \
+    cd /tmp/openssl_1.1.1g && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.1b
-
-ENV FIPS20DIR /opt/openssl-fips_2.0.16
-
-RUN FIPSDIR=$FIPS20DIR mkdir -p /tmp/openssl-fips_2.0.16 && \
-    cd /tmp/openssl-fips_2.0.16 && \
-    curl -sL https://openssl.org/source/openssl-fips-2.0.16.tar.gz | tar zxv --strip=1 && \
-    ./config --prefix=$FIPS20DIR && \
-    make && \
-    make install && \
-    rm -rf /tmp/openssl-fips_2.0.16
+    rm -rf /tmp/openssl_1.1.1g
 
 ENV ZLIB12DIR /opt/zlib_1.2.11
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -33,6 +33,7 @@ def buildExclusions = [
   [ /^ubuntu1404-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
+  [ /^alpine-latest-x64$/,            anyType,     lt(13)  ], // Alpine 3.12 doesn't have Python 2
 
   // Linux PPC LE ------------------------------------------
   [ /^centos7-ppcle/,                 anyType,     lt(10)  ],


### PR DESCRIPTION
Alpine 3.12 doesn't come with a Python 2 option and Node 10 and 12's `configure` don't seem to like Python 3 so I've added an exclusion to VersionSelectorScript. I've also had to symlink `python3` as `python` in those packages because we still force `PYTHON=python` in the commit-linux job.