### PR TITLE
ansible: add symlinks to cmake3 on centos7_ppc64

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -122,6 +122,19 @@
     insertbefore=BOF
     line='/usr/local/opt/ccache/libexec'
 
+- name: centos7_ppc64 | update package alternatives
+  when: os == "centos7" and arch == "ppc64"
+  alternatives:
+    link: /usr/local/bin/{{ cmake }}
+    name: "{{ cmake }}"
+    path: /usr/bin/{{ cmake }}3
+  loop_control:
+    loop_var: cmake
+  with_items:
+    - cmake
+    - cpack
+    - ctest
+
 - name: ubuntu1404 | update package alternatives
   when: os == "ubuntu1404"
   alternatives: link=/usr/bin/{{ gcc }} name={{ gcc }} path=/usr/bin/{{ gcc }}-4.9


### PR DESCRIPTION
On Centos 7 there are two cmake packages, cmake and cmake3. The
cmake package is cmake 2.x -- we install cmake3 as the projects
we build, e.g. libuv, require cmake 3.x. The cmake3 package
creates binaries that all have a 3 suffix, e.g. `cmake3`.

Node.js addons tested via CITGM that use cmake look for a cmake
binary without the version suffix, e.g. `cmake`. Add symlinks
so the binary names without the version suffix resolve to the
installed binaries for cmake (cmake, cpack and ctest).