### PR TITLE
ansible: remove old aix61 hosts

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -58,7 +58,6 @@ hosts:
         macos10.15-x64-1: {ip: 83.147.191.69, user: administrator}
 
     - osuosl:
-        aix61-ppc64_be-1: {ip: 140.211.9.99}
         centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
 
     - orka:
@@ -183,9 +182,6 @@ hosts:
     - osuosl:
 # secret for -1 was compromised, do not use -1 name
         aix72-ppc64_be-2: {ip: 140.211.9.30}
-        aix61-ppc64_be-1: {ip: 140.211.9.101}
-        aix61-ppc64_be-2: {ip: 140.211.9.100}
-        aix61-ppc64_be-3: {ip: 140.211.9.77}
         centos7-ppc64_le-1: {ip: 140.211.168.193, user: centos}
         centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos}
 


### PR DESCRIPTION
These hosts are long gone but still linger in our inventory