### PR TITLE
doc: add sudo to AIX Jenkins agent restart command

### DIFF
--- a/doc/jenkins-guide.md
+++ b/doc/jenkins-guide.md
@@ -206,7 +206,7 @@ launchctl stop org.nodejs.osx.jenkins
 launchctl start org.nodejs.osx.jenkins
 
 # AIX
-/etc/rc.d/rc2.d/S20jenkins start
+sudo /etc/rc.d/rc2.d/S20jenkins start
 
 # Other OSes
 ~iojs/start.sh


### PR DESCRIPTION
The agent restart command line should be run with `sudo` otherwise you will be prompted
for the password for the `iojs` user:
```
$ /etc/rc.d/rc2.d/S20jenkins start
iojs's Password:
...
```