### PR TITLE
ansible: refactor install AdoptOpenJDK Java tasks

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -32,55 +32,6 @@
   include_role:
     name: package-upgrade
 
-- name: download java ppc64
-  when: os in ("ubuntu1404", "centos7") and arch == "ppc64"
-  get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk8-releases/releases/download/jdk8u172-b11/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
-    dest: /tmp/
-
-- name: unarchive java ubuntu1404 ppc64
-  when: os in "ubuntu1404" and arch == "ppc64"
-  unarchive:
-    src: /tmp/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
-    remote_src: yes
-    dest: /home/iojs
-  tags: java
-
-- name: unarchive java centos7 ppc64
-  when: os in "centos7" and arch == "ppc64"
-  unarchive:
-    src: /tmp/OpenJDK8_ppc64le_Linux_jdk8u172-b11.tar.gz
-    remote_src: yes
-    dest: /opt
-  tags: java
-
-- name: symlink java centos7 ppc64
-  when: os in "centos7" and arch == "ppc64"
-  file:
-    src: "/opt/jdk8u172-b11/bin/java"
-    dest: "/usr/bin/java"
-    state: link
-
-- name: download java on s390x
-  when: os == "rhel7" and arch == "s390x"
-  get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u242-b08_openj9-0.18.1/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
-    dest: /tmp/
-- name: unarchive java s390x
-  when: os == "rhel7" and arch == "s390x"
-  unarchive:
-    src: /tmp/OpenJDK8U-jdk_s390x_linux_openj9_8u242b08_openj9-0.18.1.tar.gz
-    remote_src: yes
-    dest: /opt
-  tags: java
-
-- name: symlink java s390x
-  when: os == "rhel7" and arch == "s390x"
-  file:
-    src: "/opt/jdk8u242-b08/bin/java"
-    dest: "/usr/bin/java"
-    state: link
-
 # if this fails you want to check in vars/main.yml and add package name
 # as appropriate -- try to use generic os family if available.
 
@@ -109,32 +60,11 @@
         name: "{{ java_package_name }}"
         state: present
 
-- name: check if java is installed AIX
-  stat:
-    path: /home/iojs/jdk8u192-b12-jre/bin
-  register: java_exists
-  when: os|startswith("aix")
-
 - name: check if java is installed IBMi
   stat:
     path: /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java
   register: java_exists
   when: os|startswith("ibmi")
-
-- name: download java AIX
-  get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u192-b12/OpenJDK8U-jre_ppc64_aix_hotspot_8u192b12.tar.gz
-    dest: /tmp/
-  tags: java
-  when: os|startswith("aix") and java_exists.stat.exists == False
-
-- name: unarchive java AIX
-  unarchive:
-    src: /tmp/OpenJDK8U-jre_ppc64_aix_hotspot_8u192b12.tar.gz
-    remote_src: yes
-    dest: /home/iojs
-  tags: java
-  when: os|startswith("aix") and java_exists.stat.exists == False
 
 - name: install webupd8 oracle java 8 extras
   when: java.rc > 0 and os == "ubuntu1404" and arch != "ppc64"
@@ -142,3 +72,84 @@
   with_items:
     - ca-certificates
     - oracle-java8-set-default
+
+# Uses the AdoptOpenJDK API https://github.com/adoptopenjdk/openjdk-api-v3
+# to discover the most recent release for the given adoptopenjdk_version and
+# platform.
+- name: fetch adoptopenjdk metadata
+  register: adoptopenjdk_metadata
+  uri:
+    body_format: json
+    return_content: yes
+    status_code: 200
+    url: "https://api.adoptopenjdk.net/v3/assets/feature_releases/{{ adoptopenjdk_version }}/ga?architecture={{ adoptopenjdk_arch }}&image_type=jre&jvm_impl=openj9&os={{ adoptopenjdk_os }}&project=jdk&heap_size=normal&page_size=1&sort_method=DEFAULT&sort_order=DESC&vendor=adoptopenjdk"
+  when: use_adoptopenjdk == True
+
+# If we're already using the latest there is no need to do anything.
+- name: check existing adoptopenjdk version is up to date
+  set_fact:
+    update_adoptopenjdk: "{{ adoptopenjdk_metadata.json[0].version_data.openjdk_version not in java.stdout }}"
+  when: use_adoptopenjdk == True
+
+- name: create cache directory for adoptopenjdk binaries
+  file:
+    path: "/var/cache/adoptopenjdk-binaries"
+    state: directory
+  when: 
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+
+- name: download adoptopenjdk binary
+  get_url:
+    checksum: sha256:{{ adoptopenjdk_package.checksum }}
+    dest: "/var/cache/adoptopenjdk-binaries/{{ adoptopenjdk_package.name }}"
+    url: "{{ adoptopenjdk_package.link }}"
+  register: adoptopenjdk_local
+  when:
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+  vars:
+    adoptopenjdk_package: "{{ adoptopenjdk_metadata.json[0].binaries[0].package }}"
+
+- name: unpack adoptopenjdk binary
+  register: adoptopenjdk_unpacked
+  unarchive:
+    dest: "/opt/"
+    list_files: yes
+    remote_src: yes
+    src: "{{ adoptopenjdk_local.dest }}"
+  when:
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+
+# Store the current state of the symlink before modifying.
+- name: check existing adoptopenjdk symlink
+  register: adoptopenjdk_symlink
+  stat:
+    path: "/usr/bin/java"
+  when: 
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+
+- name: symlink adoptopenjdk
+  file:
+    src: "/opt/{{ adoptopenjdk_unpacked.files[0].split('/')[0] }}/bin/java"
+    dest: "/usr/bin/java"
+    state: link
+  when:
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+
+# If the symlink existed before we modified it, check if the old target matches
+# the new target. If they do not match, remove the old JRE.
+- name: remove old adoptopenjdk
+  file:
+    path: "{{ old_jdk_dir }}"
+    state: absent
+  vars:
+    old_jdk_dir: "{{ adoptopenjdk_symlink.stat.lnk_source | dirname | dirname }}"
+  when:
+    - use_adoptopenjdk == True
+    - update_adoptopenjdk == True
+    - adoptopenjdk_symlink.stat.exists
+    - adoptopenjdk_symlink.stat.lnk_source != "/opt/"+adoptopenjdk_unpacked.files[0].split('/')[0]+"/bin/java"

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -23,7 +23,7 @@ java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('
 
 # Add os_arch combinations here that should install and use AdoptOpenJDK
 # binaries. Override any variables in the dictionary. 
-# e.g. on AIX as ansible_architecture is 'chrp' on some of our hosts so we
+# e.g. on AIX ansible_architecture is 'chrp' on some of our hosts so we
 # override arch to be on the safe side.
 adoptopenjdk: {
   aix71_ppc64: { arch: ppc64 },

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -21,11 +21,13 @@ packages: {
 
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"
 
-# Add os_arch combinations here that should install and use AdoptOpenJDK binaries.
-# Override any variables in the dictionary, e.g. centos7_ppc64: { version: 11 }.
+# Add os_arch combinations here that should install and use AdoptOpenJDK
+# binaries. Override any variables in the dictionary. 
+# e.g. on AIX as ansible_architecture is 'chrp' on some of our hosts so we
+# override arch to be on the safe side.
 adoptopenjdk: {
-  aix71_ppc64: {},
-  aix72_ppc64: {},
+  aix71_ppc64: { arch: ppc64 },
+  aix72_ppc64: { arch: ppc64 },
   centos7_ppc64: {},
   rhel7_s390x: {}
 }

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -20,3 +20,17 @@ packages: {
   }
 
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"
+
+# Add os_arch combinations here that should install and use AdoptOpenJDK binaries.
+# Override any variables in the dictionary, e.g. centos7_ppc64: { version: 11 }.
+adoptopenjdk: {
+  aix71_ppc64: {},
+  aix72_ppc64: {},
+  centos7_ppc64: {},
+  rhel7_s390x: {}
+}
+
+adoptopenjdk_arch: "{{ adoptopenjdk[os+'_'+arch].arch | default(ansible_architecture) }}"
+adoptopenjdk_os: "{{ adoptopenjdk[os+'_'+arch].os | default(ansible_system | lower) }}"
+adoptopenjdk_version: "{{ adoptopenjdk[os+'_'+arch].version | default('8') }}"
+use_adoptopenjdk: "{{ adoptopenjdk[os+'_'+arch] is defined | bool }}"

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -5,9 +5,6 @@
 # purpose: script that will start or stop jenkins
 ##################################################
 
-
-# (@sam-github)  Purpose of java in PATH unknown, since an explicit path to
-# java is used to run jenkins.
 case "$1" in
 start )
         su - {{server_user}} -c '\
@@ -16,12 +13,11 @@ start )
 	      ulimit -m unlimited; \
 	      export TERM=ansi; \
               export jenkins_log_file="/home/{{server_user}}/jenkins_console.log"; \
-              export PATH=/home/{{server_user}}/jdk8u192-b12-jre/jre/bin:$PATH; \
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
               export OSTYPE=AIX72; \
-        /home/{{server_user}}/jdk8u192-b12-jre/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
+        /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
           -secret {{secret}} \
           -jnlpUrl {{jenkins_url}}/computer/{{inventory_hostname}}/slave-agent.jnlp >$jenkins_log_file 2>&1 &'
         ;;

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -89,8 +89,6 @@ needs_monit: [
 
 # some os'es needs different paths to java. add them here.
 java_path: {
-  'aix71': '/home/iojs/jdk8u192-b12-jre/bin/java',
-  'aix72': '/home/iojs/jdk8u192-b12-jre/bin/java',
   'ibmi72': '/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java',
   'macos10.10': 'java',
   'macos10.11': 'java',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/2393

Replace several duplicated tasks for installing Java from builds provided by AdoptOpenJDK with a set of common tasks.

Remove hardcoded Java release specific paths.

Thanks to @sxa for pointing me at the [AdoptOpenJDK API](https://github.com/adoptopenjdk/openjdk-api-v3) which these changes use to fetch the latest release for Java version being installed.

<details>
<summary>An example use of the API</summary>

https://api.adoptopenjdk.net/v3/assets/feature_releases/8/ga?architecture=ppc64le&image_type=jre&jvm_impl=openj9&os=linux&project=jdk&heap_size=normal&page_size=1&sort_method=DEFAULT&sort_order=DESC&vendor=adoptopenjdk
```json
[
    {
        "binaries": [
            {
                "architecture": "ppc64le",
                "download_count": 0,
                "heap_size": "normal",
                "image_type": "jre",
                "jvm_impl": "openj9",
                "os": "linux",
                "package": {
                    "checksum": "b1c91e757195b87d51027ea97fece00ac1adb9837b055e5f039dd45511fb3c0a",
                    "checksum_link": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01_openj9-0.21.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u265b01_openj9-0.21.0.tar.gz.sha256.txt",
                    "download_count": 0,
                    "link": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01_openj9-0.21.0/OpenJDK8U-jre_ppc64le_linux_openj9_8u265b01_openj9-0.21.0.tar.gz",
                    "name": "OpenJDK8U-jre_ppc64le_linux_openj9_8u265b01_openj9-0.21.0.tar.gz",
                    "size": 48506506
                },
                "project": "jdk",
                "scm_ref": "openj9-0.21.0",
                "updated_at": "2020-07-29T15:39:20Z"
            }
        ],
        "download_count": 466,
        "id": "MDc6UmVsZWFzZTI5MDY1MjIz.h/htfG2PeOnElg==",
        "release_link": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/tag/jdk8u265-b01_openj9-0.21.0",
        "release_name": "jdk8u265-b01_openj9-0.21.0",
        "release_type": "ga",
        "timestamp": "2020-07-29T10:03:22Z",
        "updated_at": "2020-07-29T10:03:22Z",
        "vendor": "adoptopenjdk",
        "version_data": {
            "build": 1,
            "major": 8,
            "minor": 0,
            "openjdk_version": "1.8.0_265-b01",
            "security": 265,
            "semver": "8.0.265+1"
        }
    }
]
```
</details>

I've run the updated scripts against `test-ibm-aix71-ppc64_be-1`, and `test-osuosl-centos7-ppc64_le-1` to update the version of Java used on those. I'll wait for some feedback/reviews before updating the rest.

Updated:
- [x] release-ibm-aix71-ppc64_be-1
- [x] release-osuosl-centos7-ppc64_le-1
- [x] test-ibm-aix71-ppc64_be-1
- [x] test-ibm-aix71-ppc64_be-2
- [x] test-osuosl-aix72-ppc64_be-2
- [x] test-osuosl-centos7-ppc64_le-1
- [x] test-osuosl-centos7-ppc64_le-2