### PR TITLE
ansible: install openjdk via yum for IBM i

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -73,24 +73,16 @@
     state: absent
 
 - name: install packages
-  when: not os|startswith("zos") and not os|startswith("macos") and not os|startswith("ibmi")
-  package: name="{{ package }}" state=present
+  when: not os|startswith("zos") and not os|startswith("macos")
+  package: 
+    name: "{{ package }}"
+    state: present
+    use: "{{ os|startswith(\"ibmi\")|ternary(\"yum\", omit) }}"
   loop_control:
     loop_var: package
   with_items:
     # ansible doesn't like empty lists
     - "{{ packages[os+'_'+arch]|default('[]') }}"
-    - "{{ packages[os]|default('[]') }}"
-    - "{{ packages[os|stripversion]|default('[]') }}"
-    - "{{ common_packages|default('[]') }}"
-
-- name: install packages IBMi
-  when: os|startswith("ibmi")
-  yum: name="{{ package }}" state=present use_backend=yum
-  loop_control:
-    loop_var: package
-  with_items:
-    # ansible doesn't like empty lists
     - "{{ packages[os]|default('[]') }}"
     - "{{ packages[os|stripversion]|default('[]') }}"
     - "{{ common_packages|default('[]') }}"

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -42,9 +42,14 @@
 
 - name: install java
   when:
-    - java.rc > 0 and not os|startswith("zos") and arch != "ppc64"
-    - java.rc > 0 and not os|startswith("macos")
-  package: name="{{ java_package_name }}" state=present
+    - java.rc > 0
+    - not os|startswith("zos")
+    - (arch != "ppc64" or os|startswith("ibmi"))
+    - not os|startswith("macos")
+  package:
+    name: "{{ java_package_name }}"
+    state: present
+    use: "{{ os|startswith(\"ibmi\")|ternary(\"yum\", omit) }}"
 
 - name: install java tap (macOS)
   become_user: administrator
@@ -59,12 +64,6 @@
   homebrew_cask:
         name: "{{ java_package_name }}"
         state: present
-
-- name: check if java is installed IBMi
-  stat:
-    path: /QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java
-  register: java_exists
-  when: os|startswith("ibmi")
 
 - name: install webupd8 oracle java 8 extras
   when: java.rc > 0 and os == "ubuntu1404" and arch != "ppc64"

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -12,6 +12,7 @@ packages: {
   'debian10': 'openjdk-8-jre-headless',
   'fedora': 'java-1.8.0-openjdk-headless',
   'freebsd': 'openjdk8-jre',
+  'ibmi': 'openjdk-11-ea',
   'macos': 'adoptopenjdk8',
   'rhel7': 'java-1.8.0-openjdk',
   'smartos': 'openjdk8',

--- a/ansible/roles/jenkins-worker/templates/ibmi_start.j2
+++ b/ansible/roles/jenkins-worker/templates/ibmi_start.j2
@@ -19,8 +19,8 @@ then
   exit 1
 fi
 
-export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
+export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -Djava.net.preferIPv4Stack=true -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
 
 echo $START_CMD
 
-exec /QOpenSys/usr/bin/system -v -kpiveO "SBMJOB CMD(QSH CMD('echo starting Jenkins slave && cd $HOME && env && exec $START_CMD')) CPYENVVAR(*YES) PRTDEV(*USRPRF) ALWMLTTHD(*YES) $SBMJOB_OPTS"
+exec /QOpenSys/usr/bin/system -v -kpiveO "SBMJOB CMD(QSH CMD('echo starting Jenkins slave && cd $HOME && env && touch $HOME/jenkins.log && setccsid 1208 $HOME/jenkins.log && exec $START_CMD')) CPYENVVAR(*YES) PRTDEV(*USRPRF) ALWMLTTHD(*YES) $SBMJOB_OPTS"

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -89,7 +89,7 @@ needs_monit: [
 
 # some os'es needs different paths to java. add them here.
 java_path: {
-  'ibmi72': '/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit/bin/java',
+  'ibmi72': '/QOpenSys/pkgs/lib/jvm/openjdk-11/bin/java',
   'macos10.10': 'java',
   'macos10.11': 'java',
   'macos10.12': 'java',


### PR DESCRIPTION
Install OpenJDK Java via the yum repository for IBM i.

Have run against `test-iinthecloud-ibmi72-ppc64_be-1` and `test-iinthecloud-ibmi72-ppc64_be-2`.

Had to pass `-Djava.net.preferIPv4Stack=true` to the Jenkins agent start command to get the agent to start up (otherwise the agent would fail to start with `java.net.SocketException: Protocol driver not attached.`).
cc @ThePrez 