### PR TITLE
jenkins: remove old macos from versionselector

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -104,10 +104,6 @@ def buildExclusions = [
   [ /sharedlibs_shared/,              anyType,     lt(9)   ],
 
   // OSX ---------------------------------------------------
-  [ /^osx1010/,                       testType,    gte(11) ],
-  [ /^osx1010(?!-release-sources)/,   releaseType, allVer  ],
-  [ /^osx1011/,                       testType,    gte(14) ],
-  [ /^osx1011/,                       releaseType, allVer  ],
   [ /^osx11/,                         testType,    lt(15)  ],
   // osx1015 enabled for all, and builds all releases to support notarization
 


### PR DESCRIPTION
These mac versions are no longer in our CI so removing
them from the versionselectorscript