### PR TITLE
jenkins: add ARM64 Windows

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -65,9 +65,10 @@ def buildExclusions = [
   [ /vcbt2015(-\w+)?$/,               testType,    gte(10)       ],
   [ /vs2017(-\w+)?$/,                 testType,    ltGte(8, 15)  ],
   [ /vs2019(-\w+)?$/,                 testType,    lt(13)        ],
-  [ /vs2015-x86$/,                    testType,    gte(10)       ], // compile x86 only once
+  [ /vs2015-x86$/,                    testType,    gte(10)       ], // compile arm64/x86 only once
   [ /vs2017-x86$/,                    testType,    ltGte(10, 14) ],
   [ /vs2019-x86$/,                    testType,    lt(14)        ],
+  [ /vs2019-arm64$/,                  testType,    lt(14)        ],
   // VS versions supported to build add-ons
   [ /vs2013-COMPILED_BY/,             testType,    gte(9)        ],
   [ /vs2015-COMPILED_BY/,             testType,    noVer         ],
@@ -161,6 +162,13 @@ combinations.each{
   if (nodeMajorVersion >= 4) {
     if (!canBuild(nodeMajorVersion, builderLabel, _buildType)) {
       println "Skipping $builderLabel for Node.js $nodeMajorVersion"
+      return
+    }
+  }
+  // Run tests on Windows ARM64 only if explicitly requested
+  if (builderLabel =~ /^win.*COMPILED_BY.*-arm64$/) {
+    if (!parameters['RUN_ARM64_TESTS'].toString().equalsIgnoreCase("true")){
+      println "Skipping $builderLabel because RUN_ARM64_TESTS is not selected"
       return
     }
   }

--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -18,7 +18,10 @@ if not defined DISABLE_CLCACHE if exist C:\clcache\dist\clcache_main\clcache_mai
 )
 
 :: Call vcbuild
-if "%nodes:~-4%" == "-x86" (
+if "%nodes:~-6%" == "-arm64" (
+  :: Building MSI is not yet supported for ARM64
+  set "VCBUILD_EXTRA_ARGS=arm64 release"
+) else if "%nodes:~-4%" == "-x86" (
   set "VCBUILD_EXTRA_ARGS=x86 %VCBUILD_EXTRA_ARGS%"
 ) else (
   set "VCBUILD_EXTRA_ARGS=x64 %VCBUILD_EXTRA_ARGS%"


### PR DESCRIPTION
Windows ARM64 cross-compilation support has recently been added to master/v14. This adds Windows ARM64 to the main Windows compile job in Jenkins. This allows us to move support for compilation for Windows ARM64 to Tier 2.

Running Node.js on ARM64 is still experimental, and we only have one machine connected to Jenkins at the moment. Thus, a checkbox is added in the main job to run the tests, disabled by default.

Test job: https://ci.nodejs.org/view/All/job/node-test-commit-windows-fanned-arm64/ . The changes in this job and the 3 subjobs that have the `-arm64` suffix need to land on the main jobs simultaneously with this PR.

cc @nodejs/build @nodejs/platform-windows 