### PR TITLE
ansible: update `upgrade-jar.yml` to use a variable

### DIFF
--- a/ansible/playbooks/jenkins/worker/upgrade-jar.yml
+++ b/ansible/playbooks/jenkins/worker/upgrade-jar.yml
@@ -14,5 +14,28 @@
         mode: 0644
         force: yes
 
-    - name: restart jenkins
+    - name: Kill Jenkins process - AIX
+      shell: ps awwx | grep jenkins | grep -v grep | awk '{ print $1 }' | xargs kill
+      when: os|startswith("aix")
+
+    - name: Restart Jenkins agent - AIX
+      shell: /etc/rc.d/rc2.d/S20jenkins start
+      become: yes
+      become_user: root
+      when: os|startswith("aix")
+
+    - name: Stop Jenkins process - macos
+      when: os|startswith("macos")
+      command: launchctl unload /Library/LaunchDaemons/org.nodejs.osx.jenkins.plist
+
+    - name: Reload Jenkins process - macos
+      when: os|startswith("macos")
+      command: launchctl load /Library/LaunchDaemons/org.nodejs.osx.jenkins.plist
+
+    - name: Restart Jenkins service - generic
+      when:
+        - not os|startswith("aix")
+        - not os|startswith("ibmi")
+        - not os|startswith("macos")
+        - not os|startswith("zos")
       service: name=jenkins state=restarted

--- a/ansible/playbooks/jenkins/worker/upgrade-jar.yml
+++ b/ansible/playbooks/jenkins/worker/upgrade-jar.yml
@@ -10,8 +10,9 @@
     - name: download slave.jar
       get_url:
         url: "{{ jenkins_worker_jar }}"
-        dest: /home/{{ server_user }}/slave.jar
+        dest: '{{ home }}/{{ server_user }}/slave.jar'
         mode: 0644
+        force: yes
 
     - name: restart jenkins
       service: name=jenkins state=restarted


### PR DESCRIPTION
When the certs expired on the main CI we had to upgrade the jenkins
agents to use the newer certs. When I tried this on the macs it failed
due to a hard coded `/home` which doesn't exist on mac. Used the create
playbook as the inspiration for this change.

I need to test this on mac before I can merge.