### PR TITLE
ansible: changes for z/OS 2.4 VMs

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -43,7 +43,6 @@ ansible_python_interpreter = /QOpenSys/pkgs/bin/python2
 
 [hosts:marist]
 ansible_become             = false
-ansible_python_interpreter = /NODEJS2/python-2017-04-12-py27/python27/bin/python
 ansible_ssh_transfer_method = sftp
 home                       = /u
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -146,6 +146,9 @@ hosts:
         zos13-s390x-1:
             ip: 148.100.36.133
             user: Unix1
+            ansible_python_interpreter: /NODEJS2/python-2017-04-12-py27/python27/bin/python
+            cmake_path_env: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
+            git_cmd: /NODEJS2/bin/git
             remote_env:
                 LIBPATH: /lib:/usr/lib:.:/NODEJS2/lib/perl5/5.24.0/os390/CORE.pod:/NODEJS2/python-2017-04-12-py27/python27/lib/
                 PATH: /NODEJS2/python-2017-04-12-py27/python27/bin:/bin:/NODEJS2/bin:/NODEJS/bin
@@ -153,9 +156,23 @@ hosts:
         zos13-s390x-2:
             ip: 148.100.36.134
             user: Unix1
+            ansible_python_interpreter: /NODEJS2/python-2017-04-12-py27/python27/bin/python
+            cmake_path_env: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
+            git_cmd: /NODEJS2/bin/git
             remote_env:
                 LIBPATH: /lib:/usr/lib:.:/NODEJS2/lib/perl5/5.24.0/os390/CORE.pod:/NODEJS2/python-2017-04-12-py27/python27/lib/
                 PATH: /NODEJS2/python-2017-04-12-py27/python27/bin:/bin:/NODEJS2/bin:/NODEJS/bin
+            server_jobs: 4
+        zos24-s390x-1:
+            ip: 148.100.36.155
+            user: unix1
+            ansible_python_interpreter: /rsusr/rocket/python-2017-04-12-py27/python27/bin/python
+            become_method: su
+            cmake_path_env: "{{ home }}/{{ server_user }}:/rsusr/rocket/bin:/bin"
+            git_cmd: /rsusr/rocket/bin/git
+            remote_env:
+                LIBPATH: /lib:/usr/lib:.:/rsusr/rocket/lib/perl5/5.24.0/os390/CORE.pod:/rsusr/rocket/python-2017-04-12-py27/python27/lib/
+                PATH: /rsusr/rocket/python-2017-04-12-py27/python27/bin:/bin:/rsusr/rocket/bin
             server_jobs: 4
 
     - mininodes:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -53,6 +53,7 @@ hosts:
 
     - marist:
         zos13-s390x-1: {ip: 148.100.36.135, user: Unix1}
+        zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
 
     - nearform:
         macos10.15-x64-1: {ip: 83.147.191.69, user: administrator}
@@ -165,6 +166,17 @@ hosts:
             server_jobs: 4
         zos24-s390x-1:
             ip: 148.100.36.155
+            user: unix1
+            ansible_python_interpreter: /rsusr/rocket/python-2017-04-12-py27/python27/bin/python
+            become_method: su
+            cmake_path_env: "{{ home }}/{{ server_user }}:/rsusr/rocket/bin:/bin"
+            git_cmd: /rsusr/rocket/bin/git
+            remote_env:
+                LIBPATH: /lib:/usr/lib:.:/rsusr/rocket/lib/perl5/5.24.0/os390/CORE.pod:/rsusr/rocket/python-2017-04-12-py27/python27/lib/
+                PATH: /rsusr/rocket/python-2017-04-12-py27/python27/bin:/bin:/rsusr/rocket/bin
+            server_jobs: 4
+        zos24-s390x-2:
+            ip: 148.100.36.156
             user: unix1
             ansible_python_interpreter: /rsusr/rocket/python-2017-04-12-py27/python27/bin/python
             become_method: su

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -151,13 +151,13 @@
   when: "'rhel7-s390x' in inventory_hostname"
 
 - name: download slave.jar
-  when: not os|startswith("zos")
   get_url:
     url: "{{ jenkins_worker_jar }}"
     dest: '{{ home }}/{{ server_user }}/slave.jar'
     mode: 0644
     timeout: 60
     force: yes
+    validate_certs: '{{ os|startswith("zos")|ternary("no", omit) }}'
 
 - name: Resolver | ipnodes needs to be present on zos, similar to hosts file
   when: os|startswith("zos")
@@ -184,17 +184,6 @@
   shell:
     cmd: "iconv -f utf8 -t ibm-1047 {{ resolve.dest }} > {{ (resolve.dest | splitext)[0] }}"
     creates: "{{ (resolve.dest | splitext)[0] }}"
-
-# temporary until we get the right cert bundles
-- name: download slave.jar -zos
-  when: os|startswith("zos")
-  get_url:
-    url: "{{ jenkins_worker_jar }}"
-    dest: '{{ home }}/{{ server_user }}/slave.jar'
-    mode: 0644
-    timeout: 60
-    validate_certs: no
-    force: yes
 
 - name: render git wrapper into place
   when: os|startswith("zos")
@@ -281,6 +270,7 @@
   when: os|startswith("zos")
   file:
     owner: "{{ server_user }}"
+    mode: "0775"
     path: "{{ home }}/{{ server_user }}/cmake"
     state: directory
 
@@ -317,11 +307,12 @@
   environment:
     _C89_CCMODE: 1
     _CC_CCMODE: 1
+    _CEE_RUNOPTS: FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)
     _CXX_CCMODE: 1
     _TAG_REDIR_ERR: txt
     _TAG_REDIR_IN: txt
     _TAG_REDIR_OUT: txt
-    PATH: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
+    PATH: "{{ cmake_path_env }}"
     TMPDIR: "{{ home }}/{{ server_user }}/temp"
   shell:
     chdir: "{{ home }}/{{ server_user }}/cmake/CMake-3.5.1-zos"
@@ -329,7 +320,7 @@
     creates: "{{ home }}/{{ server_user }}/local/bin/cmake"
 
 - name: render gyp into place - Create directory - part 1
-  when: os|startswith("zos")
+  when: os|startswith("zos13")
   file:
     path: "{{ home }}/{{ server_user }}/gyp"
     state: directory
@@ -338,7 +329,7 @@
 # only provides an https endpoint.  We store on ci
 # instead
 - name: render gyp into place - get the zip - part 2
-  when: os|startswith("zos")
+  when: os|startswith("zos13")
   uri:
     url: "http://ci.nodejs.org/downloads/zos/gyp.tar.gz"
     dest: "{{ home }}/{{ server_user }}/gyp/gyp.tar.gz"
@@ -347,7 +338,7 @@
 # note that unarchive does not work (does not like version
 # of tar) so just execute commands directly
 - name: render gyp into place - decompress - part 3
-  when: os|startswith("zos")
+  when: os|startswith("zos13")
   command: "gunzip gyp.tar.gz"
   args:
     chdir: "{{ home }}/{{ server_user }}/gyp"
@@ -356,14 +347,14 @@
 # the user option does not seem to work so
 # do that change in separate step below
 - name: render gyp into place - extract - part 4
-  when: os|startswith("zos")
+  when: os|startswith("zos13")
   command: "pax -rf gyp.tar -o from=iso8859-1,to=ibm-1047"
   args:
     chdir: "{{ home }}/{{ server_user }}/gyp"
     creates:  "{{ home }}/{{ server_user }}/gyp/LICENSE"
 
 - name: render gyp into place - fix up ownership - part 5
-  when: os|startswith("zos")
+  when: os|startswith("zos13")
   command: "chown -R {{ server_user }} {{ home }}/{{ server_user }}/gyp"
 
 # This has to be done before the `service` (and similar) commands because

--- a/ansible/roles/jenkins-worker/templates/git-wrapper.j2
+++ b/ansible/roles/jenkins-worker/templates/git-wrapper.j2
@@ -6,9 +6,9 @@ export _TAG_REDIR_IN=txt
 export _TAG_REDIR_OUT=txt
 
 if [[ $1 == "rev-parse" ]]; then
-  /NODEJS2/bin/git "$@" | cat
+  {{ git_cmd }} "$@" | cat
 elif [[ $1 == "whatchanged" ]]; then
-  /NODEJS2/bin/git "$@" | iconv -f iso8859-1 -t ibm-1047 | iconv -t iso8859-1 -f ibm-1047
+  {{ git_cmd }} "$@" | iconv -f iso8859-1 -t ibm-1047 | iconv -t iso8859-1 -f ibm-1047
 else
-  /NODEJS2/bin/git $@
+  {{ git_cmd }} $@
 fi

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -102,7 +102,8 @@ java_path: {
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',
   'smartos18': '/opt/local/java/openjdk8/bin/java',
-  'zos13': '/u/unix1/java/J8.0_64/bin/java'
+  'zos13': '/u/unix1/java/J8.0_64/bin/java',
+  'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 
 # same for bash. will default to /bin/bash if you don't set it


### PR DESCRIPTION
The location of some installed tools has changed in the z/OS 2.4 VMs
we've been given from marist compared to the existing z/OS 2.2 VMs.

Refs: https://github.com/nodejs/build/issues/2435

- [x] Run ansible scripts on new z/OS 2.4 VM
- [x] Add new z/OS 2.4 VM to firewall
- [x] Test libuv build on new z/OS VM