### PR TITLE
ansible: remove `.nodejs.org` from hostname on AIX and mac

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -23,13 +23,13 @@
 - name: Set hostname to inventory_hostname macOS
   command: "{{ item }}"
   with_items:
-    - "sudo scutil --set HostName {{ inventory_hostname }}.nodejs.org"
-    - "sudo scutil --set ComputerName {{ inventory_hostname }}.nodejs.org"
+    - "sudo scutil --set HostName {{ inventory_hostname }}"
+    - "sudo scutil --set ComputerName {{ inventory_hostname }}"
     - "dscacheutil -flushcache"
   when: os|startswith("macos")
 
 - name: Set hostname to inventory_hostname AIX
-  command: " hostname {{ inventory_hostname }}.nodejs.org"
+  command: " hostname {{ inventory_hostname }}"
   when: os|startswith("aix")
 
 - name: disable joyent smartconnect


### PR DESCRIPTION
The `nodejs.org` is uneeded and at least on AIX it causes tests to fail by resolving to an incorrect IP

refs: https://github.com/nodejs/build/issues/2447