### PR TITLE
ansible: remove z/OS 2.2 VMs

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -52,7 +52,6 @@ hosts:
         macos10.10-x64-1: {ip: 207.254.58.162, port: 10014, user: administrator}
 
     - marist:
-        zos13-s390x-1: {ip: 148.100.36.135, user: Unix1}
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
 
     - nearform:
@@ -144,26 +143,6 @@ hosts:
         macos11.0-arm64-2: {ip: 199.7.163.10, user: administrator}
 
     - marist:
-        zos13-s390x-1:
-            ip: 148.100.36.133
-            user: Unix1
-            ansible_python_interpreter: /NODEJS2/python-2017-04-12-py27/python27/bin/python
-            cmake_path_env: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
-            git_cmd: /NODEJS2/bin/git
-            remote_env:
-                LIBPATH: /lib:/usr/lib:.:/NODEJS2/lib/perl5/5.24.0/os390/CORE.pod:/NODEJS2/python-2017-04-12-py27/python27/lib/
-                PATH: /NODEJS2/python-2017-04-12-py27/python27/bin:/bin:/NODEJS2/bin:/NODEJS/bin
-            server_jobs: 4
-        zos13-s390x-2:
-            ip: 148.100.36.134
-            user: Unix1
-            ansible_python_interpreter: /NODEJS2/python-2017-04-12-py27/python27/bin/python
-            cmake_path_env: "{{ home }}/{{ server_user }}:/bin:/NODEJS2/bin:/NODEJS/bin"
-            git_cmd: /NODEJS2/bin/git
-            remote_env:
-                LIBPATH: /lib:/usr/lib:.:/NODEJS2/lib/perl5/5.24.0/os390/CORE.pod:/NODEJS2/python-2017-04-12-py27/python27/lib/
-                PATH: /NODEJS2/python-2017-04-12-py27/python27/bin:/bin:/NODEJS2/bin:/NODEJS/bin
-            server_jobs: 4
         zos24-s390x-1:
             ip: 148.100.36.155
             user: unix1

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -102,7 +102,6 @@ java_path: {
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',
   'smartos18': '/opt/local/java/openjdk8/bin/java',
-  'zos13': '/u/unix1/java/J8.0_64/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 


### PR DESCRIPTION
The new z/OS 2.4 VMs look to be in good working order so remove the
old z/OS 2.2 VMs that the new ones replace.

Closes: https://github.com/nodejs/build/issues/2435

I've gone through the Jenkins configs and removed any references to the old VMs.