### PR TITLE
github-bot: update Node.js from 10.x -> 14.x

### DIFF
--- a/ansible/roles/github-bot/tasks/main.yml
+++ b/ansible/roles/github-bot/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Bootstrap | Add nodesource repo
   apt_repository:
-    repo: deb https://deb.nodesource.com/node_10.x jessie main
+    repo: deb https://deb.nodesource.com/node_14.x jessie main
     state: present
 
 - name: Bootstrap | APT Update and upgrade


### PR DESCRIPTION
It's about time we bump Node.js the @nodejs-github-bot is running (for obvious reasons).

CI says it's good to go and with pretty decent test coverage, it feels less than risky to go ahead and update Node.js on the server.

Refs https://github.com/nodejs/github-bot/pull/287

/cc @nodejs/github-bot 