### PR TITLE
jenkins: add overlapped-checker.exe to binary.tgz

### DIFF
--- a/jenkins/scripts/windows/node-compile-windows.cmd
+++ b/jenkins/scripts/windows/node-compile-windows.cmd
@@ -17,6 +17,7 @@ if errorlevel 1 exit /b
 :: Select files to pack
 set "BINARY_FILES=config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/node.pdb"
 if exist Release\node_test_engine.dll set "BINARY_FILES=%BINARY_FILES% Release/node_test_engine.dll"
+if exist Release\overlapped-checker.exe set "BINARY_FILES=%BINARY_FILES% Release/overlapped-checker.exe"
 
 :: Setup binary package
 rm -rf binary


### PR DESCRIPTION
Required for testing overlapped I/O on windows (#29412)