### PR TITLE
ansible: fix needed to run debian8 bootstrap in check mode

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/debian8.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian8.yml
@@ -5,12 +5,12 @@
 #
 
 - name: check for apt-transport-https
-  raw: stat /usr/lib/apt/methods/https
+  stat:
+    path: /usr/lib/apt/methods/https
   register: has_apt_transport
-  failed_when: has_apt_transport.rc > 1
 
 - name: install apt-transport-https
-  when: has_apt_transport.rc == 1
+  when: has_apt_transport.stat.exists == False
   raw: apt-get install -y apt-transport-https
 
 - name: install dbus


### PR DESCRIPTION
Running playbooks using the `bootstrap` role on machines running debian8 failed when in check mode:

```
$ ansible-playbook --check playbooks/create-github-bot.yml

TASK [bootstrap : check for apt-transport-https] ****************************************************************************************************************************************
skipping: [infra-rackspace-debian8-x64-1]

TASK [bootstrap : install apt-transport-https] ******************************************************************************************************************************************
fatal: [infra-rackspace-debian8-x64-1]: FAILED! => {"msg": "The conditional check 'has_apt_transport.rc == 1' failed. The error was: error while evaluating conditional (has_apt_transport.rc == 1): 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/..../build/ansible/roles/bootstrap/tasks/partials/debian8.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: install apt-transport-https\n  ^ here\n"}
```

The `install apt-transport-https` task failed due to the fact that the preceding `check for apt-transport-https` did not define the `has_apt_transport` result because it got skipped.

Ansible skips that task by default because it uses a `raw` command and it's therefore unknown wheter or not that command has a side effect.

~~By setting `check_mode: no` we tell ansible it's okey to run that command also when running playbooks in check mode (`--check`).~~

Instead of using `raw`, we ended up wanting to use `stat` for the purpose of checking if a file exists or not. Primarily because it's more self descriptive and ansible knows it safe to execute in all scenarios, so it doesn't need to be _forcibly_ run in check mode.

Refs https://github.com/nodejs/build/issues/2487