### PR TITLE
ansible: remove reference to old AIX71 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -35,7 +35,6 @@ hosts:
         centos7-x64-1: {ip: 138.68.12.105}
 
     - ibm:
-        aix71-ppc64_be-1: {ip: 129.33.196.199, user: b9s010a}
         aix71-ppc64_be-2: {ip: 169.48.19.173}
         rhel7-s390x-1: {ip: 148.100.86.101, user: linux1}
 
@@ -119,8 +118,6 @@ hosts:
         ubuntu1804-x64-1: {ip: 178.128.181.213}
 
     - ibm:
-        aix71-ppc64_be-1: {ip: 129.33.196.197, user: b9s010a}
-        aix71-ppc64_be-2: {ip: 129.33.196.198, user: b9s010a}
         aix71-ppc64_be-3: {ip: 169.48.22.38}
         aix71-ppc64_be-4: {ip: 169.48.22.51}
         rhel7-s390x-1: {ip: 148.100.86.21, user: linux1}


### PR DESCRIPTION
Our DOU expired at the end of 2020 so these machines have now been
removed. The machines have already been replaced.