### PR TITLE
ansible: fix scripts for Orka macOS 10.14 hosts

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -56,4 +56,3 @@ ansible_winrm_server_cert_validation = ignore
 
 [hosts:macos]
 home = /Users
-ansible_python_interpreter = /usr/bin/python3

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -62,7 +62,11 @@ hosts:
         centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
 
     - orka:
-        macos10.15-x64-1: {ip: 199.7.167.101, port: 8822, user: administrator}
+        macos10.15-x64-1:
+            ansible_python_interpreter: /usr/bin/python3
+            ip: 199.7.167.101
+            port: 8822
+            user: administrator
 
     - packetnet:
         centos7-arm64-1: {ip: 147.75.104.218}
@@ -203,11 +207,31 @@ hosts:
         centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos}
 
     - orka:
-        macos10.15-x64-1: {ip: 199.7.167.100, port: 8823, user: administrator}
-        macos10.15-x64-2: {ip: 199.7.167.99, port: 8823, user: administrator}
-        macos10.14-x64-1: {ip: 199.7.167.99, port: 8822, user: administrator}
-        macos10.14-x64-2: {ip: 199.7.167.100, port: 8824, user: administrator}
-        macos10.14-x64-3: {ip: 199.7.167.101, port: 8824, user: administrator}
+        macos10.15-x64-1:
+            ansible_python_interpreter: /usr/bin/python3
+            ip: 199.7.167.100
+            port: 8823
+            user: administrator
+        macos10.15-x64-2:
+            ansible_python_interpreter: /usr/bin/python3
+            ip: 199.7.167.99
+            port: 8823
+            user: administrator
+        macos10.14-x64-1:
+            ansible_python_interpreter: /usr/local/bin/python3
+            ip: 199.7.167.99
+            port: 8822
+            user: administrator
+        macos10.14-x64-2:
+            ansible_python_interpreter: /usr/local/bin/python3
+            ip: 199.7.167.100
+            port: 8824
+            user: administrator
+        macos10.14-x64-3:
+            ansible_python_interpreter: /usr/local/bin/python3
+            ip: 199.7.167.101
+            port: 8824
+            user: administrator
 
     - iinthecloud:
         ibmi72-ppc64_be-1: {ip: 65.183.160.52, user: nodejs}

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/macos10.14.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/macos10.14.yml
@@ -1,0 +1,11 @@
+---
+
+#
+# install tap2junit from pip
+#
+
+- name: install tap2junit
+  pip:
+    name: tap2junit
+    state: latest
+    executable: /usr/local/bin/pip3

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -7,6 +7,6 @@ export OSTYPE=osx
 export ARCH=x64
 export DESTCPU=x64
 
-PATH="/usr/local/opt/ccache/libexec:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
+PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp


### PR DESCRIPTION
The Orka macOS 10.14 do not have a system Python installed in
`/usr/bin`. Amend the ansible scripts to use the brew installed
Python 3 on those hosts.

Fixes: https://github.com/nodejs/build/issues/2512

cc @AshCripps 