### PR TITLE
ansible,docker: ensure <1024 are privileged ports

### DIFF
--- a/ansible/roles/docker/templates/jenkins.service.j2
+++ b/ansible/roles/docker/templates/jenkins.service.j2
@@ -9,7 +9,7 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/docker run --init --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} -v /home/{{ server_user }}/.ccache/:/home/{{ server_user }}/.ccache --name node-ci-{{ item.name }} node-ci:{{ item.name }}
+ExecStart=/usr/bin/docker run --init --rm -v /home/{{ server_user }}/{{ item.name }}/:/home/{{ server_user }} -v /home/{{ server_user }}/.ccache/:/home/{{ server_user }}/.ccache --name node-ci-{{ item.name }} --sysctl net.ipv4.ip_unprivileged_port_start=1024 node-ci:{{ item.name }}
 ExecStop=/usr/bin/docker stop -t 5 node-ci-{{ item.name }}
 Restart=always
 RestartSec=30

--- a/ansible/roles/jenkins-worker/templates/docker-jenkins.service.j2
+++ b/ansible/roles/jenkins-worker/templates/docker-jenkins.service.j2
@@ -9,7 +9,7 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/docker run --init --rm -v /home/{{ server_user }}:/home/{{ server_user }} --name node-ci-{{ item.name }} node-ci:{{ item.name }}
+ExecStart=/usr/bin/docker run --init --rm -v /home/{{ server_user }}:/home/{{ server_user }} --name node-ci-{{ item.name }} --sysctl net.ipv4.ip_unprivileged_port_start=1024 node-ci:{{ item.name }}
 ExecStop=/usr/bin/docker stop -t 5 node-ci-{{ item.name }}
 Restart=always
 RestartSec=30


### PR DESCRIPTION
Since Docker 20.10.0 @ 2020-12-08, port binding has been made unrestricted.
This change undoes that by ensuring that <1024 are privileged. Node.js' test
suite assumes that binding to a lower port will result in a privilege failure
so we need to create an environment suitable for that assumption.

Ref: https://github.com/nodejs/node/issues/36847