### PR TITLE
jenkins: unset LIBPATH on AIX 7.1

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -118,6 +118,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
       if [ "$NODEJS_MAJOR_VERSION" -gt "9" ]; then
         export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/gcc6/bin:/opt/freeware/bin:$PATH"
         export CC="gcc" CXX="g++" CXX_host="g++"
+        unset LIBPATH
         echo "Compiler set to 6.3"
         return
       else


### PR DESCRIPTION
It appears that either Jenkins and/or the JDK on AIX is setting the
`LIBPATH` environment variable which is breaking `gcc`/`g++`. Some
jobs already `unset LIBPATH` -- now do this consistently in the
`select-compiler.sh` script.

This should allow us to avoid having to do the rather horrible manual 
hack in https://github.com/nodejs/build/blob/master/ansible/MANUAL_STEPS.md#fix-missing-shared-objects

Refs: https://github.com/nodejs/build/issues/2534

cc @nodejs/platform-aix 