### PR TITLE
ansible: fix curl: not found errors on AIX

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -199,6 +199,19 @@
     regexp: '^127\.0\.1\.1\s+\w.+$'
     line: '127.0.1.1        {{safe_hostname}}'
 
+- name: aix | update curl symlinks
+  when: os|startswith("aix")
+  file:
+    src: "/opt/freeware/bin/{{ curl }}"
+    dest: "/usr/bin/{{ curl }}"
+    state: link
+  loop_control:
+    loop_var: curl
+  with_items:
+    - curl
+    - curl_32
+    - curl_64
+
 - name: run ccache installer
   when: os == "rhel7" and arch == "s390x" and not has_ccache.stat.exists
   include: ccache.yml

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -54,7 +54,7 @@ packages: {
   ],
 
   aix: [
-    'bash,cmake,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo',
+    'bash,cmake,curl,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo',
   ],
 
   ibmi: [


### PR DESCRIPTION
Recent versions of the AIX Toolbox curl package no longer create
symlinks in `/usr/bin`. Some jobs in the CI expect to be able to
run `curl` from the PATH.

Explicitly install the curl package (previously it was installed
as a dependency of git) and create symlinks into `/usr/bin`.

Fixes: https://github.com/nodejs/build/issues/2536

cc @nodejs/platform-aix 