### PR TITLE
jenkins: replace AIX71 upper limit with releaseType

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -92,7 +92,7 @@ def buildExclusions = [
 
   // AIX PPC64 ---------------------------------------------
   [ /aix71/,                          anyType,     lt(10)  ],
-  [ /aix71/,                          anyType,     gte(15)  ],
+  [ /aix71/,                          releaseType, gte(15) ],
   [ /aix72/,                          anyType,     lt(15)  ],
 
   // Shared libs docker containers -------------------------


### PR DESCRIPTION
We still want to test on the earlier AIX but not release on it