### PR TITLE
ansible: add python3 to AIX hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -54,7 +54,7 @@ packages: {
   ],
 
   aix: [
-    'bash,cmake,curl,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo,python-setuptools',
+    'bash,cmake,curl,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo,python-setuptools,python3',
   ],
 
   ibmi: [


### PR DESCRIPTION
I've run this on all of our test/release AIX 7.1 and 7.2 hosts. It installs Python 3 (3.7.9 at this time) into `/opt/freeware/bin`, e.g. `/opt/freeware/bin/python3`. Crucially it leaves the existing Python 2 installation alone (so `python` still runs Python 2). 

On the AIX 7.2 machines there is already a Python 3.6.12 installation in `/opt/bin/python3`. We end up with three versions of Python installed (2.7.18, 3.6.12 and 3.7.9) but they're in different directories and the python3 binary we pick up depends on the path. If we've run through select-compiler.sh and prepend `/opt/freeware/bin` to the path `python3` will be 3.7.9. https://github.com/nodejs/build/blob/f95880c7e40a1d547afdbfeb9376c476bd6cd5e7/jenkins/scripts/select-compiler.sh#L103

I haven't found a CI job that will actually use Python 3 yet as they either directly call `python configure ...` (i.e. invoke `python` which is Python 2) or they run `make run-ci` which defaults the `PYTHON` make variable to `python` (again Python 2). We'll probably need to directly run `configure ...` (as there is Python autodetection/selection logic in the `configure` script) and/or set the default `PYTHON` in the makefile to `python3` in master/16.x onwards.

cc @nodejs/platform-aix 