### PR TITLE
Add M1 macs 

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -50,8 +50,9 @@ hosts:
         ubuntu1804_docker-x64-1: {ip: 165.225.150.76, user: ubuntu}
 
     - macstadium:
-        macos10.11-x64-1: {ip: 207.254.58.162, port: 10013, user: administrator}
-        macos10.10-x64-1: {ip: 207.254.58.162, port: 10014, user: administrator}
+        macos11.0-arm64-1:
+            ip: 207.254.38.74
+            user: administrator
 
     - marist:
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
@@ -157,6 +158,12 @@ hosts:
             user: administrator
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
+        macos11.0-arm64-3:
+            ip: 207.254.38.86
+            user: administrator
+        macos11.0-arm64-4:
+            ip: 207.254.38.89
+            user: administrator
 
     - marist:
         zos24-s390x-1:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -156,16 +156,6 @@ hosts:
         ubuntu1804-x64-1: {ip: 165.225.149.88, user: ubuntu}
 
     - macstadium:
-        macos11.0-arm64-1:
-            ip: 199.7.163.9
-            user: administrator
-            remote_env:
-                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
-        macos11.0-arm64-2:
-            ip: 199.7.163.10
-            user: administrator
-            remote_env:
-                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
         macos11.0-arm64-3:
             ansible_python_interpreter: /usr/bin/python3
             ip: 207.254.38.86

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -56,6 +56,7 @@ hosts:
             user: administrator
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
+            server_jobs: 6
 
     - marist:
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -152,7 +152,11 @@ hosts:
 
     - macstadium:
         macos11.0-arm64-1: {ip: 199.7.163.9, user: administrator}
-        macos11.0-arm64-2: {ip: 199.7.163.10, user: administrator}
+        macos11.0-arm64-2:
+            ip: 199.7.163.10
+            user: administrator
+            remote_env:
+                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
 
     - marist:
         zos24-s390x-1:

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -155,7 +155,11 @@ hosts:
         ubuntu1804-x64-1: {ip: 165.225.149.88, user: ubuntu}
 
     - macstadium:
-        macos11.0-arm64-1: {ip: 199.7.163.9, user: administrator}
+        macos11.0-arm64-1:
+            ip: 199.7.163.9
+            user: administrator
+            remote_env:
+                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
         macos11.0-arm64-2:
             ip: 199.7.163.10
             user: administrator
@@ -204,14 +208,6 @@ hosts:
         ubuntu1604-arm64_odroid_c2-1: {ip: 70.167.220.147}
         ubuntu1604-arm64_odroid_c2-2: {ip: 70.167.220.148}
         ubuntu1604-arm64_odroid_c2-3: {ip: 70.167.220.149, user: odroid}
-
-    - macstadium:
-        macos10.10-x64-1: {ip: 207.254.58.162, port: 10005, user: administrator}
-        macos10.10-x64-2: {ip: 207.254.58.162, port: 10006, user: administrator}
-        macos10.11-x64-1: {ip: 207.254.58.162, port: 10003, user: administrator}
-        macos10.11-x64-2: {ip: 207.254.58.162, port: 10004, user: administrator}
-        macos10.12-x64-1: {ip: 207.254.58.162, port: 10001, user: administrator}
-        macos10.12-x64-2: {ip: 207.254.58.162, port: 10002, user: administrator}
 
     - msft:
         win10_vs2017-arm64-1: {}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -51,8 +51,11 @@ hosts:
 
     - macstadium:
         macos11.0-arm64-1:
+            ansible_python_interpreter: /usr/bin/python3
             ip: 207.254.38.74
             user: administrator
+            remote_env:
+                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
 
     - marist:
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
@@ -159,11 +162,17 @@ hosts:
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
         macos11.0-arm64-3:
+            ansible_python_interpreter: /usr/bin/python3
             ip: 207.254.38.86
             user: administrator
+            remote_env:
+                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
         macos11.0-arm64-4:
+            ansible_python_interpreter: /usr/bin/python3
             ip: 207.254.38.89
             user: administrator
+            remote_env:
+                PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
 
     - marist:
         zos24-s390x-1:

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -76,30 +76,30 @@
 # Ensure node is not installed anywhere but the linter servers
 #
 
-# - hosts:
-#   - test
-#   - release
-#   - "!test-packetnet-ubuntu1804-x64-1"
-#   - "!test-packetnet-ubuntu1804-x64-2"
-#   - "!test-ibm-ubuntu1804-x64-1"
-#   tasks:
-#     - name: remove node and npm packages
-#       when: not os|startswith("win") and not os|startswith("zos") and not os|startswith("ibmi")
-#       package:
-#         name: "{{ package }}"
-#         state: absent
-#       loop_control:
-#         loop_var: package
-#       with_items: [ "node", "nodejs", "npm" ]
-#     - name: fail if node is in the path - please uninstall it
-#       when: not os|startswith("win")
-#       shell: "node -v"
-#       register: node_check_cmd
-#       failed_when: node_check_cmd.rc == 0
-#       changed_when: False
-#     - name: fail if node is in the path - please uninstall it
-#       when: os|startswith("win")
-#       win_shell: "node -v"
-#       register: node_check_cmd_win
-#       failed_when: node_check_cmd_win.rc == 0
-#       changed_when: False
+- hosts:
+  - test
+  - release
+  - "!test-packetnet-ubuntu1804-x64-1"
+  - "!test-packetnet-ubuntu1804-x64-2"
+  - "!test-ibm-ubuntu1804-x64-1"
+  tasks:
+    - name: remove node and npm packages
+      when: not os|startswith("win") and not os|startswith("zos") and not os|startswith("ibmi") and os != "macos11.0"
+      package:
+        name: "{{ package }}"
+        state: absent
+      loop_control:
+        loop_var: package
+      with_items: [ "node", "nodejs", "npm" ]
+    - name: fail if node is in the path - please uninstall it
+      when: not os|startswith("win")
+      shell: "node -v"
+      register: node_check_cmd
+      failed_when: node_check_cmd.rc == 0
+      changed_when: False
+    - name: fail if node is in the path - please uninstall it
+      when: os|startswith("win")
+      win_shell: "node -v"
+      register: node_check_cmd_win
+      failed_when: node_check_cmd_win.rc == 0
+      changed_when: False

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -76,30 +76,30 @@
 # Ensure node is not installed anywhere but the linter servers
 #
 
-- hosts:
-  - test
-  - release
-  - "!test-packetnet-ubuntu1804-x64-1"
-  - "!test-packetnet-ubuntu1804-x64-2"
-  - "!test-ibm-ubuntu1804-x64-1"
-  tasks:
-    - name: remove node and npm packages
-      when: not os|startswith("win") and not os|startswith("zos") and not os|startswith("ibmi")
-      package:
-        name: "{{ package }}"
-        state: absent
-      loop_control:
-        loop_var: package
-      with_items: [ "node", "nodejs", "npm" ]
-    - name: fail if node is in the path - please uninstall it
-      when: not os|startswith("win")
-      shell: "node -v"
-      register: node_check_cmd
-      failed_when: node_check_cmd.rc == 0
-      changed_when: False
-    - name: fail if node is in the path - please uninstall it
-      when: os|startswith("win")
-      win_shell: "node -v"
-      register: node_check_cmd_win
-      failed_when: node_check_cmd_win.rc == 0
-      changed_when: False
+# - hosts:
+#   - test
+#   - release
+#   - "!test-packetnet-ubuntu1804-x64-1"
+#   - "!test-packetnet-ubuntu1804-x64-2"
+#   - "!test-ibm-ubuntu1804-x64-1"
+#   tasks:
+#     - name: remove node and npm packages
+#       when: not os|startswith("win") and not os|startswith("zos") and not os|startswith("ibmi")
+#       package:
+#         name: "{{ package }}"
+#         state: absent
+#       loop_control:
+#         loop_var: package
+#       with_items: [ "node", "nodejs", "npm" ]
+#     - name: fail if node is in the path - please uninstall it
+#       when: not os|startswith("win")
+#       shell: "node -v"
+#       register: node_check_cmd
+#       failed_when: node_check_cmd.rc == 0
+#       changed_when: False
+#     - name: fail if node is in the path - please uninstall it
+#       when: os|startswith("win")
+#       win_shell: "node -v"
+#       register: node_check_cmd_win
+#       failed_when: node_check_cmd_win.rc == 0
+#       changed_when: False

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright Node.js contributors. All rights reserved.

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright Node.js contributors. All rights reserved.

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -83,18 +83,18 @@
     - "{{ common_packages|default('[]') }}"
 
 # Currently does not work on the DTK for 11.0 - The unsupported warnings cause the task to fail
-- name: install packages (macos)
-  when: os|startswith("macos")
-  become_user: administrator
-  package: name="{{ package }}" state=present
-  loop_control:
-    loop_var: package
-  with_items:
-    # ansible doesn't like empty lists
-    - "{{ packages[os+'_'+arch]|default('[]') }}"
-    - "{{ packages[os]|default('[]') }}"
-    - "{{ packages[os|stripversion]|default('[]') }}"
-    - "{{ common_packages|default('[]') }}"
+# - name: install packages (macos)
+#   when: os|startswith("macos")
+#   become_user: administrator
+#   package: name="{{ package }}" state=present
+#   loop_control:
+#     loop_var: package
+#   with_items:
+#     # ansible doesn't like empty lists
+#     - "{{ packages[os+'_'+arch]|default('[]') }}"
+#     - "{{ packages[os]|default('[]') }}"
+#     - "{{ packages[os|stripversion]|default('[]') }}"
+#     - "{{ common_packages|default('[]') }}"
 
 - name: centos7_ppc64 | update package alternatives
   when: os == "centos7" and arch == "ppc64"

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -83,18 +83,18 @@
     - "{{ common_packages|default('[]') }}"
 
 # Currently does not work on the DTK for 11.0 - The unsupported warnings cause the task to fail
-# - name: install packages (macos)
-#   when: os|startswith("macos")
-#   become_user: administrator
-#   package: name="{{ package }}" state=present
-#   loop_control:
-#     loop_var: package
-#   with_items:
-#     # ansible doesn't like empty lists
-#     - "{{ packages[os+'_'+arch]|default('[]') }}"
-#     - "{{ packages[os]|default('[]') }}"
-#     - "{{ packages[os|stripversion]|default('[]') }}"
-#     - "{{ common_packages|default('[]') }}"
+- name: install packages (macos)
+  when: os|startswith("macos")
+  become_user: administrator
+  community.general.homebrew: name="{{ package }}" state=present
+  loop_control:
+    loop_var: package
+  with_items:
+    # ansible doesn't like empty lists
+    - "{{ packages[os+'_'+arch]|default('[]') }}"
+    - "{{ packages[os]|default('[]') }}"
+    - "{{ packages[os|stripversion]|default('[]') }}"
+    - "{{ common_packages|default('[]') }}"
 
 - name: centos7_ppc64 | update package alternatives
   when: os == "centos7" and arch == "ppc64"

--- a/ansible/roles/baselayout/tasks/partials/ccache/macos.yml
+++ b/ansible/roles/baselayout/tasks/partials/ccache/macos.yml
@@ -8,6 +8,6 @@
 - name: "ccache : add ccache to the path (macos)"
   when: ccache_mac.rc == 1
   lineinfile:
-    dest: "etc/paths"
+    dest: "/etc/paths"
     insertbefore: BOF
     line: "usr/local/opt/ccache/libexec"

--- a/ansible/roles/baselayout/tasks/partials/ccache/macos.yml
+++ b/ansible/roles/baselayout/tasks/partials/ccache/macos.yml
@@ -10,4 +10,4 @@
   lineinfile:
     dest: "/etc/paths"
     insertbefore: BOF
-    line: "usr/local/opt/ccache/libexec"
+    line: "/usr/local/opt/ccache/libexec"

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -53,17 +53,29 @@
 
 - name: install java tap (macOS)
   become_user: administrator
-  when: java.rc > 0 and os|startswith("macos")
+  when: java.rc > 0 and os|startswith("macos10")
   homebrew_tap:
         name: AdoptOpenJDK/openjdk
         state: present
 
 - name: install java (macOS)
   become_user: administrator
-  when: java.rc > 0 and os|startswith("macos")
+  when: java.rc > 0 and os|startswith("macos10")
   homebrew_cask:
         name: "{{ java_package_name }}"
         state: present
+
+- name: Fetch java (Apple Silicon)
+  when: os|startswith("macos11")
+  shell:
+    chdir: "/Users/administrator"
+    cmd: "curl -L -o zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz"
+
+- name: Extract java (Apple Silicon)
+  when: os|startswith("macos11")
+  shell:
+    chdir: "/Users/administrator"
+    cmd: "tar -xf zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz"
 
 - name: install webupd8 oracle java 8 extras
   when: java.rc > 0 and os == "ubuntu1404" and arch != "ppc64"

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -13,7 +13,7 @@ packages: {
   'fedora': 'java-1.8.0-openjdk-headless',
   'freebsd': 'openjdk8-jre',
   'ibmi': 'openjdk-11-ea',
-  'macos': 'adoptopenjdk8',
+  'macos10': 'adoptopenjdk8',
   'rhel7': 'java-1.8.0-openjdk',
   'smartos': 'openjdk8',
   'ubuntu': 'openjdk-8-jre-headless',

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -4,8 +4,8 @@ export NODE_TEST_DIR="$HOME/tmp"
 export JOBS="{{ jobs_env }}"
 
 export OSTYPE=osx
-export ARCH=x64
-export DESTCPU=x64
+export ARCH="{{ archtype[os] }}"
+export DESTCPU="{{ archtype[os] }}"
 
 PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -4,8 +4,8 @@ export NODE_TEST_DIR="$HOME/tmp"
 export JOBS="{{ jobs_env }}"
 
 export OSTYPE=osx
-export ARCH="{{ archtype[os] }}"
-export DESTCPU="{{ archtype[os] }}"
+export ARCH="{{ arch }}"
+export DESTCPU="{{ arch }}"
 
 PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -7,6 +7,6 @@ export OSTYPE=osx
 export ARCH="{{ arch }}"
 export DESTCPU="{{ arch }}"
 
-PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
+PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -97,7 +97,8 @@ java_path: {
   'macos10.14': 'java',
   'macos10.15': 'java',
   'macos10.16': 'java',
-  'macos11.0': 'java',
+  # Currently hardcoded untill adopt have their build available
+  'macos11.0': '/Users/administrator/zulu8.50.0.1017-ca-jdk8.0.275-macos_aarch64/bin/java',
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -87,10 +87,6 @@ needs_monit: [
   'debian7',
   ]
 
-archtype: {
-  macos11.0: 'arm64'
-}
-
 # some os'es needs different paths to java. add them here.
 java_path: {
   'ibmi72': '/QOpenSys/pkgs/lib/jvm/openjdk-11/bin/java',

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -98,7 +98,7 @@ java_path: {
   'macos10.15': 'java',
   'macos10.16': 'java',
   # Currently hardcoded untill adopt have their build available
-  'macos11.0': '/Users/administrator/zulu8.50.0.1017-ca-jdk8.0.275-macos_aarch64/bin/java',
+  'macos11.0': '/Users/administrator/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64/bin/java',
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -87,6 +87,10 @@ needs_monit: [
   'debian7',
   ]
 
+archtype: {
+  macos11.0: 'arm64'
+}
+
 # some os'es needs different paths to java. add them here.
 java_path: {
   'ibmi72': '/QOpenSys/pkgs/lib/jvm/openjdk-11/bin/java',

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -16,7 +16,7 @@
   - name: Check if Homebrew is already installed (Apple Sillicon)
     stat:
       path: /opt/homebrew/bin/brew
-    register: brew
+    register: armbrew
     when: os == "macos11.0"
 
   - name: Check if Homebrew is already installed
@@ -28,7 +28,12 @@
   - name: Install Homebrew
     become_user: administrator
     script: files/install-homebrew.sh
-    when: not brew.stat.exists
+    when: os != "macos11.0" and not brew.stat.exists
+
+  - name: Install Homebrew
+    become_user: administrator
+    script: files/install-homebrew.sh
+    when: os == "macos11.0" and not armbrew.stat.exists
 
   - name: Upgrade installed packages
     become_user: administrator

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -13,15 +13,22 @@
     script: files/install-xcode.sh
     when: xcode.rc > 1
 
+  - name: Check if Homebrew is already installed (Apple Sillicon)
+    stat:
+      path: /opt/homebrew/bin/brew
+    register: brew
+    when: os == "macos11.0"
+
   - name: Check if Homebrew is already installed
     stat:
       path: /usr/local/bin/brew
-    register: brew
+    register: armbrew
+    when: os != "macos11.0"
 
   - name: Install Homebrew
     become_user: administrator
     script: files/install-homebrew.sh
-    when: not brew.stat.exists
+    when: not brew.stat.exists and os != "macos11.0"
 
   - name: Upgrade installed packages
     become_user: administrator

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -22,13 +22,13 @@
   - name: Check if Homebrew is already installed
     stat:
       path: /usr/local/bin/brew
-    register: armbrew
+    register: brew
     when: os != "macos11.0"
 
   - name: Install Homebrew
     become_user: administrator
     script: files/install-homebrew.sh
-    when: not brew.stat.exists and os != "macos11.0"
+    when: not brew.stat.exists
 
   - name: Upgrade installed packages
     become_user: administrator


### PR DESCRIPTION
Update the ansible scripts to support apple silicon and add the three new M1 macs donated to us by macstadium.


@nodejs/build-infra can I get `207.254.38.74` added to the release ci firewall and `207.254.38.86` + `207.254.38.89`  to the test ci firewall please?


*The commented lines will be readded this branch is quite old so I had some bugs to iron out*