### PR TITLE
ansible: install Python 3 on IBM i

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -58,7 +58,7 @@ packages: {
   ],
 
   ibmi: [
-    'autoconf,automake,ca-certificates-mozilla,ccache,cmake,coreutils-gnu,gcc,gcc-cplusplus,gcc-cpp,git,libstdcplusplus-devel,m4-gnu,openssl-devel,python2-pip,sed-gnu,zlib-devel',
+    'autoconf,automake,ca-certificates-mozilla,ccache,cmake,coreutils-gnu,gcc,gcc-cplusplus,gcc-cpp,git,libstdcplusplus-devel,m4-gnu,openssl-devel,python3,python3-pip,python2-pip,sed-gnu,zlib-devel',
   ],
 
   debian7: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -58,7 +58,7 @@ packages: {
   ],
 
   ibmi: [
-    'autoconf,automake,ca-certificates-mozilla,ccache,cmake,coreutils-gnu,gcc,gcc-cplusplus,gcc-cpp,git,libstdcplusplus-devel,m4-gnu,openssl-devel,python3,python3-pip,python2-pip,sed-gnu,zlib-devel',
+    'autoconf,automake,ca-certificates-mozilla,ccache,cmake,coreutils-gnu,gcc,gcc-cplusplus,gcc-cpp,git,libstdcplusplus-devel,m4-gnu,openssl-devel,python3,python3-pip,sed-gnu,zlib-devel',
   ],
 
   debian7: [

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ibmi.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ibmi.yml
@@ -8,4 +8,4 @@
   pip:
     name: tap2junit
     state: present
-    executable: /QOpenSys/pkgs/bin/pip2
+    executable: /QOpenSys/pkgs/bin/pip3


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/2507

Unlike the AIX packages in https://github.com/nodejs/build/pull/2564, on IBM i installing the `python3` package overwrites `/QOpenSys/pkgs/bin/python` so that it points to Python 3 (3.6.12). However prior to running these changes on the IBM i machines (https://github.com/nodejs/build/issues/2507#issuecomment-791472742) `test-iinthecloud-ibmi72-ppc64_be-1` already had `python3` installed but `test-iinthecloud-ibmi72-ppc64_be-2` did not so we had a discrepancy anyway where one host's `python` pointed to Python 3 and the other to Python 2. Applying these changes to the two test machines has made them consistent and `python` points to the Python 3 installation.

Currently https://ci.nodejs.org/job/node-test-commit-ibmi/ is only run daily on the master branch so we do not need to maintain compatibility for Node.js 12 or 10.