### PR TITLE
ansible: update Joyent hosted IP addresses

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -17,6 +17,7 @@ hosts:
         ubuntu1804-x64-3: {ip: 157.245.7.159, alias: metrics}
 
     - joyent:
+        debian10-x64-1: {ip: 147.75.88.62, alias: grafana}
         smartos15-x64-1: {ip: 139.178.83.227, alias: backup}
         ubuntu1604-x64-1: {ip: 147.75.88.57, alias: unencrypted}
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -17,8 +17,8 @@ hosts:
         ubuntu1804-x64-3: {ip: 157.245.7.159, alias: metrics}
 
     - joyent:
-        smartos15-x64-1: {ip: 165.225.151.21, alias: backup}
-        ubuntu1604-x64-1: {ip: 165.225.149.55, alias: unencrypted}
+        smartos15-x64-1: {ip: 139.178.83.227, alias: backup}
+        ubuntu1604-x64-1: {ip: 147.75.88.57, alias: unencrypted}
 
     - rackspace:
         debian8-x64-1: {ip: 23.253.100.79, alias: gh-bot}
@@ -43,9 +43,9 @@ hosts:
         ibmi72-ppc64_be-1: {ip: 65.183.160.62, user: nodejs}
 
     - joyent:
-        smartos17-x64-2: {ip: 165.225.149.208}
-        smartos18-x64-2: {ip: 165.225.148.12}
-        ubuntu1804_docker-x64-1: {ip: 165.225.150.76, user: ubuntu}
+        smartos17-x64-2: {ip: 147.75.88.60}
+        smartos18-x64-2: {ip: 147.75.88.53}
+        ubuntu1804_docker-x64-1: {ip: 147.75.88.56, user: ubuntu}
 
     - macstadium:
         macos10.11-x64-1: {ip: 207.254.58.162, port: 10013, user: administrator}
@@ -135,12 +135,12 @@ hosts:
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
 
     - joyent:
-        smartos17-x64-3: {ip: 165.225.148.15}
-        smartos17-x64-4: {ip: 165.225.148.16}
-        smartos18-x64-3: {ip: 165.225.151.114}
-        smartos18-x64-4: {ip: 165.225.149.13}
+        smartos17-x64-3: {ip: 147.75.88.59}
+        smartos17-x64-4: {ip: 147.75.88.61}
+        smartos18-x64-3: {ip: 147.75.88.54}
+        smartos18-x64-4: {ip: 147.75.88.55}
         ubuntu1804_docker-x64-1: {ip: 165.225.151.201, user: ubuntu}
-        ubuntu1804-x64-1: {ip: 165.225.149.88, user: ubuntu}
+        ubuntu1804-x64-1: {ip: 147.75.88.51, user: ubuntu}
 
     - macstadium:
         macos11.0-arm64-1: {ip: 199.7.163.9, user: administrator}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -140,7 +140,6 @@ hosts:
         smartos17-x64-4: {ip: 147.75.88.61}
         smartos18-x64-3: {ip: 147.75.88.54}
         smartos18-x64-4: {ip: 147.75.88.55}
-        ubuntu1804_docker-x64-1: {ip: 165.225.151.201, user: ubuntu}
         ubuntu1804-x64-1: {ip: 147.75.88.51, user: ubuntu}
 
     - macstadium:


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/2552

cc @mhdawson @jbergstroem 

Some oddities:
- ~I can't find a replacement for `test-joyent-ubuntu1804_docker-x64-1` in the table in https://github.com/nodejs/build/issues/2552. It also looks like all the hosts in https://ci.nodejs.org/search/?q=test-joyent that are containers (i.e. have the word "container" in their node names) are offline.~ Removed in this PR.
- It looks like `test-joyent-ubuntu1604_arm_cross-x64-1` and `release-joyent-ubuntu1604_arm_cross-x64-1` were removed from the inventory in https://github.com/nodejs/build/pull/2290/files#diff-6faf346b88ef5cbd5f6733c35ef37f0884f3fcc946a55c5b811843b652421f6d and possibly did not need to be migrated as we now cross compile in docker containers. The build history for https://ci.nodejs.org/computer/test-joyent-ubuntu1604_arm_cross-x64-1/builds is empty (i.e. no recent builds).
- ~`infra-joyent-debian10-x64-1/grafana` (from the table) doesn't appear to match anything in the inventory.~ Added in this PR.