### PR TITLE
ansible: add Python 3 to SmartOS hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -137,12 +137,14 @@ packages: {
   ],
 
   smartos17: [
-    'gcc7'
+    'gcc7',
+    'python36'
   ],
 
   smartos18: [
     'gcc7',
-    'ccache'
+    'ccache',
+    'python37'
   ],
 
   ubuntu: [


### PR DESCRIPTION
The inventory changes are from https://github.com/nodejs/build/pull/2568 (so I can get the correct IP addresses to run the playbook against) and can be ignored.

Latest available Python 3 on SmartOS 17 appears to be Python 3.6.4, while on SmartOS 18 it is Python 3.7.1.

SmartOS 17:
```
# pkgin search python3
python36-3.6.4 =     Interpreted, interactive, object-oriented programming language
python35-3.5.4nb1    Interpreted, interactive, object-oriented programming language
python34-3.4.7nb1    Interpreted, interactive, object-oriented programming language
```

SmartOS 18:
```
# pkgin search python3
python37-3.7.1       Interpreted, interactive, object-oriented programming language
python36-3.6.7       Interpreted, interactive, object-oriented programming language
python35-3.5.6       Interpreted, interactive, object-oriented programming language
python34-3.4.9       Interpreted, interactive, object-oriented programming language
```

I have run these changes against:
- release-joyent-smartos17-x64-2
- release-joyent-smartos18-x64-2
- test-joyent-smartos17-x64-3
- test-joyent-smartos17-x64-4
- test-joyent-smartos18-x64-3
- test-joyent-smartos18-x64-4