### PR TITLE
ansible: add Python 3 to centos7-arm64 hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -40,7 +40,7 @@ packages: {
 
   # centos-release-scl is required to enable SCLo but we do it manually in
   # partials/repo/centos7.yml for arm64
-  centos7_arm64: ['git'], # git2u not available for aarch64 (yet)
+  centos7_arm64: ['git,python3'], # git2u not available for aarch64 (yet)
   centos7_x64: ['devtoolset-6-libatomic-devel,git2u,centos-release-scl'],
   centos7_ppc64: ['cmake3,devtoolset-6-libatomic-devel,git,python3'],
 


### PR DESCRIPTION
Installs Python 3.8, enabled via `. /opt/rh/rh-python38/enable`.

Refs: https://github.com/nodejs/build/issues/2507

Currently Node.js 14 and later will build with Python 3. This maps to where we currently use gcc 8 to compile on arm64:
https://github.com/nodejs/build/blob/6882ed52582172c1b74eb67278b29e8aeb723495/jenkins/scripts/VersionSelectorScript.groovy#L26-L27