### PR TITLE
ansible: add Python 3 to alpine 3.11 container

### DIFF
--- a/ansible/roles/docker/templates/alpine311.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine311.Dockerfile.j2
@@ -29,6 +29,7 @@ RUN apk add --no-cache --virtual .build-deps \
         make \
         paxctl \
         python \
+        python3 \
         tar \
         ccache \
         openjdk8 \
@@ -41,7 +42,7 @@ RUN apk add --no-cache --virtual .build-deps \
         libtool \
         autoconf
 
-RUN pip install tap2junit
+RUN pip3 install tap2junit
 
 RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 


### PR DESCRIPTION
I've reansibled:

- test-digitalocean-ubuntu1804-docker-x64-1
- test-digitalocean-ubuntu1804-docker-x64-2
- test-softlayer-ubuntu1804-docker-x64-1

with these changes and restarted the alpine containers. The alpine 3.11 containers now container Python 3.8.2 in `/usr/bin/python3`.

Refs: https://github.com/nodejs/build/issues/2507