### PR TITLE
ansible,jenkins: add OpenSSL 3.0.0 to sharedlibs container

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -44,15 +44,25 @@ RUN mkdir -p /tmp/openssl_1.1.0l && \
     make install && \
     rm -rf /tmp/openssl_1.1.0l
 
-ENV OPENSSL111DIR /opt/openssl-1.1.1g
+ENV OPENSSL111DIR /opt/openssl-1.1.1k
 
-RUN mkdir -p /tmp/openssl_1.1.1g && \
-    cd /tmp/openssl_1.1.1g && \
-    curl -sL https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.1k && \
+    cd /tmp/openssl_1.1.1k && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.1g
+    rm -rf /tmp/openssl_1.1.1k
+
+ENV OPENSSL300DIR /opt/openssl-3.0.0
+
+RUN mkdir -p /tmp/openssl_3.0.0 && \
+    cd /tmp/openssl_3.0.0 && \
+    curl -sL https://www.openssl.org/source/openssl-3.0.0-alpha13.tar.gz | tar zxv --strip=1 && \
+    ./config --prefix=$OPENSSL300DIR && \
+    make -j 6 && \
+    make install && \
+    rm -rf /tmp/openssl_3.0.0
 
 ENV ZLIB12DIR /opt/zlib_1.2.11
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -93,6 +93,7 @@ def buildExclusions = [
 
   // Shared libs docker containers -------------------------
   [ /ubi81_sharedlibs/,               anyType,     lt(13)  ],
+  [ /sharedlibs_openssl300/,          anyType,     lt(15)  ],
   [ /sharedlibs_openssl111/,          anyType,     lt(11)  ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],
   [ /sharedlibs_openssl110/,          anyType,     gte(12) ],


### PR DESCRIPTION
Add OpenSSL 3.0.0 alpha13 to the sharedlibs container. Add an entry to
the VersionSelectorScript to build against it with Node.js 15 onwards.

Update OpenSSL 1.1.1g to 1.1.1k.

Refs: https://github.com/nodejs/build/issues/2584

