### PR TITLE
ansible,docker: install Python 3.9 in Stretch RPi's

### DIFF
--- a/ansible/roles/jenkins-worker/templates/rpi_stretch.Dockerfile.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_stretch.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:stretch
+FROM balenalib/rpi-raspbian:stretch
 
 ENV LC_ALL=C \
     USER={{ server_user }} \
@@ -26,7 +26,9 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
       openssh-client \
       gzip \
       xz-utils \
-      curl && \
+      curl \
+      libffi-dev \
+      zlib1g-dev && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -35,6 +37,15 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 50 && \
     update-alternatives --install /usr/bin/cpp cpp /usr/bin/gcc-6 50 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 50 && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-6 50
+
+RUN mkdir /python && \
+    cd /python && \
+    curl https://github.com/python/cpython/archive/refs/tags/v3.9.3.tar.gz -L --output v3.9.3.tar.gz && \
+    tar xf v3.9.3.tar.gz && \
+    cd cpython-3.9.3 && \
+    ./configure && \
+    make install && \
+    rm -rf /python
 
 RUN addgroup \
       --gid {{ server_user_gid.stdout_lines[0] }} \

--- a/ansible/roles/jenkins-worker/templates/rpi_stretch.Dockerfile.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_stretch.Dockerfile.j2
@@ -40,9 +40,9 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 50 && \
 
 RUN mkdir /python && \
     cd /python && \
-    curl https://github.com/python/cpython/archive/refs/tags/v3.9.3.tar.gz -L --output v3.9.3.tar.gz && \
-    tar xf v3.9.3.tar.gz && \
-    cd cpython-3.9.3 && \
+    curl https://github.com/python/cpython/archive/refs/tags/v3.9.4.tar.gz -L --output v3.9.4.tar.gz && \
+    tar xf v3.9.4.tar.gz && \
+    cd cpython-3.9.4 && \
     ./configure && \
     make install && \
     rm -rf /python

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -121,11 +121,9 @@ raspberry_pi: {
       { name: 'jessie', template: 'rpi_jessie.Dockerfile.j2' }
     ],
     armv7l: [
-      { name: 'jessie', template: 'rpi_jessie.Dockerfile.j2' },
       { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' }
     ],
     arm64: [
-      { name: 'jessie', template: 'rpi_jessie.Dockerfile.j2' },
       { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' }
     ]
   }


### PR DESCRIPTION
This also changes the base image to balenalib/rpi-raspbian:stretch.
The old one is no longer maintained.
