### PR TITLE
ansible: remove debian7

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -4,6 +4,7 @@
 # variables shared in baselayout
 #
 
+git_no_binpkg: [ ]
 git_version: 2.10.2
 
 ssh_config: /etc/ssh/sshd_config

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -4,7 +4,6 @@
 # variables shared in baselayout
 #
 
-git_no_binpkg: ['debian7']
 git_version: 2.10.2
 
 ssh_config: /etc/ssh/sshd_config
@@ -54,10 +53,6 @@ packages: {
 
   ibmi: [
     'autoconf,automake,ca-certificates-mozilla,ccache,cmake,coreutils-gnu,gcc,gcc-cplusplus,gcc-cpp,git,libstdcplusplus-devel,m4-gnu,openssl-devel,python3,python3-pip,sed-gnu,zlib-devel',
-  ],
-
-  debian7: [
-    'gcc-4.8,g++-4.8,sudo',
   ],
 
   debian8: [


### PR DESCRIPTION
This is no longer in the CI so it should be alright to remove it.

Refs: https://github.com/nodejs/build/pull/2607