### PR TITLE
ansible: update OpenSSL 3.0 to use quictls/openssl

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -58,7 +58,8 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    git clone git@github.com:quictls/openssl.git && cd openssl && \
+    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-alpha14+quic --depth 1 && \
+    cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \
     make install && \

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -58,7 +58,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    curl -sL https://www.openssl.org/source/openssl-3.0.0-alpha14.tar.gz | tar zxv --strip=1 && \
+    git clone git@github.com:quictls/openssl.git && cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \
     make install && \


### PR DESCRIPTION
This commit update the version of OpenSSL 3.0 to use the quictls/openssl
fork. This for will be used until upstream OpenSSL includes support for
the QUIC protocol. At that point we can switch back to using upstream
again.