### PR TITLE
armv7: enable gcc-8 for armv7 cross-compile

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -50,6 +50,8 @@ def buildExclusions = [
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,   anyType, lt(12)  ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,   anyType, gte(14) ],
   [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,      anyType, lt(14)  ],
+  [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,      anyType, gte(16) ],
+  [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,      anyType, lt(16)  ],
   [ /^ubuntu1604-arm64/,              anyType,     gte(14) ],
 
   // Windows -----------------------------------------------


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/2445

I was looking at this today and I think it's actually all in place, even in our CIs we have labels for this to work. It's just a matter of turning it on and trying it out ...