### PR TITLE
docker: update containers - gcc8 for cross, openssl3-a14

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
@@ -5,12 +5,14 @@ ENV LC_ALL=C
 RUN apt-get update \
   && apt-get dist-upgrade -y \
   && apt-get install -y software-properties-common \
-  && add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
   && apt-get update \
   && apt-get install -y \
     ccache \
     g++ \
     gcc \
+    g++-8 \
+    gcc-8 \
     git \
     openjdk-8-jre-headless \
     curl \
@@ -20,7 +22,9 @@ RUN apt-get update \
     libfontconfig1 \
     make \
     gcc-6-multilib \
-    g++-6-multilib
+    g++-6-multilib \
+    gcc-8-multilib \
+    g++-8-multilib
 
 RUN pip install tap2junit \
   && pip3 install tap2junit

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -58,7 +58,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    curl -sL https://www.openssl.org/source/openssl-3.0.0-alpha13.tar.gz | tar zxv --strip=1 && \
+    curl -sL https://www.openssl.org/source/openssl-3.0.0-alpha14.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \
     make install && \


### PR DESCRIPTION
Builds on #2614, it turns out we didn't have gcc-8 ready in the cross compiler containers for host builds.

Also had to do the openssl-3-a14 update because a13 was having "not gzip content" errors (I couldn't replicate locally but upgrading to yesterday's release did the trick). I'm afraid this might have introduced new TLS failures from the one test run I've done so far. https://ci.nodejs.org/job/node-test-commit-linux-containered/26388/#showFailuresLink (test-crypto-dh-stateless & test-crypto-dh).

I'm also watching for some potential new failures from the gcc-8 armv7 builds, more runs need to shake out flakys. We'll also need to keep an eye on nightlies for the release version.

This is live now across the 4 containers in ci and 1 in ci-release.