### PR TITLE
jenkins: enable building releases with osx11

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -106,8 +106,13 @@ def buildExclusions = [
   [ /sharedlibs_shared/,              anyType,     lt(9)   ],
 
   // OSX ---------------------------------------------------
+  [ /osx11-release-pkg/,              releaseType, lt(16) ],
+  [ /osx11-release-tar/,              releaseType, lt(16) ],
+  [ /osx1015-release-pkg/,            releaseType, gte(16)  ],
   [ /^osx11/,                         testType,    lt(15)  ],
-  // osx1015 enabled for all, and builds all releases to support notarization
+
+  // osx1015 enabled for all up, and builds all releases to support notarization
+  // osx11 only for 15+ and builds the fat binary
 
   // FreeBSD -----------------------------------------------
   [ /^freebsd10/,                     anyType,     gte(11) ],


### PR DESCRIPTION
enable building the pkg from 16 onwards with only the osx11 machine, enable building the release tar for osx11 on 16.