### PR TITLE
jenkins: stop testing on ubuntu1604-64 for Node.js 16

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -34,6 +34,7 @@ def buildExclusions = [
   [ /^ubuntu1404-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
+  [ /^ubuntu1604-64/,                 anyType,     gte(16) ],
   [ /^alpine-latest-x64$/,            anyType,     lt(13)  ], // Alpine 3.12 doesn't have Python 2
 
   // Linux PPC LE ------------------------------------------


### PR DESCRIPTION
Ubuntu 16.04 does not have new enough gcc/g++/Python versions to
meet the minimum for Node.js 16 and is out of LTS support at the
end of April 2021.