### PR TITLE
ansible: add Python 3 PPA for Ubuntu 16.04

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -127,6 +127,13 @@
     - gcc
     - g++
 
+- name: ubuntu1604 | update python package alternatives
+  when: os == "ubuntu1604"
+  alternatives:
+    link: "/usr/bin/python3"
+    name: python3
+    path: "/usr/bin/python3.9"
+
 - name: smartos17 | update gcc symlinks
   when: os == "smartos17"
   file:

--- a/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/ubuntu1604.yml
@@ -10,3 +10,10 @@
     state: present
     update_cache: yes
   register: has_updated_package_repo
+
+# add PPA for Python 3
+- name: "repo : add deadsnakes PPA"
+  apt_repository:
+    repo: 'ppa:deadsnakes/ppa'
+    state: present
+    update_cache: yes

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -153,5 +153,9 @@ packages: {
 
   ubuntu1404: [
     'ntp,gcc-8,g++-8,gcc-6,g++-6,g++-4.8,gcc-4.8,g++-4.9,gcc-4.9,binutils-2.26',
-  ]
+  ],
+
+  ubuntu1604: [
+    'python3.9,python3.9-distutils',
+  ],
 }


### PR DESCRIPTION
The benchmarking machines used for testing V8 and benchmarking are
still Ubuntu 16.04 so will need updating to a more recent Python 3
to continue being able to build Node.js 16.