### PR TITLE
ansible: update iptables playbook

### DIFF
--- a/ansible/playbooks/jenkins/host/iptables.yml
+++ b/ansible/playbooks/jenkins/host/iptables.yml
@@ -26,34 +26,29 @@
       - hostgroups[inventory_hostname] == hostvars[host].type
       # Following condition filters out entries without an IP address.
       - hostvars[host]['ansible_host'] is defined
-      # Following condition filters out entries that specify a hostname instead
-      # of an address (i.e. the Windows hosts). Ansible has a ipaddr filter but
-      # that requires an additional Python package (netaddr) to be installed.
-      - hostvars[host]['ansible_host'] | regex_findall('^[0-9.]+$')
     iptables:
       table: filter
       chain: jnlp
       jump: ACCEPT
-      comment: "{{ host }}"
-      source: "{{ hostvars[host]['ansible_host'] }}/32"
+      comment: "{{ comment }}"
+      source: "{{ ip_address }}/32"
     loop_control:
       loop_var: host
     with_inventory_hostnames: "{{ hostgroups[inventory_hostname] }}"
+    vars:
+      # Some hosts specify a hostname rather than a numeric IP address in the
+      # inventory. In such cases, add the supplied hostname instead of the
+      # name of the host to iptables rules.
+      comment: "{{ host if is_numeric_ip else host_or_ip }}"
+      host_or_ip: "{{ hostvars[host]['ansible_host'] }}"
+      ip_address: "{{ host_or_ip if is_numeric_ip else (comment | dig) }}"
+      # Use this regexp as ipaddr filter requires netaddr to be installed.
+      is_numeric_ip: "{{ host_or_ip | regex_findall('^[0-9.]+$') }}"
 
-  # we _could_ use lookup('dig') here but it requires dnspython
-  - name: lookup ip address for proxy host
-    check_mode: no
-    run_once: true
-    local_action: raw dig +short {{ jumphost }}
-    register: jumphost_ip
-    failed_when: not jumphost_ip.stdout_lines[0]
-
-  # awful awful. should really look up this somehow but i can't figure out
-  # how to do it properly.
   - name: add proxy host(s) to firewall
     iptables:
       table: filter
       chain: jnlp
       jump: ACCEPT
       comment: "{{ jumphost }}"
-      source: "{{ jumphost_ip.stdout_lines[0] }}/32"
+      source: "{{ jumphost | dig }}/32"

--- a/ansible/playbooks/jenkins/host/iptables.yml
+++ b/ansible/playbooks/jenkins/host/iptables.yml
@@ -21,8 +21,15 @@
 
   tasks:
   - name: add hosts to firewall
-    when: not 'ansible_ssh_common_args' in hostvars[host] and
-          hostgroups[inventory_hostname] == hostvars[host].type
+    when:
+      - not 'ansible_ssh_common_args' in hostvars[host]
+      - hostgroups[inventory_hostname] == hostvars[host].type
+      # Following condition filters out entries without an IP address.
+      - hostvars[host]['ansible_host'] is defined
+      # Following condition filters out entries that specify a hostname instead
+      # of an address (i.e. the Windows hosts). Ansible has a ipaddr filter but
+      # that requires an additional Python package (netaddr) to be installed.
+      - hostvars[host]['ansible_host'] | regex_findall('^[0-9.]+$')
     iptables:
       table: filter
       chain: jnlp
@@ -35,6 +42,7 @@
 
   # we _could_ use lookup('dig') here but it requires dnspython
   - name: lookup ip address for proxy host
+    check_mode: no
     run_once: true
     local_action: raw dig +short {{ jumphost }}
     register: jumphost_ip

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -22,6 +22,7 @@
 #
 
 import re
+import subprocess
 
 from ansible.errors import AnsibleFilterError
 
@@ -53,11 +54,18 @@ def stripversion(value):
     return match.group() if match else False
 
 
+def dig(value):
+    return subprocess.check_output(
+        ['dig', '+short', value], universal_newlines=True
+    ).splitlines()[0]
+
+
 class FilterModule(object):
     ''' Query filter '''
 
     def filters(self):
         return {
+            'dig': dig,
             'match_key': match_key,
             'startswith': starts_with,
             'stripversion': stripversion


### PR DESCRIPTION
- Add a filter to skip over hosts that do not have an IP address, which
can happen if they have been removed from the main inventory but not
from secrets. Also filter out hosts that use hostnames instead of
numeric IP addresses (i.e. the Windows hosts).
Allow the proxy host look up when ansible is run in `--check` mode.

- Add filter for looking up IP addresses via `dig`. Add entries for
hosts that set their `ip` to a hostname instead of a numeric IP
address -- in the iptables rules we are adding these commented with
the supplied `ip` hostname rather than the name of the host.