### PR TITLE
metrics: Point to new metrics link

### DIFF
--- a/ansible/www-standalone/tools/metrics/public-index.html
+++ b/ansible/www-standalone/tools/metrics/public-index.html
@@ -326,6 +326,7 @@ pre code, pre tt {
   <body>
     <div class="container">
       <div class="body-content"><h1 id="nodejs-org-download-metrics">nodejs.org Download Metrics</h1>
+        <h2>  For "current" metrics go <a href="https://storage.googleapis.com/access-logs-summaries-nodejs/index.html">here.</a> Everything below is just historic data</h2>
 <p>This directory contains anonymized log records for binary and source downloads of Node.js from nodejs.org.</p>
 <h2 id="what-data-is-available-">What data is available?</h2>
 <p>There is roughly one log file per day, starting on the 14th of May 2014 to the current day. There is a gap in the data from the 1st to the 21st of September 2015 due to a server configuration error.</p>


### PR DESCRIPTION
Give a new link to where the current summaries are currently stored. This pr is meant to be a stop gap so people can access the data if they want until someone has time and patience to redesign the website and backfill the gaps in the data.