### PR TITLE
ansible: fixes for apt package upgrades

### DIFF
--- a/ansible/roles/package-upgrade/tasks/partials/apt.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/apt.yml
@@ -16,6 +16,6 @@
   environment:
     FLASH_KERNEL_SKIP: true
 
-  # don't know how to use autoremove=yes for all packages
 - name: clean unwanted packages
-  command: apt-get -y autoremove warn=False
+  apt:
+    autoremove: yes

--- a/ansible/roles/package-upgrade/tasks/partials/apt.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/apt.yml
@@ -5,16 +5,9 @@
 #
 
 - name: upgrade installed packages
-  when: "'scaleway-ubuntu1804-armv7l' not in inventory_hostname"
-  apt: upgrade=dist update_cache=yes
-
-  # kernel upgrades on the scaleway hosts are dicey
-  # see https://github.com/scaleway/image-ubuntu/issues/132 for kernel woes
-- name: upgrade installed packages (safe)
-  when: "'scaleway-ubuntu1804-armv7l' in inventory_hostname"
-  apt: upgrade=safe update_cache=yes
-  environment:
-    FLASH_KERNEL_SKIP: true
+  apt:
+    update_cache: yes
+    upgrade: dist
 
 - name: clean unwanted packages
   apt:


### PR DESCRIPTION
### ansible: use apt ansible task to autoremove

Ansible's builtin `apt` task has had an `autoremove` option since
version 2.1 of the builtin. Using the builtin task rather than
directly running `apt` will correctly set the `DEBIAN_FRONTEND`
environment variable to `noninteractive` to prevent user prompts
from packages which would otherwise cause `apt` to wait for user
input (which will never come when run via Ansible).

### ansible: remove scaleway hosts apt workaround 

Hosts at scaleway were removed from the inventory so there are no
longer any matching hosts.
