### PR TITLE
backup: update rsnapshot configuration

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -8,16 +8,18 @@ currently being backed up.
 
  - ci.nodejs.org:
    - full backup of /var/lib/jenkins (rotated, excluding workdirs)
+   - full backup of /etc (rotated)
    - iptables rules (rotated)
  - ci-release.nodejs.org:
    - full backup of /var/lib/jenkins (rotated, excluding workdirs)
+   - full backup of /etc (rotated)
    - iptables rules (rotated)
- - iojs-softlayer-benchmark: mysql dump (rotated)
  - nodejs-www:
    - /home/dist/iojs: all artifacts for iojs.org (static, no deletion)
    - /home/dist/nodejs: all artifacts for nodejs.org (static, no deletion)
    - /home/libuv/www/dist: all artifacts for libuv.org (static, no deletion)
    - /var/log/nginx: all logs for nodejs, iojs and libuv (rotated)
+   - full backup of /etc (rotated)
 
 
 ### Folder structure

--- a/backup/rsnapshot.conf
+++ b/backup/rsnapshot.conf
@@ -8,7 +8,7 @@ cmd_logger	/usr/bin/logger
 
 retain	daily	7
 retain	weekly	4
-retain	monthly	12
+retain	monthly	6
 
 verbose		2
 loglevel	3
@@ -21,6 +21,5 @@ ssh_args	-p 22 -i /root/.ssh/nodejs_build_backup
 cmd_preexec	/root/backup_scripts/dist.sh
 backup	root@ci.nodejs.org:/var/lib/jenkins/	ci.nodejs.org/	+rsync_long_args=--exclude "workspace*"
 backup	root@ci-release.nodejs.org:/var/lib/jenkins/	ci-release.nodejs.org/	+rsync_long_args=--exclude "workspace*"
-backup	root@nodejs-www:/var/log/nginx/	www-logs/	+rsync_long_args=--exclude "*.log" --exclude "old/*"
-backup_script	/root/backup_scripts/benchmark_mysql.sh	benchmark/
+backup	root@direct.nodejs.org:/var/log/nginx/	www-logs/	+rsync_long_args=--exclude "*.log" --exclude "old/*"
 backup_script	/root/backup_scripts/iptables.sh	iptables/

--- a/backup/rsnapshot.conf
+++ b/backup/rsnapshot.conf
@@ -21,5 +21,8 @@ ssh_args	-p 22 -i /root/.ssh/nodejs_build_backup
 cmd_preexec	/root/backup_scripts/dist.sh
 backup	root@ci.nodejs.org:/var/lib/jenkins/	ci.nodejs.org/	+rsync_long_args=--exclude "workspace*"
 backup	root@ci-release.nodejs.org:/var/lib/jenkins/	ci-release.nodejs.org/	+rsync_long_args=--exclude "workspace*"
+backup	root@ci.nodejs.org:/etc/	etc/ci.nodejs.org/
+backup	root@ci-release.nodejs.org:/etc/	etc/ci-release.nodejs.org/
+backup	root@direct.nodejs.org:/etc/	etc/nodejs.org/
 backup	root@direct.nodejs.org:/var/log/nginx/	www-logs/	+rsync_long_args=--exclude "*.log" --exclude "old/*"
 backup_script	/root/backup_scripts/iptables.sh	iptables/


### PR DESCRIPTION
The first commit updates the copy of `rsnapshot.conf` we have in this repository with what is currently deployed on the backup server, taken via:
```
ssh backup cat /opt/local/etc/rsnapshot.conf > rsnapshot.conf
```
(FWIW it looks like we no longer take mysql dumps from the benchmark machine -- I think this was part of https://github.com/nodejs/build/issues/2485 with the de-chartering of the benchmarking WG (https://github.com/nodejs/TSC/pull/955).)

The second commit is a proposed change (not yet made) to also backup `/etc` from both CI servers. This will include nginx and telegraf (for grafana) configuration. Currently the whole of `/etc` is around 7mb on each server. I've left the existing Jenkins backup where it is to not disturb the diffs to the existing backups since those are large. We would end up with a directory structure for each backup (e.g. under `/backup/periodic/daily.0`):
directory | backup of
---|---
`ci.nodejs.org` | existing `/var/lib/jenkins` from ci.nodejs.org
`ci-release.nodejs.org` | existing `/var/lib/jenkins` from ci-release.nodejs.org
`etc/ci.nodejs.org` | `/etc` from ci.nodejs.org
`etc/ci-release.nodejs.org` | `/etc` from ci-release.nodejs.org
`etc/nodejs.org` | `/etc` from (direct.)nodejs.org

cc @nodejs/build-infra 