### PR TITLE
www: use `docker:lts` in `build-site.sh`

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -37,12 +37,12 @@ git checkout origin/master
 nodeuid=$(grep ^nodejs: /etc/passwd | awk -F: '{print $3}')
 nodegid=$(grep ^nodejs: /etc/passwd | awk -F: '{print $4}')
 
-docker pull node:latest
+docker pull node:lts
 docker run \
   --rm \
   -v ${clonedir}:/website/ \
   -v /home/nodejs/.npm:/npm/ \
-  node:latest \
+  node:lts \
   bash -c " \
     apt-get update && apt-get install -y rsync && \
     addgroup nodejs --gid ${nodeuid} && \


### PR DESCRIPTION
The nodejs.org website build uses `fibers` which is broken on Node.js 16
due to an incompatibility with the version of V8 that it contains.
Switch the Docker image used to build the website from `node:latest` to
`node:lts` to buy some time for the website to migrate off `fibers`.

---

This is live -- I edited the script on the www server, tested it and then synced the changes into this PR via:
```
ssh www cat /home/nodejs/build-site.sh > build-site.sh
```

Fixes: https://github.com/nodejs/build/issues/2123#issuecomment-829551740
