### PR TITLE
jenkins: stop testing 16.x on AIX71

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -92,7 +92,7 @@ def buildExclusions = [
 
   // AIX PPC64 ---------------------------------------------
   [ /aix71/,                          anyType,     lt(10)  ],
-  [ /aix71/,                          releaseType, gte(15) ],
+  [ /aix71/,                          anyType,     gte(15) ],
   [ /aix72/,                          anyType,     lt(15)  ],
 
   // Shared libs docker containers -------------------------


### PR DESCRIPTION
I like to propose we stop testing 16.x on AIX71 - we list support as for AIX72 only and we only build the 16.x releases on AIX 72 meaning the binaries wont even run on AIX71.

cc @richardlau @mhdawson 