### PR TITLE
ansible: update to OpenSSL 3.0.0-alpha16+quic

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -58,7 +58,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-alpha15+quic --depth 1 && \
+    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-alpha16+quic --depth 1 && \
     cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \


### PR DESCRIPTION
Tested locally, no new test failures with current nodejs/node master. In the process of deploying to our containers.