### PR TITLE
ansible: fixes for freebsd

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -134,6 +134,13 @@
     name: python3
     path: "/usr/bin/python3.9"
 
+- name: freebsd | update python package alternatives
+  when: os == "freebsd11"
+  file:
+    dest: "/usr/local/bin/python"
+    state: link
+    src: "/usr/local/bin/python2"
+
 - name: smartos17 | update gcc symlinks
   when: os == "smartos17"
   file:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -73,7 +73,7 @@ packages: {
   ],
 
   freebsd: [
-    'ccache,git,gmake,sudo,python3,py36-pip'
+    'ccache,git,gmake,sudo,python3'
   ],
 
   'macos10.10': [

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/freebsd.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/freebsd.yml
@@ -1,11 +1,18 @@
 ---
 
 #
-# freebsd: python2.7
+# freebsd: python3.8
 #
 
 - name: install pip
-  package: name=py27-pip state=present
+  package: name=py38-pip state=present
+
+- name: freebsd | update pip3 symlink
+  when: os == "freebsd11"
+  file:
+    dest: "/usr/local/bin/pip3"
+    state: link
+    src: "/usr/local/bin/pip-3.8"
 
 - name: install tap2junit
   pip: name=tap2junit state=present

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -47,8 +47,8 @@ monitor_pidfile="/var/run/${name}/${name}_monitor.pid"
 required_files="${procname} ${jenkins_jar}"
 
 command="/usr/sbin/daemon"
-command_args="-f -r -p ${pidfile} -P ${monitor_pidfile} \
-              ${procname} ${jenkins_args} -slaveLog ${jenkins_log_file}"
+command_args="-f -r -p ${pidfile} -P ${monitor_pidfile} -o ${jenkins_log_file} \
+              ${procname} ${jenkins_args}"
 
 start_precmd="jenkins_prestart"
 start_cmd="jenkins_start"


### PR DESCRIPTION
- Update `python` to point to `python2` (for consistency with other
platforms in our CI; use `python3` for Python 3).
- Use `py38-pip` to match the version of Python 3 installed.
- Create a `pip3` symlink as Ansible's `pip` task fails without it.
- `-slaveLog` Jenkins agent parameter has been obsoleted. Use the
`-o` parameter to `daemon` to redirect stdout/stderr to the log file.

Refs: https://github.com/nodejs/build/issues/2531