### PR TITLE
ansible: fix multiple register vars on Fedora

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/fedora.yml
+++ b/ansible/roles/bootstrap/tasks/partials/fedora.yml
@@ -20,15 +20,8 @@
   when: os not in ("fedora30")
   raw: alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && alternatives --set python /usr/bin/python2.7
 
-- name: check for libselinux-python bindings
-  when: os in ("fedora30")
-  raw: dnf info libselinux-python | grep Installed
-  register: has_libselinux
-  failed_when:  has_libselinux.rc > 1
-
-- name: check for python3-libselinux bindings
-  when: os not in ("fedora30")
-  raw: dnf info python3-libselinux | grep Installed
+- name: check for {{ 'libselinux-python' if os in ("fedora30") else 'python3-libselinux' }} bindings
+  raw: dnf info {{ 'libselinux-python' if os in ("fedora30") else 'python3-libselinux' }} | grep Installed
   register: has_libselinux
   failed_when:  has_libselinux.rc > 1
 
@@ -36,7 +29,7 @@
   when: os in ("fedora30") and has_libselinux.rc == 1
   raw: dnf install -y libselinux-python
 
-- name: install python3-libselinux nbindings
+- name: install python3-libselinux bindings
   when: os not in ("fedora30") and has_libselinux.rc == 1
   raw: dnf install -y libselinux-python
 


### PR DESCRIPTION
Tasks registering variables in Ansible will alway set the variable
regardless of any `when` clause(s). This means if more than one task
registers the same variable, the last one "wins". Fix the bootstrap
role on Fedora by correctly registering `has_libselinux` in both
`fedora30` and non-`fedora30` cases.

Refs: https://github.com/nodejs/build/issues/2531

Fixes this error:
```
TASK [bootstrap : install libselinux-python bindings] ******************************************************************************************************
fatal: [test-digitalocean-fedora30-x64-2]: FAILED! => {"msg": "The conditional check 'os in (\"fedora30\") and has_libselinux.rc == 1' failed. The error was: error while evaluating conditional (os in (\"fedora30\") and has_libselinux.rc == 1): 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/home/rlau/sandbox/github/build/ansible/roles/bootstrap/tasks/partials/fedora.yml': line 35, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: install libselinux-python bindings\n  ^ here\n"}
```