### PR TITLE
ansible: use python3 in nodejs_yaml

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright Node.js contributors. All rights reserved.


### PR DESCRIPTION
python3 is the default for python3 now with python pointing to python2.
This script fails on machines without python2 installed but as its
now EOL we should prefer python3