### PR TITLE
ansible: add gcc-8 to Ubuntu 18.04 hosts/containers

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -144,14 +144,20 @@ packages: {
   ],
 
   ubuntu: [
-    'ccache,g++,gcc,g++-6,gcc-6,git,libfontconfig1,sudo,python3-pip',
+    'ccache,g++,gcc,git,libfontconfig1,sudo,python3-pip',
   ],
 
   ubuntu1404: [
     'ntp,gcc-8,g++-8,gcc-6,g++-6,g++-4.8,gcc-4.8,g++-4.9,gcc-4.9,binutils-2.26',
   ],
 
+  # Default gcc/g++ package is 5.
   ubuntu1604: [
-    'python3.9,python3.9-distutils',
+    'gcc-6,g++-6,python3.9,python3.9-distutils',
+  ],
+
+  # Default gcc/g++ package is 7.
+  ubuntu1804: [
+    'gcc-6,g++-6,gcc-8,g++-8',
   ],
 }

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -144,7 +144,7 @@ packages: {
   ],
 
   ubuntu: [
-    'ccache,g++,gcc,git,libfontconfig1,sudo,python3-pip',
+    'ccache,git,libfontconfig1,sudo,python3-pip',
   ],
 
   ubuntu1404: [
@@ -153,7 +153,7 @@ packages: {
 
   # Default gcc/g++ package is 5.
   ubuntu1604: [
-    'gcc-6,g++-6,python3.9,python3.9-distutils',
+    'gcc-8,g++-6,gcc-6,g++-6,python3.9,python3.9-distutils',
   ],
 
   # Default gcc/g++ package is 7.

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -15,8 +15,8 @@ ENV ARCH x64
 
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     ccache \
-    g++ \
-    gcc \
+    g++-6 \
+    gcc-6 \
     g++-8 \
     gcc-8 \
     git \

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     ccache \
     g++ \
     gcc \
+    g++-8 \
+    gcc-8 \
     git \
     openjdk-8-jre-headless \
     curl \

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -17,8 +17,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install apt-utils -y && \
     apt-get dist-upgrade -y && apt-get install -y \
       ccache \
-      g++ \
-      gcc \
+      g++-6 \
+      gcc-6 \
       g++-8 \
       gcc-8 \
       git \

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install apt-utils -y && \
       ccache \
       g++ \
       gcc \
+      g++-8 \
+      gcc-8 \
       git \
       openjdk-8-jre-headless \
       curl \

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -168,9 +168,9 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
         export CXX="ccache g++-8"
         export LINK="g++-8"
       else
-        export CC="ccache gcc"
-        export CXX="ccache g++"
-        export LINK="g++"
+        export CC="ccache gcc-6"
+        export CXX="ccache g++-6"
+        export LINK="g++-6"
       fi
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -162,6 +162,18 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
         echo "Compiler set to GCC 6 for $NODEJS_MAJOR_VERSION"
       fi
       ;;
+    *ubuntu1804*64 )
+      if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
+        export CC="ccache gcc-8"
+        export CXX="ccache g++-8"
+        export LINK="g++-8"
+      else
+        export CC="ccache gcc"
+        export CXX="ccache g++"
+        export LINK="g++"
+      fi
+      echo "Compiler set to GCC" `$CXX -dumpversion`
+      ;;
   esac
 
 elif [ "$SELECT_ARCH" = "ARM64" ]; then


### PR DESCRIPTION
Baseline gcc/g++ compiler version for Node.js 16 and above is 8. The
default `gcc` and `g++` packages on Ubuntu 18.04 install version 7.

Moves `gcc-6` and `g++-6` out of the common `ubuntu` packages into
`ubuntu1604` -- it doesn't seem worth installing a lower version of
GCC to the default for Ubuntu 18.04.

Update `select-compiler.sh` to select GCC 8 for Node.js 16 and later.

Refs: https://github.com/nodejs/build/issues/2445