### PR TITLE
tools: add host-map tool

### DIFF
--- a/tools/host-map/host-map.mjs
+++ b/tools/host-map/host-map.mjs
@@ -1,0 +1,120 @@
+import { spawnSync } from 'child_process';
+import { basename, dirname, resolve } from 'path';
+import chalk from 'chalk';
+import columnify from 'columnify';
+const { green } = chalk;
+
+const __filename = new URL(import.meta.url).pathname;
+const __dirname = dirname(__filename);
+
+const dir = resolve(__dirname, '..', '..', 'ansible');
+const childProc = spawnSync('python3', ['plugins/inventory/nodejs_yaml.py'],
+  { cwd: dir, encoding: 'utf8' });
+const hosts = JSON.parse(childProc.stdout);
+
+const inventory = hosts._meta.hostvars;
+
+const typeFilter = (type, hostVars) => {
+  return hostVars.type === type;
+};
+
+let inventoryFilter;
+if (process.argv.length > 2) {
+  const type = process.argv[2];
+  if (['infra', 'release', 'test'].includes(type)) {
+    inventoryFilter = typeFilter.bind(this, type);
+  } else {
+    console.error(`Unknown inventory type '${type}'.`);
+    process.exit(-2);
+  }
+} else {
+  console.error(`Usage: node ${basename(__filename)} <infra|release|test>`);
+  process.exit(-1);
+}
+
+// Shorten provider names to shorten table width.
+// Also map, e.g. SoftLayer to IBM Cloud.
+const providerMap = new Map([
+  ['digitalocean', 'do'],
+  ['iinthecloud', 'iitc'],
+  ['nearform', 'nf'],
+  ['packetnet', 'packet'],
+  ['rackspace', 'rs'],
+  ['softlayer', 'ibm']
+]);
+const mapProvider = (provider) => {
+  return providerMap.get(provider) || provider;
+};
+
+// Disambiguate containers, jenkins workspaces, etc.
+const getPlatform = (host) => {
+  let { arch, os } = host;
+  if (host.containers) {
+    os += '_docker';
+  }
+  if (host.alias && host.alias.startsWith('jenkins-workspace')) {
+    os += '_workspace';
+  }
+  // TODO: work out how to disambiguate Windows hosts.
+  const platform = [os, arch].join('-');
+  return platform;
+};
+
+// Platforms and providers are our rows and columns.
+const platforms = new Set();
+const providers = new Set();
+for (const vars of Object.values(inventory)) {
+  if (inventoryFilter(vars)) {
+    providers.add(mapProvider(vars.provider));
+    platforms.add(getPlatform(vars));
+  }
+}
+
+const sortedProviders = [...providers].sort();
+const data = [];
+for (const p of [...platforms].sort()) {
+  const entry = { platform: p };
+  for (const provider of sortedProviders) {
+    entry[provider] = 0;
+  }
+  data.push(entry);
+}
+
+// Count the hosts per platform per provider.
+for (const host of Object.values(inventory)) {
+  if (inventoryFilter(host)) {
+    const platform = getPlatform(host);
+    data.find((e) => e.platform === platform)[mapProvider(host.provider)]++;
+  }
+}
+
+console.log(columnify(data,
+  {
+    align: 'right',
+    columnSplitter: '|',
+    preserveNewLines: true,
+    dataTransform: (data) => {
+      // Hide zeroes to make the table easier to read.
+      return data > 0 ? data : '';
+    },
+    headingTransform: (data) => {
+      // Add heading separator.
+      return `${data}\n${'-'.repeat(data.length)}\n`;
+    },
+    config: {
+      platform: {
+        align: 'left',
+        dataTransform: (platform) => {
+          // Highlight platforms spread across multiple providers.
+          let providerCount = 0;
+          const entry = data.find((n) => n.platform === platform);
+          for (const provider of sortedProviders) {
+            if (entry[provider] > 0) {
+              providerCount++;
+            }
+          }
+          return providerCount > 1 ? green(platform) : platform;
+        }
+      }
+    }
+  }));

--- a/tools/host-map/package.json
+++ b/tools/host-map/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "host-map",
+  "version": "1.0.0",
+  "description": "Show distribution of CI hosts across providers.",
+  "main": "host-map.mjs",
+  "scripts": {
+    "lint": "semistandard",
+    "start": "node .",
+    "test": "npm run lint"
+  },
+  "type": "module",
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^4.1.1",
+    "columnify": "^1.5.4"
+  },
+  "devDependencies": {
+    "semistandard": "^16.0.0"
+  }
+}


### PR DESCRIPTION
I've put together a little tool to visualize where our CI hosts are and highlight platforms which are spread across more than one provider. It parses the output of [`ansible/plugins/inventory/nodejs_yaml.py`](https://github.com/nodejs/build/blob/master/ansible/plugins/inventory/nodejs_yaml.py) so is dependent on this repository.

e.g. without the highlighting:
```
$ node . test
platform                |azure|do|ibm|iitc|joyent|macstadium|marist|msft|nf|orka|osuosl|packet|requireio|rs
--------                |-----|--|---|----|------|----------|------|----|--|----|------|------|---------|--
aix71-ppc64             |     |  |  2|    |      |          |      |    |  |    |      |      |         |  
aix72-ppc64             |     |  |   |    |      |          |      |    |  |    |     4|      |         |  
centos6-x64             |     |  |  2|    |      |          |      |    |  |    |      |      |         |  
centos7-arm64           |     |  |   |    |      |          |      |    |  |    |      |     2|         |  
centos7-ppc64           |     |  |   |    |      |          |      |    |  |    |     2|      |         |  
centos7-x64             |     |  |  1|    |      |          |      |    |  |    |      |      |         | 1
debian10-arm64          |     |  |   |    |      |          |      |    |  |    |      |      |       11|  
debian10-armv6l         |     |  |   |    |      |          |      |    |  |    |      |      |       12|  
debian10-armv7l         |     |  |   |    |      |          |      |    |  |    |      |      |       12|  
debian10-x64            |     |  |  1|    |      |          |      |    |  |    |      |      |         | 1
debian8-x64             |     | 1|   |    |      |          |      |    |  |    |      |      |         | 1
debian9-x64             |     | 1|  1|    |      |          |      |    |  |    |      |      |         |  
fedora30-x64            |     | 2|   |    |      |          |      |    |  |    |      |      |         |  
fedora32-x64            |     | 1|   |    |      |          |      |    |  |    |      |      |         | 1
freebsd11-x64           |     | 2|   |    |      |          |      |    |  |    |      |      |         |  
ibmi72-ppc64            |     |  |   |   2|      |          |      |    |  |    |      |      |         |  
macos10.14-x64          |     |  |   |    |      |          |      |    |  |   3|      |      |         |  
macos10.15-x64          |     |  |   |    |      |          |      |    | 3|   2|      |      |         |  
macos11.0-arm64         |     |  |   |    |      |         2|      |    | 1|    |      |      |         |  
rhel7-s390x             |     |  |  4|    |      |          |      |    |  |    |      |      |         |  
smartos17-x64           |     |  |   |    |     2|          |      |    |  |    |      |      |         |  
smartos18-x64           |     |  |   |    |     2|          |      |    |  |    |      |      |         |  
ubuntu1404-x64          |     | 1|  1|    |      |          |      |    |  |    |      |      |         |  
ubuntu1404-x86          |     | 1|  1|    |      |          |      |    |  |    |      |      |         |  
ubuntu1604-arm64        |     |  |   |    |      |          |      |    |  |    |      |     2|         |  
ubuntu1604-x64          |     |  |   |    |      |          |      |    | 2|    |      |      |         | 2
ubuntu1604-x86          |     | 2|   |    |      |          |      |    |  |    |      |      |         |  
ubuntu1804-x64          |     | 1|   |    |     1|          |      |    |  |    |      |      |         |  
ubuntu1804_docker-x64   |     | 2|  1|    |      |          |      |    |  |    |      |      |         |  
ubuntu1804_workspace-x64|     |  |  1|    |      |          |      |    |  |    |      |     2|         |  
ubuntu2004-x64          |     | 2|   |    |      |          |      |    |  |    |      |      |         |  
win10-arm64             |     |  |   |    |      |          |      |   2|  |    |      |      |         |  
win10-x64               |    8|  |   |    |      |          |      |    |  |    |      |      |         |  
win2012r2-x64           |     |  |   |    |      |          |      |    |  |    |      |      |         |14
win2016-x64             |    6|  |   |    |      |          |      |    |  |    |      |      |         |  
zos24-s390x             |     |  |   |    |      |          |     2|    |  |    |      |      |         |  
$
```
with highlighting:
![image](https://user-images.githubusercontent.com/5445507/120310102-e91ce000-c2cd-11eb-85ba-75580dccd2fa.png)

we can (more easily) see that, for example, all of our current Fedora 30 hosts are hosted at DigitalOcean, so were we to replace these with, say Fedora 34, we might want to consider rebalancing so that an unforeseen outage at one provider wouldn't take out all of the hosts.
