### PR TITLE
ansible: provide absolute path in nodejs_yaml.py

### DIFF
--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -29,6 +29,7 @@ import json
 import os
 import subprocess
 import sys
+from os import path
 
 import yaml
 try:
@@ -74,7 +75,9 @@ def main():
     config.read('ansible.cfg')
 
     # load public inventory
-    export = parse_yaml(load_yaml_file(INVENTORY_FILENAME), config)
+    basepath = path.dirname(__file__)
+    inventory_path = path.abspath(path.join(basepath, "..", "..", "inventory.yml"))
+    export = parse_yaml(load_yaml_file(inventory_path), config)
 
     # try to load a secret inventory for each access level
     if check_decrypt_tool():


### PR DESCRIPTION
For AWX we need to use the nodejs_yaml.py script to parse the inventory
however the file expects to be run from within the `ansible`
subdirectory.

As Adoptium use AWX and the same format script as us this PR uses their
solution to fix the problem.

refs: https://github.com/adoptium/infrastructure/pull/1730