### PR TITLE
jenkins: add centos7-release-sources to select-compiler.sh

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -154,6 +154,16 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       . /opt/rh/devtoolset-6/enable
       echo "Compiler set to devtoolset-6"
       ;;
+    centos7-release-sources )
+      if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
+        . /opt/rh/devtoolset-8/enable
+      else
+        . /opt/rh/devtoolset-6/enable
+      fi
+      export CC="ccache gcc"
+      export CXX="ccache g++"
+      echo "Compiler set to GCC" `$CXX -dumpversion`
+      ;;
     *ubuntu1604-*64|benchmark )
       if [ "$NODEJS_MAJOR_VERSION" -gt "12" ]; then
         export CC="gcc-6"


### PR DESCRIPTION
The `centos7-release-sources` part of the `iojs+release` job builds
the `node` binary and should select the compiler to use based on the
Node.js version being built. Put this logic in `select-compiler.sh`
(as is done for other platforms).

Refs: https://github.com/nodejs/build/issues/2671
Refs: https://github.com/nodejs/build/issues/2481

I'll also need to update the CI job to call `select-compiler.sh` (currently it directly enables devtoolset-6).