### PR TITLE
ansible: build gn from source on Linux PPC/s390x

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -7,7 +7,6 @@
     * [Full Xcode](#full-xcode)
     * [Signing certificates](#signing-certificates)
 * [RHEL7-S390X](#rhel7-s390x)
-  * [V8 build-tools](#v8-build-tools)
   * [devtoolset-6 install](#devtoolset-6-install)
 * [macOS](#macos)
 * [AIX 7.2 Install](#aix-72-install)
@@ -127,18 +126,6 @@ Not After : Jan 22 03:40:05 2025 GMT
 ```
 
 ## RHEL7-S390X
-
-### V8 build-tools
-
-Copy `/home/iojs/build-tools/{gn,ninja}` from any other RHEL7-S390X host that
-has them to the newly provisioned one. Confirm `gn --version` is at least
-`1620`.
-
-If building from scratch, gn is built from  https://gn.googlesource.com/gn,
-and ninja is built from https://github.com/ninja-build/ninja.
-
-Note: If https://bugs.chromium.org/p/chromium/issues/detail?id=1029662 is
-resolved this will no longer be necessary.
 
 ### devtoolset-6 install
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -145,10 +145,10 @@ hosts:
         aix71-ppc64_be-4:  
             ip: 169.48.22.51
             server_jobs: 6
-        rhel7-s390x-1: {ip: 148.100.86.21, user: linux1}
-        rhel7-s390x-2: {ip: 148.100.86.117, user: linux1}
-        rhel7-s390x-3: {ip: 148.100.86.28, user: linux1}
-        rhel7-s390x-4: {ip: 148.100.86.94, user: linux1}
+        rhel7-s390x-1: {ip: 148.100.86.21, user: linux1, build_test_v8: yes}
+        rhel7-s390x-2: {ip: 148.100.86.117, user: linux1, build_test_v8: yes}
+        rhel7-s390x-3: {ip: 148.100.86.28, user: linux1, build_test_v8: yes}
+        rhel7-s390x-4: {ip: 148.100.86.94, user: linux1, build_test_v8: yes}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
 
     - joyent:
@@ -236,8 +236,8 @@ hosts:
         aix72-ppc64_be-4:
             ip: 140.211.9.101
             server_jobs: 6
-        centos7-ppc64_le-1: {ip: 140.211.168.193, user: centos}
-        centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos}
+        centos7-ppc64_le-1: {ip: 140.211.168.193, user: centos, build_test_v8: yes}
+        centos7-ppc64_le-2: {ip: 140.211.168.244, user: centos, build_test_v8: yes}
 
     - orka:
         macos10.15-x64-1:

--- a/ansible/roles/build-test-v8/meta/argument_specs.yml
+++ b/ansible/roles/build-test-v8/meta/argument_specs.yml
@@ -1,0 +1,17 @@
+argument_specs:
+  main:
+    short_description: The main task for prereqs for build/testing V8.
+    options:
+      tools_dest_dir:
+        description: The location to place the symlink to the binaries.
+        required: yes
+        type: "str"
+      tools_git_dir:
+        description: The location to put git checkouts.
+        required: yes
+        type: "str"
+      tools_user:
+        default: "{{ server_user|default(omit) }}"
+        description: The user to install binaries under.
+        type: "str"
+

--- a/ansible/roles/build-test-v8/meta/main.yml
+++ b/ansible/roles/build-test-v8/meta/main.yml
@@ -1,0 +1,16 @@
+# Build/testing V8 requires ninja and gn. V8's depot_tools toolchain provides
+# prebuilt binaries for x64 but for ppc64 and s390x we need to compile these
+# ourselves.
+dependencies:
+  - role: ninja
+    when: arch == 'ppc64' or arch == 's390x'
+    vars:
+      ninja_dest_dir: "{{ tools_dest_dir }}"
+      ninja_git_dir: "{{ tools_git_dir }}/ninja"
+      ninja_user: "{{ tools_user }}"
+  - role: gn
+    when: arch == 'ppc64' or arch == 's390x'
+    vars:
+      gn_dest_dir: "{{ tools_dest_dir }}"
+      gn_git_dir: "{{ tools_git_dir }}/gn"
+      gn_user: "{{ tools_user }}"

--- a/ansible/roles/gn/meta/argument_specs.yml
+++ b/ansible/roles/gn/meta/argument_specs.yml
@@ -1,0 +1,17 @@
+argument_specs:
+  main:
+    short_description: The main task for compiling gn from source.
+    options:
+      gn_dest_dir:
+        description: The location to place the symlink to the gn binary.
+        required: yes
+        type: "str"
+      gn_git_dir:
+        description: The location to put the git checkout.
+        required: yes
+        type: "str"
+      gn_user:
+        default: "{{ server_user|default(omit) }}"
+        description: The user to install gn under.
+        type: "str"
+

--- a/ansible/roles/gn/tasks/main.yml
+++ b/ansible/roles/gn/tasks/main.yml
@@ -1,0 +1,45 @@
+- name: check existing gn
+  ansible.builtin.command: "{{ gn_dest_dir }}/gn --version"
+  changed_when: no
+  failed_when: no
+  register: gn_installed_version
+
+- name: clone/update gn repository
+  ansible.builtin.git:
+    dest: "{{ gn_git_dir }}"
+    repo: "https://gn.googlesource.com/gn"
+  become: "{{ gn_user|default(omit)|bool }}"
+  become_user: "{{ gn_user|default(omit) }}"
+  register: gn_git
+
+# `gn --version` includes the first seven characters of the commit hash the
+# binary was built from: e.g. 1620 (570aaed)
+- name: check if gn needs to be rebuilt
+  ansible.builtin.set_fact:
+    rebuild_gn: "{{ not gn_installed_version.stdout|default('') is search(gn_git.after[:7]) }}"
+
+# Requires a C++17 compiler. At the moment we're only building on CentOS/RHEL
+# so have devtoolset-8 available.
+- name: build gn
+  ansible.builtin.shell: |
+    python3 build/gen.py && \
+    . /opt/rh/devtoolset-8/enable && \
+    {{ gn_dest_dir }}/ninja -C out && \
+    out/gn_unittests
+  args:
+    chdir: "{{ gn_git_dir }}"
+  become: "{{ gn_user|default(omit)|bool }}"
+  become_user: "{{ gn_user|default(omit) }}"
+  environment:
+    CC: gcc
+    CXX: g++
+  when: rebuild_gn
+
+- name: create symlink
+  ansible.builtin.file:
+    dest: "{{ gn_dest_dir }}/gn"
+    src: "{{ gn_git_dir }}/out/gn"
+    state: link
+  become: "{{ gn_user|default(omit)|bool }}"
+  become_user: "{{ gn_user|default(omit) }}"
+  when: rebuild_gn

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -104,6 +104,17 @@
     cmd: "./bootstrap --verbose && make -j6 VERBOSE=1 && make install"
     creates: "/usr/local/bin/cmake"
 
+# Running the role for build/testing V8 is currently called here as we require
+# `/home/{{ server_user }}` to have been created.
+- name: build/test V8 role
+  when: build_test_v8|default(False)
+  include_role:
+    name: build-test-v8
+  vars:
+    tools_dest_dir: "/home/{{ server_user }}/build-tools"
+    tools_git_dir: "/home/{{ server_user }}"
+    tools_user: "{{ server_user }}"
+
 - name: prepare installing tap2junit
   when: type != "release"
   include: "{{ pip_include }}"

--- a/ansible/roles/ninja/meta/argument_specs.yml
+++ b/ansible/roles/ninja/meta/argument_specs.yml
@@ -1,0 +1,17 @@
+argument_specs:
+  main:
+    short_description: The main task for compiling ninja from source.
+    options:
+      ninja_dest_dir:
+        description: The location to place the symlink to the ninja binary.
+        required: yes
+        type: "str"
+      ninja_git_dir:
+        description: The location to put the git checkout.
+        required: yes
+        type: "str"
+      ninja_user:
+        default: "{{ server_user|default(omit) }}"
+        description: The user to install ninja under.
+        type: "str"
+

--- a/ansible/roles/ninja/tasks/main.yml
+++ b/ansible/roles/ninja/tasks/main.yml
@@ -1,0 +1,45 @@
+- name: check existing ninja
+  ansible.builtin.command: "{{ ninja_dest_dir }}/ninja --version"
+  changed_when: no
+  failed_when: no
+  register: ninja_installed_version
+
+- name: get Ninja release information from GitHub
+  ansible.builtin.uri:
+    return_content: yes
+    url: https://api.github.com/repos/ninja-build/ninja/releases/latest
+  register: ninja_latest
+
+# Tag in GitHub is prefixed with 'v' but the output from `ninja --version` is not.
+- name: check if Ninja needs to be rebuilt
+  ansible.builtin.set_fact:
+    rebuild_ninja: "{{ not ninja_installed_version.stdout|default('') == ninja_latest.json.tag_name[1:] }}"
+
+- name: clone/update ninja-build repository
+  ansible.builtin.git:
+    dest: "{{ ninja_git_dir }}"
+    repo: https://github.com/ninja-build/ninja
+    version: "{{ ninja_latest.json.tag_name }}"
+  become: "{{ ninja_user|default(omit)|bool }}"
+  become_user: "{{ ninja_user|default(omit) }}"
+  when: rebuild_ninja
+
+- name: build Ninja
+  ansible.builtin.shell: |
+    python3 ./configure.py --bootstrap && \
+    ./ninja ninja_test && ./ninja_test
+  args:
+    chdir: "{{ ninja_git_dir }}"
+  become: "{{ ninja_user|default(omit)|bool }}"
+  become_user: "{{ ninja_user|default(omit) }}"
+  when: rebuild_ninja
+
+- name: create symlink
+  ansible.builtin.file:
+    dest: "{{ ninja_dest_dir }}/ninja"
+    src: "{{ ninja_git_dir }}/ninja"
+    state: link
+  become: "{{ ninja_user|default(omit)|bool }}"
+  become_user: "{{ ninja_user|default(omit) }}"
+  when: rebuild_ninja
+ 


### PR DESCRIPTION
Add `build-test-v8` meta-role for installing prerequisites for V8
building/testing. Add roles to build `gn` and `ninja` binaries from
source and call those from the `build-test-v8` role for Linux on
ppc64/s390x.

This removes a previously manual step from the Linux PPC/s390x setup (docs also updated).

I've deployed this onto
- test-ibm-rhel7-s390x-1
- test-ibm-rhel7-s390x-2
- test-ibm-rhel7-s390x-3
- test-ibm-rhel7-s390x-4
- test-osuosl-centos7-ppc64_le-1
- test-osuosl-centos7-ppc64_le-2

to update the version of `gn` (the version we'd previously manually compiled is now too old, see https://github.com/nodejs/node/pull/38990#issuecomment-858764907). 
We're now updated to:
```
[iojs@test-osuosl-centos7-ppc64--le-1 build-tools]$ ./ninja --version
1.10.2
[iojs@test-osuosl-centos7-ppc64--le-1 build-tools]$ ./gn --version
1916 (d2dce75)
[iojs@test-osuosl-centos7-ppc64--le-1 build-tools]$
```