### PR TITLE
github-bot: update deploy procedure after default branch change

### DIFF
--- a/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
+++ b/ansible/roles/github-bot/templates/deploy-github-bot.sh.j2
@@ -10,7 +10,7 @@ cd /home/{{ server_user }}/github-bot
 git reset --hard
 git clean -fdx
 git fetch origin
-git checkout origin/master
+git checkout origin/main
 
 npm install --cache-min 1440 --production
 sudo systemctl restart github-bot

--- a/ansible/roles/github-bot/templates/github-bot-deploy-webhook.json.j2
+++ b/ansible/roles/github-bot/templates/github-bot-deploy-webhook.json.j2
@@ -6,7 +6,7 @@
   "rules": [
     {
       "event": "push",
-      "match": "ref == \"refs/heads/master\"",
+      "match": "ref == \"refs/heads/main\"",
       "exec": "/home/{{ server_user }}/bin/deploy-github-bot.sh"
     }
   ]


### PR DESCRIPTION
The nodejs/github-bot' default branch just changed to `main`. That also means our deploy procedure has to change accordingly, to listen for commits and pull from `main` as opposed to `master`.

Refs https://github.com/nodejs/github-bot/issues/302