### PR TITLE
ansible: allow running playbook in check mode

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/centos.yml
+++ b/ansible/roles/bootstrap/tasks/partials/centos.yml
@@ -1,5 +1,6 @@
 - name: check for firewalld
   raw: stat /usr/sbin/firewalld
+  check_mode: no
   register: has_firewalld
   failed_when: has_firewalld.rc > 1
 

--- a/ansible/roles/bootstrap/tasks/partials/centos6.yml
+++ b/ansible/roles/bootstrap/tasks/partials/centos6.yml
@@ -6,11 +6,13 @@
 
 - name: check for python
   raw: stat /usr/bin/python
+  check_mode: no
   register: has_python
   failed_when: has_python.rc > 1
 
 - name: check for libselinux-python bindings
   raw: yum info libselinux-python | grep Installed
+  check_mode: no
   register: has_libselinux
   failed_when:  has_libselinux.rc > 1
 

--- a/ansible/roles/bootstrap/tasks/partials/debian9.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian9.yml
@@ -6,6 +6,7 @@
 
 - name: check for apt-transport-https
   raw: stat /usr/lib/apt/methods/https
+  check_mode: no
   register: has_apt_transport
   failed_when: has_apt_transport.rc > 1
 

--- a/ansible/roles/bootstrap/tasks/partials/fedora.yml
+++ b/ansible/roles/bootstrap/tasks/partials/fedora.yml
@@ -9,6 +9,7 @@
 
 - name: check for python
   raw: stat /usr/bin/python2
+  check_mode: no
   register: has_python
   failed_when: has_python.rc > 1
 
@@ -22,6 +23,7 @@
 
 - name: check for {{ 'libselinux-python' if os in ("fedora30") else 'python3-libselinux' }} bindings
   raw: dnf info {{ 'libselinux-python' if os in ("fedora30") else 'python3-libselinux' }} | grep Installed
+  check_mode: no
   register: has_libselinux
   failed_when:  has_libselinux.rc > 1
 
@@ -40,6 +42,7 @@
 
 - name: check for firewalld
   raw: stat /usr/sbin/firewalld
+  check_mode: no
   register: has_firewalld
   failed_when: has_firewalld.rc > 1
 

--- a/ansible/roles/bootstrap/tasks/partials/freebsd.yml
+++ b/ansible/roles/bootstrap/tasks/partials/freebsd.yml
@@ -6,6 +6,7 @@
 
 - name: check for python
   raw: stat /usr/local/bin/python
+  check_mode: no
   register: has_python
   failed_when: has_python.rc > 1
 

--- a/ansible/roles/bootstrap/tasks/partials/ubuntu1604.yml
+++ b/ansible/roles/bootstrap/tasks/partials/ubuntu1604.yml
@@ -6,11 +6,13 @@
 
 - name: check for python
   raw: stat /usr/bin/python
+  check_mode: no
   failed_when: has_python.rc > 1
   register: has_python
 
 - name: check for aptitude
   raw: stat /usr/bin/aptitude
+  check_mode: no
   failed_when: has_aptitude.rc > 1
   register: has_aptitude
 

--- a/ansible/roles/bootstrap/tasks/partials/ubuntu1804.yml
+++ b/ansible/roles/bootstrap/tasks/partials/ubuntu1804.yml
@@ -6,11 +6,13 @@
 
 - name: check for python
   raw: stat /usr/bin/python
+  check_mode: no
   failed_when: has_python.rc > 1
   register: has_python
 
 - name: check for aptitude
   raw: stat /usr/bin/aptitude
+  check_mode: no
   failed_when: has_aptitude.rc > 1
   register: has_aptitude
 

--- a/ansible/roles/bootstrap/tasks/partials/zos.yml
+++ b/ansible/roles/bootstrap/tasks/partials/zos.yml
@@ -6,5 +6,6 @@
 
 - name: check for python
   shell: "python --version"
+  check_mode: no
   register: has_python
   failed_when: has_python.rc > 1

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -37,6 +37,7 @@
 
 - name: Check if java is already installed
   raw: java -version
+  check_mode: no
   register: java
   ignore_errors: yes
 


### PR DESCRIPTION
In some places we use the Ansible `raw` task to execute a command on
the remote machine. Typically this is done to check for the presence
of a file. Ansible itself has no way of knowing if the command we are
executing makes modifications to the system so does not run `raw` tasks
when `ansible-playbook` is run with `--check`. Some of our subsequent
tasks rely on the `raw` task having previous run (to create a variable)
so the playbook currently errors with messages such as:
`'dict object' has no attribute ...`
when run in `--check` mode.

Mark `raw` tasks that do not make modifications with `check_mode: no`
(which means "don't check if `--check` was set and just execute the
command"). This allows us to run the playbook with `--check` first to
see what Ansible thinks would change without actually making the
changes.