### PR TITLE
ansible: install g++-8 on Ubuntu 16.04

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -153,7 +153,7 @@ packages: {
 
   # Default gcc/g++ package is 5.
   ubuntu1604: [
-    'gcc-8,g++-6,gcc-6,g++-6,python3.9,python3.9-distutils',
+    'gcc-8,g++-8,gcc-6,g++-6,python3.9,python3.9-distutils',
   ],
 
   # Default gcc/g++ package is 7.


### PR DESCRIPTION
Fixup copy/paste error and install g++-8 on Ubuntu 16.04.

Refs: https://github.com/nodejs/build/pull/2660