### PR TITLE
Fixes for Ubuntu 16.04 to fix C++ coverage

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -132,7 +132,7 @@
   alternatives:
     link: "/usr/bin/python3"
     name: python3
-    path: "/usr/bin/python3.9"
+    path: "/usr/bin/python3.7"
 
 - name: freebsd | update python package alternatives
   when: os == "freebsd11"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -153,7 +153,7 @@ packages: {
 
   # Default gcc/g++ package is 5.
   ubuntu1604: [
-    'gcc-8,g++-8,gcc-6,g++-6,python3.9,python3.9-distutils',
+    'gcc-8,g++-8,gcc-6,g++-6,python3.7,python3.7-distutils',
   ],
 
   # Default gcc/g++ package is 7.

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -168,10 +168,12 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
         export CC="ccache gcc-8"
         export CXX="ccache g++-8"
+        export GCOV="gcov-8"
         export LINK="g++-8"
       else
         export CC="ccache gcc-6"
         export CXX="ccache g++-6"
+        export GCOV="gcov-6"
         export LINK="g++-6"
       fi
       echo "Compiler set to GCC" `$CXX -dumpversion`


### PR DESCRIPTION
Two build side fixes required together with https://github.com/nodejs/node/pull/39326 to address the currently broken C++ coverage.

- **ansible: downgrade to Python 3.7 on Ubuntu 16.04**
On Ubuntu 16.04 the `python3-pip` package is not compatible with
Python 3.8 and later. Downgrade Python 3 to Python 3.7 which is
new enough for building current Node.js (Python 3.6 or later) but
still compatible with the `python3-pip` package.

- **jenkins: set GCOV on Ubuntu to match CC/CXX**
Code coverage runs `gcov` but this needs to match the version of
gcc/g++ used.

Refs: https://github.com/nodejs/node/issues/39303
Refs: https://github.com/nodejs/node/pull/39326