### PR TITLE
ansible: install glib2-devel on centos7-ppc64

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -42,7 +42,7 @@ packages: {
   # partials/repo/centos7.yml for arm64
   centos7_arm64: ['git,python3'], # git2u not available for aarch64 (yet)
   centos7_x64: ['devtoolset-6-libatomic-devel,git222,centos-release-scl,python3'],
-  centos7_ppc64: ['cmake3,devtoolset-6-libatomic-devel,git,python3'],
+  centos7_ppc64: ['cmake3,devtoolset-6-libatomic-devel,glib2-devel,git,python3'],
 
   centos7: [
     'bzip2-devel,openssl-devel,ccache,gcc-c++,devtoolset-6,sudo,zlib-devel,libffi-devel,devtoolset-8,devtoolset-8-libatomic-devel',

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -89,6 +89,7 @@
 # to discover the most recent release for the given adoptopenjdk_version and
 # platform.
 - name: fetch adoptopenjdk metadata
+  check_mode: no
   register: adoptopenjdk_metadata
   uri:
     body_format: json

--- a/ansible/roles/ninja/tasks/main.yml
+++ b/ansible/roles/ninja/tasks/main.yml
@@ -8,6 +8,7 @@
   ansible.builtin.uri:
     return_content: yes
     url: https://api.github.com/repos/ninja-build/ninja/releases/latest
+  check_mode: no
   register: ninja_latest
 
 # Tag in GitHub is prefixed with 'v' but the output from `ninja --version` is not.


### PR DESCRIPTION
V8 CI needs `glib2-devel` installed.

Also a commit to fix running in check mode.

Fixes: https://github.com/nodejs/build/issues/2702
Refs: https://github.com/nodejs/node/pull/39373#issuecomment-878994383