### PR TITLE
ansible: use `maint/maint-*` branches of ICU

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -37,21 +37,19 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
-ENV ICU64DIR=/opt/icu-64.1 \
-    ICU65DIR=/opt/icu-65.1 \
-    ICU67DIR=/opt/icu-67.1 \
-    ICU68DIR=/opt/icu-68.2 \
-    ICU69DIR=/opt/icu-69.1
+ENV ICU64DIR=/opt/icu-64 \
+    ICU65DIR=/opt/icu-65 \
+    ICU67DIR=/opt/icu-67 \
+    ICU68DIR=/opt/icu-68 \
+    ICU69DIR=/opt/icu-69
 
 RUN for ICU_ENV in $(env | grep ICU..DIR); do \
     ICU_PREFIX=$(echo $ICU_ENV | cut -d '=' -f 2) && \
     ICU_VERSION=$(echo $ICU_PREFIX | cut -d '-' -f 2) && \
-    ICU_MAJOR=$(echo $ICU_VERSION | cut -d '.' -f 1) && \
-    ICU_MINOR=$(echo $ICU_VERSION | cut -d '.' -f 2) && \
     mkdir -p /tmp/icu-$ICU_VERSION && \
     cd /tmp/icu-$ICU_VERSION && \
-    curl -sL "https://github.com/unicode-org/icu/releases/download/release-$ICU_MAJOR-$ICU_MINOR/icu4c-${ICU_MAJOR}_$ICU_MINOR-src.tgz" | tar zxv --strip=1 && \
-    cd source && \
+    curl -sL "https://api.github.com/repos/unicode-org/icu/tarball/maint/maint-$ICU_VERSION" | tar zxv --strip=1 && \
+    cd icu4c/source && \
     ./runConfigureICU Linux --prefix=$ICU_PREFIX && \
     make -j $JOBS && \
     make install && \


### PR DESCRIPTION
Use the `maint/maint-*` branches of the ICU repository to build the
"system" ICU libraries. Node.js 12 requires patches on top of ICU 64
to pass intl tests which are present on the `maint/maint-64` branch
but not in the 64.2 release. These patches are present in the Node.js
source tree for `v12.x-staging` under [`tools/icu/patches`](https://github.com/nodejs/node/tree/v12.x-staging/tools/icu/patches) but these
are only applied when building ICU statically linked.