### PR TITLE
ansible: update to openssl-3.0.0-beta1

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -80,7 +80,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-alpha16+quic --depth 1 && \
+    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-beta1+quic --depth 1 && \
     cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \


### PR DESCRIPTION
This commit updates the version of quictls/openssl to 3.0.0-beta1. This
change will cause a test failure so it needs to be coordinated with
https://github.com/nodejs/node/pull/38753.