### PR TITLE
ansible: require a limit when running build helper tasks

### DIFF
--- a/ansible/playbooks/jenkins/worker/clear-workspace.yml
+++ b/ansible/playbooks/jenkins/worker/clear-workspace.yml
@@ -5,8 +5,17 @@
 #
 
 - hosts: test
-  gather_facts: yes
+  gather_facts: no
   tasks:
+
+  - name: Check for limit
+    fail:
+      msg: "No limit set!"
+    when: ansible_limit is not defined
+    run_once: true
+
+  - name: Gathering facts
+    setup:
 
   - name: remove workspace
     file: 

--- a/ansible/playbooks/jenkins/worker/restart-agent.yml
+++ b/ansible/playbooks/jenkins/worker/restart-agent.yml
@@ -5,8 +5,16 @@
 #
 
 - hosts: test
-  gather_facts: yes
+  gather_facts: no
   tasks:
+    - name: Check for limit
+      fail:
+        msg: "No limit set!"
+      when: ansible_limit is not defined
+      run_once: true
+
+    - name: Gathering facts
+      setup:
 
     - name: Kill Jenkins process - AIX
       shell: ps awwx | grep jenkins | grep -v grep | awk '{ print $1 }' | xargs kill


### PR DESCRIPTION
Ensure a limit is set when running this potentially dangerous playbooks
which could cause a lot of damage if run against every machine in the
cluster