### PR TITLE
ansible: create `gtar` symlink on AIX

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -188,18 +188,15 @@
     regexp: '^127\.0\.1\.1\s+\w.+$'
     line: '127.0.1.1        {{safe_hostname}}'
 
-- name: aix | update curl symlinks
+- name: aix | update symlinks
   when: os|startswith("aix")
   file:
-    src: "/opt/freeware/bin/{{ curl }}"
-    dest: "/usr/bin/{{ curl }}"
+    src: "/opt/freeware/bin/{{ item.0 }}"
+    dest: "/usr/bin/{{ item.1 }}"
     state: link
-  loop_control:
-    loop_var: curl
-  with_items:
-    - curl
-    - curl_32
-    - curl_64
+  with_together:
+    - [ 'curl', 'curl_32', 'curl_64', 'tar' ]
+    - [ 'curl', 'curl_32', 'curl_64', 'gtar' ]
 
 - name: run ccache installer
   include: "{{ ccache_include }}"


### PR DESCRIPTION
New versions of the `tar` package from the AIX Toolbox no longer
create the `/usr/bin/gtar` symlink. Ansible's `unarchive` task
attempts to find `gtar` before falling back to using `tar` but on
AIX `tar` is not the GNU version of `tar` and the `unarchive` task
is incompatible with it.

Similar to https://github.com/nodejs/build/issues/2536 / https://github.com/nodejs/build/pull/2537.