### PR TITLE
ansible: clear yum packages cache

### DIFF
--- a/ansible/roles/package-upgrade/tasks/partials/yum.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/yum.yml
@@ -3,8 +3,10 @@
 #
 # Updates all packages for centos-based distributions
 #
+- name: clean yum packages cache
+  ansible.builtin.command: yum clean packages
 
-  - name: upgrade installed packages
-    yum: name=* state=latest use_backend=yum expire-cache=yes
+- name: upgrade installed packages
+  yum: name=* state=latest use_backend=yum expire-cache=yes
 # If difficulty recognizing yum is encountered, see https://github.com/ansible/ansible/pull/69484, it is possible
 # to apply that patch manually to a local install of ansible (if necessary).


### PR DESCRIPTION
Clear the yum packages cache to prevent `/var` filling up.

Refs: https://github.com/nodejs/build/issues/2718#issuecomment-891126582

Ansible doesn't provide a task/option to do this so we need to directly run `yum clean`, see https://github.com/ansible/ansible/pull/31450#issuecomment-352889579.