### PR TITLE
jenkins: fix rule for ubuntu2004

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -35,7 +35,7 @@ def buildExclusions = [
   [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1604-64/,                 anyType,     gte(16) ],
-  [ /^ubuntu2004-64/,                 anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
+  [ /^ubuntu2004-(arm|x)?64/,         anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
   [ /^alpine-latest-x64$/,            anyType,     lt(13)  ], // Alpine 3.12 doesn't have Python 2
 
   // Linux PPC LE ------------------------------------------


### PR DESCRIPTION
Fix the VersionSelector rule for ubuntu2004 to allow for the arch
qualifier (e.g. arm).

Refs: https://github.com/nodejs/build/pull/2731