### PR TITLE
build,test: Add CentOS7 Dockerfile (arm64 only for now)

### DIFF
--- a/ansible/roles/docker/templates/centos7.Dockerfile.j2
+++ b/ansible/roles/docker/templates/centos7.Dockerfile.j2
@@ -1,0 +1,54 @@
+FROM centos:7
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV SHELL /bin/bash
+ENV HOME /home/{{ server_user }}
+ENV PATH /usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
+ENV DESTCPU {{ arch }}
+ENV ARCH {{ arch }}
+
+RUN yum -y update && \
+    yum install -y \
+      gcc \
+      gcc-c++ \
+      make \
+      git \
+      java-1.8.0-openjdk-headless \
+      pkgconfig \
+      curl \
+      python3-pip \
+      fontconfig-devel
+
+RUN pip3 install tap2junit
+
+RUN groupadd --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
+
+RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} -c {{ server_user }} {{ server_user }}
+
+RUN yum -y install epel-release
+RUN yum -y install ccache
+
+RUN yum -y install glibc-devel zip unzip perl openssh-clients libgomp make scl-utils avahi kernel-devel policycoreutils-python which libgfortran
+RUN rpm -ivh https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-runtime-6.1-1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-libs-0.168-3.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-runtime-3.0-8s.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-ltrace-0.7.91-17.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-strace-4.12-3.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-client-3.0-8s.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-gfortran-6.3.1-3.1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-binutils-2.27-12.el7.1.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-libelf-0.168-3.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-0.168-3.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gdb-7.12.1-48.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-make-4.1-3.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-c++-6.3.1-3.1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-memstomp-0.1.5-5.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-dwz-0.12-1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-3.0-8s.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-toolchain-6.1-1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-6.3.1-3.1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-valgrind-3.12.0-1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-libstdc++-devel-6.3.1-3.1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-oprofile-1.1.0-4.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-devel-3.0-8s.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-perftools-6.1-1.el7.aarch64.rpm https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-6.1-1.el7.aarch64.rpm
+
+RUN yum -y install centos-release-scl
+RUN yum -y install devtoolset-8 devtoolset-8-libatomic-devel
+
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
+
+USER iojs:iojs
+
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
+CMD cd /home/iojs \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java -Xmx{{ server_ram|default('128m') }} \
+          -jar /home/{{ server_user }}/slave.jar \
+          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
+          -secret {{ item.secret }}


### PR DESCRIPTION
"arm64 only" is due to the special way that I'm currently installing the devtoolset-6 packages in here for now. I feel this needs a better solution ...

Signed-off-by: Stewart X Addison <sxa@redhat.com>