### PR TITLE
build,test: add python-is-python3 to ubuntu 20.04 dockerfiles

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     openjdk-8-jre-headless \
     curl \
     python3-pip \
+    python-is-python3 \
     libfontconfig1
 
 RUN pip3 install tap2junit

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install apt-utils -y && \
       pkg-config \
       curl \
       python3-pip \
+      python-is-python3 \
       libfontconfig1
 
 RUN pip3 install tap2junit


### PR DESCRIPTION
Problem identified by @MylesBorins while building Node14 on the new Ubuntu 20.04 test system. (Fix went live yesterday, but this is the corresponding PR)

Signed-off-by: Stewart X Addison <sxa@redhat.com>