### PR TITLE
doc: flesh out a little more info on the docker-host playbook

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -213,11 +213,20 @@ containers:
 Where each item corresponds to a container to be set up and run on the host.
 
 Each `name` should exist as a node in Jenkins and the corresponding `secret`
-should be given. The `os` determines the `Dockerfile` to use to build the host.
-The templates for these can be found in `roles/docker/templates/`.
+should be given.  The `os` determines the `Dockerfile` to use to build the
+host.  The templates for these can be found in `roles/docker/templates/`. 
+
+For testing purposes, the stanza above can be added into
+`host_vars/<docker_host>`, then the master record should be in the
+`inventory.yml` in the secrets repository.
 
 Note that the Docker host itself doesn't need to be known by Jenkins, just the
 containers that are managed there.
+
+The docker-host playbook sets up services which are managed via `systemctl`. 
+If you log into the host sytsem you can view them with `systemctl | grep
+jenkins-` and start and stop individual ones using `systemctl start` and
+`systemctl stop` commands as and when required.
 
 ### TODO
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -226,7 +226,9 @@ containers that are managed there.
 The docker-host playbook sets up services which are managed via `systemctl`. 
 If you log into the host sytsem you can view them with `systemctl | grep
 jenkins-` and start and stop individual ones using `systemctl start` and
-`systemctl stop` commands as and when required.
+`systemctl stop` commands as and when required. For more information on
+debugging problems, see the
+[separate guide to fixing docker machines](https://github.com/nodejs/build/blob/master/doc/jenkins-guide.md#fixing-machines-with-docker)
 
 ### TODO
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -228,7 +228,7 @@ If you log into the host sytsem you can view them with `systemctl | grep
 jenkins-` and start and stop individual ones using `systemctl start` and
 `systemctl stop` commands as and when required. For more information on
 debugging problems, see the
-[separate guide to fixing docker machines](https://github.com/nodejs/build/blob/master/doc/jenkins-guide.md#fixing-machines-with-docker)
+[separate guide to fixing docker machines](../doc/jenkins-guide.md#fixing-machines-with-docker)
 
 ### TODO
 


### PR DESCRIPTION
Sefl-explanatory - add a bit more information for people deploying docker host machines.

Signed-off-by: Stewart X Addison <sxa@redhat.com>