### PR TITLE
build,test: Add libuv prereqs to centos7 dockerfile

### DIFF
--- a/ansible/roles/docker/templates/centos7.Dockerfile.j2
+++ b/ansible/roles/docker/templates/centos7.Dockerfile.j2
@@ -25,6 +25,8 @@ RUN yum -y update && \
       python3-pip \
       fontconfig-devel
 
+RUN yum -y install libtool automake
+
 RUN pip3 install tap2junit
 
 RUN groupadd --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}

--- a/ansible/roles/docker/templates/centos7.Dockerfile.j2
+++ b/ansible/roles/docker/templates/centos7.Dockerfile.j2
@@ -23,9 +23,9 @@ RUN yum -y update && \
       pkgconfig \
       curl \
       python3-pip \
-      fontconfig-devel
-
-RUN yum -y install libtool automake
+      fontconfig-devel \
+      libtool \
+      automake
 
 RUN pip3 install tap2junit
 


### PR DESCRIPTION
[libuv-test-commit-linux](https://ci.nodejs.org/job/libuv-test-commit-linux) requires some additional packages which were not in the original CentOS7 dockerfile which is in use for the new aarch64 systems ([Ref issue](https://github.com/nodejs/build/issues/2729))

This has been deployed on the machines and those jobs can now run without prereq issues.

Signed-off-by: Stewart X Addison <sxa@redhat.com>