### PR TITLE
ansible: update Fedora 30 hosts to Fedora 34

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -31,10 +31,10 @@ ansible_python_interpreter = /opt/local/bin/python
 [hosts:freebsd]
 ansible_python_interpreter = /usr/local/bin/python
 
-[hosts:fedora30]
+[hosts:fedora32]
 ansible_python_interpreter = /usr/bin/python3
 
-[hosts:fedora32]
+[hosts:fedora34]
 ansible_python_interpreter = /usr/bin/python3
 
 [hosts:ibm]

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -126,8 +126,8 @@ hosts:
         debian8-x64-1: {ip: 159.203.103.52}
         debian9-x64-1: {ip: 138.197.97.208}
         fedora32-x64-1: {ip: 159.203.117.50}
-        fedora30-x64-1: {ip: 178.62.236.249}
-        fedora30-x64-2: {ip: 159.203.98.84}
+        fedora34-x64-1: {ip: 178.62.236.249}
+        fedora34-x64-2: {ip: 159.203.98.84}
         freebsd11-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd11-x64-2: {ip: 107.170.28.213, user: freebsd}
         ubuntu1404-x64-1: {ip: 45.55.252.223}

--- a/ansible/roles/bootstrap/tasks/partials/fedora.yml
+++ b/ansible/roles/bootstrap/tasks/partials/fedora.yml
@@ -49,3 +49,7 @@
 - name: remove firewalld
   when: has_firewalld.rc == 0
   raw: dnf remove -y firewalld
+
+- name: update crypto policies
+  when: os in ("fedora34")
+  raw: update-crypto-policies --set LEGACY


### PR DESCRIPTION
Update the two DigitalOcean Fedora 30 host to Fedora 34.

Refs: https://github.com/nodejs/build/issues/2527#issuecomment-911814447

> Reimaging was fairly painless but I ran into https://www.digitalocean.com/community/questions/fedora-33-how-to-persist-dns-settings-via-etc-resolv-conf (with Fedora 34) meaning our playbooks failed until I went onto the machine and fixed the DNS settings (as per https://www.digitalocean.com/community/questions/fedora-33-how-to-persist-dns-settings-via-etc-resolv-conf?answer=66950).

Deployed. Labels have been swapped so the existing Fedora 32 hosts are now `fedora-last-latest-x64` while the reimaged Fedora 34 hosts are now `fedora-latest-x64`.