### PR TITLE
doc: add TOC entry for Windows section

### DIFF
--- a/doc/jenkins-guide.md
+++ b/doc/jenkins-guide.md
@@ -17,6 +17,7 @@ A guide on maintaining Node.js' Test and Release Jenkins clusters
   * [Read-only filesystem](#read-only-filesystem)
   * [Restart the machine](#restart-the-machine)
   * [Fixing machines with Docker](#fixing-machines-with-docker)
+  * [Windows](#windows)
   * [IDK what to do](#idk-what-to-do)
 
 


### PR DESCRIPTION
FYI GitHub's web UI has a button now with an auto-generated TOC but that doesn't help if you're reading the doc from a local checkout (e.g. via VSCode's markdown preview).
<details>
<summary>Screenshot of auto-generated TOC</summary>

![image](https://user-images.githubusercontent.com/5445507/132204772-fb74362b-dda0-4e11-ac07-879fa1d56304.png)

</details>
