### PR TITLE
www: run sync-benchmarking once every four hours

### DIFF
--- a/ansible/www-standalone/tasks/site-setup.yaml
+++ b/ansible/www-standalone/tasks/site-setup.yaml
@@ -113,7 +113,7 @@
     - '*/30 *    * * *   dist    /home/staging/tools/promote/promote_nightly.sh nodejs'
     - '*/5  *    * * *   nodejs  /home/nodejs/check-build-site.sh nodejs'
     - '*/5  *    * * *   root    /home/nodejs/cdn-purge.sh'
-    - '* */4   * * *   nodejs  /home/nodejs/sync-benchmarking.sh'
+    - '0 */4   * * *   nodejs  /home/nodejs/sync-benchmarking.sh'
   tags: setup
 
 - name: Site Setup | Add dist-perms script in cron.daily


### PR DESCRIPTION
Fix the crontab so that `sync-benchmarking.sh` is only run once
every four hours and not every minute of every fourth hour.