### PR TITLE
ansible: add gcc8 to SmartOS 18

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -139,6 +139,7 @@ packages: {
 
   smartos18: [
     'gcc7',
+    'gcc8',
     'ccache',
     'python37'
   ],

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -181,6 +181,14 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       fi
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;
+    smartos18* )
+      if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
+        export PATH="/opt/local/gcc8/bin:$PATH"
+      fi
+      export CC="ccache gcc"
+      export CXX="ccache g++"
+      echo "Compiler set to GCC" `$CXX -dumpversion`
+      ;;
   esac
 
 elif [ "$SELECT_ARCH" = "ARM64" ]; then


### PR DESCRIPTION
Node.js 16 requires a minimum gcc/g++ 8 compiler.