### PR TITLE
Revert "ansible: add gcc8 to SmartOS 18 (#2754)"

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -139,7 +139,6 @@ packages: {
 
   smartos18: [
     'gcc7',
-    'gcc8',
     'ccache',
     'python37'
   ],

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -181,14 +181,6 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       fi
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;
-    smartos18* )
-      if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
-        export PATH="/opt/local/gcc8/bin:$PATH"
-      fi
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-      echo "Compiler set to GCC" `$CXX -dumpversion`
-      ;;
   esac
 
 elif [ "$SELECT_ARCH" = "ARM64" ]; then


### PR DESCRIPTION
This reverts commit 0eaed4617b672e33820c1ff3a88d2bca29e7333a.

Node.js builds with gcc8 on our SmartOS 18 hosts crash when running `torque`. Undo https://github.com/nodejs/build/pull/2754 to have passing builds again.

SmartOS is kind of outside my knowledge base, so I'd need help getting a suitable gcc 8.3 based environment.