### PR TITLE
update OpenSSL in sharedlib containers

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -66,15 +66,15 @@ RUN mkdir -p /tmp/openssl_1.1.0l && \
     make install && \
     rm -rf /tmp/openssl_1.1.0l
 
-ENV OPENSSL111DIR /opt/openssl-1.1.1k
+ENV OPENSSL111DIR /opt/openssl-1.1.1l
 
-RUN mkdir -p /tmp/openssl_1.1.1k && \
-    cd /tmp/openssl_1.1.1k && \
-    curl -sL https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.1l && \
+    cd /tmp/openssl_1.1.1l && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.1l.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.1k
+    rm -rf /tmp/openssl_1.1.1l
 
 ENV OPENSSL300DIR /opt/openssl-3.0.0
 

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -80,7 +80,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-beta1+quic --depth 1 && \
+    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0+quic --depth 1 && \
     cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -64,15 +64,15 @@ RUN mkdir -p /tmp/openssl_1.1.0l && \
     make install && \
     rm -rf /tmp/openssl_1.1.0l
 
-ENV OPENSSL111DIR /opt/openssl-1.1.1k
+ENV OPENSSL111DIR /opt/openssl-1.1.1l
 
-RUN mkdir -p /tmp/openssl_1.1.1k && \
-    cd /tmp/openssl_1.1.1k && \
-    curl -sL https://www.openssl.org/source/openssl-1.1.1k.tar.gz | tar zxv --strip=1 && \
+RUN mkdir -p /tmp/openssl_1.1.1l && \
+    cd /tmp/openssl_1.1.1l && \
+    curl -sL https://www.openssl.org/source/openssl-1.1.1l.tar.gz | tar zxv --strip=1 && \
     ./config --prefix=$OPENSSL111DIR && \
     make -j 6 && \
     make install && \
-    rm -rf /tmp/openssl_1.1.1k
+    rm -rf /tmp/openssl_1.1.1l
 
 ENV OPENSSL300DIR /opt/openssl-3.0.0
 

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -78,7 +78,7 @@ ENV OPENSSL300DIR /opt/openssl-3.0.0
 
 RUN mkdir -p /tmp/openssl_3.0.0 && \
     cd /tmp/openssl_3.0.0 && \
-    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0-alpha16+quic --depth 1 && \
+    git clone https://github.com/quictls/openssl.git -b openssl-3.0.0+quic --depth 1 && \
     cd openssl && \
     ./config --prefix=$OPENSSL300DIR && \
     make -j 6 && \


### PR DESCRIPTION
Updates to latest OpenSSL 1.1.1 and 3.0.0. Not yet deployed as tests need to be updated in Node.js core to cope with error message changes between OpenSSL 3.0.0-alpha16 and 3.0.0-beta/final (e.g. we would need https://github.com/nodejs/node/pull/38512/commits/be21e9e74989d02ce71b88d667d20c044fd30c87 to land).

cc @danbev 