### PR TITLE
jenkins: skip LTO builds on Node.js < 16

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -43,6 +43,7 @@ def buildExclusions = [
 
   // Linux S390X --------------------------------------------
   [ /s390x/,                          anyType,     lt(6)   ],
+  [ /lto-s390x/,                      anyType,     lt(16)  ],
 
   // ARM  --------------------------------------------------
   [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],


### PR DESCRIPTION
Unfortunately it turns out that the multijob plugin appears to have issues when resuming with subjobs that run the same job with different parameters. In preparation of converting the s390x LTO build from a second invocation of `node-test-commit-linuxone` (with `CONFIG_FLAGS` set to `--enable-lto`) to a second "platform", add the exclusion for Node.js versions earlier than 16 to the VersionSelectorScript.

Refs: https://github.com/nodejs/build/issues/2758