### PR TITLE
ansible: move `ansible.cfg`

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,12 +1,12 @@
 [defaults]
-filter_plugins      = plugins/filter
+filter_plugins      = ansible/plugins/filter
 gathering           = explicit
 host_key_checking   = False
-inventory           = plugins/inventory/nodejs_yaml.py
-library             = plugins/library
+inventory           = ansible/plugins/inventory/nodejs_yaml.py
+library             = ansible/plugins/library
 remote_user         = root
 retry_files_enabled = False
-roles_path          = roles
+roles_path          = ansible/roles
 squash_actions      = apk
 
 

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -144,6 +144,12 @@ def get_secrets_path():
             print("It must be the path to a local checkout of https://github.com/nodejs-private/secrets", file=sys.stderr)
             return None
 
+    path = os.path.realpath('../secrets/build/')
+    if os.path.isdir(path):
+        return path
+
+    print("Checked ../secrets/build/: it is not a directory", file=sys.stderr)
+
     path = os.path.realpath('../../secrets/build/')
     if os.path.isdir(path):
         return path

--- a/doc/ansible-testing.md
+++ b/doc/ansible-testing.md
@@ -93,12 +93,11 @@ fake secrets to the inventory instead and
 `export NODE_BUILD_SECRETS=/invalid/path/` to make sure the real secrets are
 not accessible.
 
-While in the `ansible` directory, run the playbook using the following
+While in the `build` directory, run the playbook using the following
 command:
 
 ```bash
-$ cd ansible
-$ ansible-playbook playbooks/create-github-bot.yml
+$ ansible-playbook ansible/playbooks/create-github-bot.yml
 ```
 
 Don't forget to run `vagrant down` once you are down with the virtual machine.


### PR DESCRIPTION
replacement of #2700.

After consulting with some ansible experts at Red Hat the best method to get AWX working is to move the `ansible.cfg` file to the root of the repo where AWX expects it.

What does this change? Nothing except for now we need to run our playbooks from the root directory instead - e.g. `ansible-playbook ansible/playbooks/playbook --limit "target"`

I think ive updated the doc but let me know if it appears elsewhere