### PR TITLE
ansible: update smartos hosts

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -51,8 +51,8 @@ hosts:
         ibmi73-ppc64_be-1: {ip: 65.183.160.62, user: nodejs}
 
     - joyent:
-        smartos17-x64-2: {ip: 147.75.88.60}
         smartos18-x64-2: {ip: 147.75.88.53}
+        smartos20-x64-2: {ip: 147.75.88.60}
         ubuntu1804_docker-x64-1: {ip: 147.75.88.56, user: ubuntu}
 
     - macstadium:
@@ -159,10 +159,10 @@ hosts:
         ubuntu1804-x64-2: {ip: 50.97.245.9}
 
     - joyent:
-        smartos17-x64-3: {ip: 147.75.88.59}
-        smartos17-x64-4: {ip: 147.75.88.61}
         smartos18-x64-3: {ip: 147.75.88.54}
         smartos18-x64-4: {ip: 147.75.88.55}
+        smartos20-x64-3: {ip: 147.75.88.59}
+        smartos20-x64-4: {ip: 147.75.88.61}
         ubuntu1804-x64-1: {ip: 147.75.88.51, user: ubuntu}
 
     - macstadium:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -169,6 +169,13 @@ packages: {
     'python37'
   ],
 
+  smartos20: [
+    'gcc9',
+    'ccache',
+    'python38',
+    'py38-pip'
+  ],
+
   ubuntu: [
     'ccache,git,libfontconfig1,sudo,python3-pip',
   ],

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -98,6 +98,7 @@ java_path: {
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',
   'smartos18': '/opt/local/java/openjdk8/bin/java',
+  'smartos20': '/opt/local/java/openjdk8/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -91,6 +91,7 @@ def buildExclusions = [
   [ /^smartos17/,                     anyType,     gte(12) ],
   [ /^smartos18/,                     anyType,     lt(12)  ],
   [ /^smartos18/,                     releaseType, gte(14) ],
+  [ /^smartos18/,                     anyType,     gte(16)  ],
 
   // AIX PPC64 ---------------------------------------------
   [ /aix71/,                          anyType,     lt(10)  ],


### PR DESCRIPTION
Replace smartos17 hosts with smartos20.

Refs: https://github.com/nodejs/build/issues/2757

This has been deployed onto all the previous smartos17 hosts.
