### PR TITLE
ansible: use Java 17 on AIX

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -89,7 +89,7 @@
     body_format: json
     return_content: yes
     status_code: 200
-    url: "https://api.adoptopenjdk.net/v3/assets/feature_releases/{{ adoptopenjdk_version }}/ga?architecture={{ adoptopenjdk_arch }}&image_type=jre&jvm_impl=openj9&os={{ adoptopenjdk_os }}&project=jdk&heap_size=normal&page_size=1&sort_method=DEFAULT&sort_order=DESC&vendor=adoptopenjdk"
+    url: "https://api.adoptopenjdk.net/v3/assets/feature_releases/{{ adoptopenjdk_version }}/{{ adoptopenjdk_type }}?architecture={{ adoptopenjdk_arch }}&image_type=jre&jvm_impl=openj9&os={{ adoptopenjdk_os }}&project=jdk&heap_size=normal&page_size=1&sort_method=DEFAULT&sort_order=DESC&vendor=adoptopenjdk"
   when: use_adoptopenjdk == True
 
 # If we're already using the latest there is no need to do anything.

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -28,12 +28,13 @@ java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('
 # override arch to be on the safe side.
 adoptopenjdk: {
   aix71_ppc64: { arch: ppc64 },
-  aix72_ppc64: { arch: ppc64 },
+  aix72_ppc64: { arch: ppc64, version: 17, type: ea },
   centos7_ppc64: {},
   rhel7_s390x: {}
 }
 
 adoptopenjdk_arch: "{{ adoptopenjdk[os+'_'+arch].arch | default(ansible_architecture) }}"
 adoptopenjdk_os: "{{ adoptopenjdk[os+'_'+arch].os | default(ansible_system | lower) }}"
+adoptopenjdk_type: "{{ adoptopenjdk[os+'_'+arch].type | default('ga') }}"
 adoptopenjdk_version: "{{ adoptopenjdk[os+'_'+arch].version | default('8') }}"
 use_adoptopenjdk: "{{ adoptopenjdk[os+'_'+arch] is defined | bool }}"

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -16,6 +16,7 @@ start )
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
+              export PATH=$PATH:/opt/freeware/bin \
               export OSTYPE=AIX72; \
               export JOBS={{ jobs_env }}; \
         /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \


### PR DESCRIPTION
Update the JRE used to run the Jenkins agent on AIX to Java ~11~17.
Also adds `/opt/freeware/bin` to the `PATH` for the agent to
pick up binaries from yum packages that no longer create symbolic
links in `/usr/bin`.

Refs: https://github.com/nodejs/build/issues/2718

Trying this out on `test-osuosl-aix72-ppc64_be-3` to see if we still hit issues with agent disconnects and/or zombie processes when the Jenkins agent is run with Java ~11~17.