### PR TITLE
Exclude ubuntu2004-armv7l execution on Node<12

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -35,8 +35,7 @@ def buildExclusions = [
   [ /^ubuntu1404-64/,                 anyType,     gte(12) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1604-64/,                 anyType,     gte(16) ],
-  [ /^ubuntu2004-(arm|x)?64/,         anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
-  [ /^ubuntu2004-armv7l/,             anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
+  [ /^ubuntu2004/,                    anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
   [ /^alpine-latest-x64$/,            anyType,     lt(13)  ], // Alpine 3.12 doesn't have Python 2
 
   // Linux PPC LE ------------------------------------------

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -36,6 +36,7 @@ def buildExclusions = [
   [ /^ubuntu1604-32/,                 anyType,     gte(10) ], // 32-bit linux for <10 only
   [ /^ubuntu1604-64/,                 anyType,     gte(16) ],
   [ /^ubuntu2004-(arm|x)?64/,         anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
+  [ /^ubuntu2004-armv7l/,             anyType,     lt(13)  ], // Ubuntu 20 doesn't have Python 2
   [ /^alpine-latest-x64$/,            anyType,     lt(13)  ], // Alpine 3.12 doesn't have Python 2
 
   // Linux PPC LE ------------------------------------------


### PR DESCRIPTION
Current Ubuntu armv7l docker image is 20.04 and so needs to be excluded from Node 12.
I did this initially with another conditional but have modified it to try and catch all ubuntu2004 - can anyone see any issue with this (I don't think the 32/64 bit is necessarily significant?

Signed-off-by: Stewart X Addison <sxa@redhat.com>