### PR TITLE
ansible: add test-ibm-ubuntu1804-x64-2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -156,6 +156,7 @@ hosts:
         rhel7-s390x-3: {ip: 148.100.86.28, user: linux1, build_test_v8: yes}
         rhel7-s390x-4: {ip: 148.100.86.94, user: linux1, build_test_v8: yes}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
+        ubuntu1804-x64-2: {ip: 50.97.245.9}
 
     - joyent:
         smartos17-x64-3: {ip: 147.75.88.59}
@@ -352,7 +353,6 @@ hosts:
         debian9-x64-1: {ip: 169.60.150.88}
         debian10-x64-1: {ip: 169.44.16.126}
         ubuntu1404-x64-1: {ip: 50.97.245.5}
-        ubuntu1404-x86-1: {ip: 50.97.245.9}
         ubuntu1804_docker-x64-1: {ip: 52.117.26.9}
 
     - packetnet:


### PR DESCRIPTION
Repurpose unused test-softlayer-ubuntu1404-x86-1 as an additional
Ubuntu 18.04 x64 test host.