### PR TITLE
ansible: fixups for AIX setup

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix.yml
@@ -28,14 +28,14 @@
    src: "/opt/freeware/bin/pip"
    dest: "/usr/bin/pip"
    state: link
-  when: pip_exists.stat.exists == False
+  when: pip_exists.stat.exists == False and os == "aix71"
 
 - name: create symbolic link AIX72
   file:
    src: "/opt/bin/pip"
    dest: "/usr/bin/pip"
    state: link
-  when: pip_exists.stat.exists == False
+  when: pip_exists.stat.exists == False and os == "aix72"
 
 - name: install tap2junit
   pip: 

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -16,6 +16,7 @@ start )
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
+              export PATH="$PATH:/opt/freeware/bin"; \
               export OSTYPE=AIX72; \
               export JOBS={{ jobs_env }}; \
         /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \

--- a/ansible/roles/user-create/tasks/main.yml
+++ b/ansible/roles/user-create/tasks/main.yml
@@ -30,6 +30,15 @@
     mode: 0755
     recurse: yes
 
+- name: set ulimits for AIX
+  changed_when: False
+  command: chsec -f /etc/security/limits -s {{ server_user }} -a {{ item }}
+  when: os|startswith("aix")
+  with_items:
+  - "data=-1"
+  - "fsize=-1"
+  - "nofiles=-1"
+
 - name: create NODE_TEST_DIR directory
   file: path="{{ home }}/{{ server_user }}/tmp" state=directory
 


### PR DESCRIPTION
Add conditionals to the two pip symlink tasks so that they only
run on the verison of AIX they were intended.

Add `/opt/freeware/bin` to the PATH for the Jenkins agent as newer
AIX Toolbox packages (e.g. most recent `git`) no longer create
symbolic links under `/usr/bin`.

---

We've recently reinstalled `test-osuosl-aix72-ppc64_be-3` and these changes were necessary for the Ansible scripts to set up the machine.