### PR TITLE
doc: add AIX cleanup job to Jenkins guide

### DIFF
--- a/doc/jenkins-guide.md
+++ b/doc/jenkins-guide.md
@@ -301,7 +301,9 @@ reboot
 ```
 
 On the advice of the system adminstrators managing the AIX machines, please do
-not restart them without good reason, it will make things worse.
+not restart them without good reason, it will make things worse. It may help to
+run the https://ci.nodejs.org/job/aix-cleanup/ to kill any stray processes from
+earlier failed job runs.
 
 ### Fixing machines with Docker
 


### PR DESCRIPTION
Reference recently added cleanup job[1] for AIX for killing leftover
processes from earlier Jenkins job runs.

[1]: https://ci.nodejs.org/job/aix-cleanup/