### PR TITLE
metrics: add index-generator file

### DIFF
--- a/ansible/roles/metrics/files/index-generator/.gcloudignore
+++ b/ansible/roles/metrics/files/index-generator/.gcloudignore
@@ -1,0 +1,1 @@
+node_modules

--- a/ansible/roles/metrics/files/index-generator/Dockerfile
+++ b/ansible/roles/metrics/files/index-generator/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14-slim
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . ./
+
+CMD ["npm", "run", "index-generator"]

--- a/ansible/roles/metrics/files/index-generator/index-generator.js
+++ b/ansible/roles/metrics/files/index-generator/index-generator.js
@@ -1,0 +1,61 @@
+const { Storage } = require('@google-cloud/storage')
+const storage = new Storage({
+    keyFilename: "metrics-processor-service-key.json",
+  });
+const express = require('express')
+const bodyParser = require('body-parser')
+const app = express()  
+app.use(bodyParser.json())
+
+
+async function getFileList() {
+
+      let fileList = []
+
+      const [files] = await storage.bucket('access-logs-summaries-nodejs').getFiles()
+      for (const file of files){
+          if (!file.name.includes('html')){
+            fileList.push(file.name)
+          }
+      }
+      return fileList
+}
+
+
+async function generateIndex() {
+    
+    let fileList = []
+    fileList = await getFileList()
+
+    const baseURL = "https://storage.googleapis.com/access-logs-summaries-nodejs/"
+    let body = ''
+
+    for (file of fileList){
+        let bodyString = '<p> <a href="' + baseURL.concat(file) + '"> ' + file + ' </a></p>\n'
+        body += (bodyString)
+    }
+
+    indexfile = '<html>\n<head>\n</head>\n<body>\n' + body + '</body>\n</html>'    
+
+    storage.bucket('access-logs-summaries-nodejs').file('index.html').save(indexfile, function (err) {
+        if (err) {
+          console.log('ERROR UPLOADING: ', err)
+        } else {
+          console.log('Upload complete')
+        }
+      })
+}
+
+app.post('/', async (req, res) => {
+    if (req.body.message.attributes.objectId != 'index.html'){
+        await generateIndex()
+    }
+    res.status(200).send()
+  })
+  
+  const port = process.env.PORT || 8080
+  app.listen(port, () => {
+    console.log('Listening on port: ', port)
+  })
+  
+  module.exports = app

--- a/ansible/roles/metrics/files/index-generator/package.json
+++ b/ansible/roles/metrics/files/index-generator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "index-generator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index-generator.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "index-generator": "node --trace-warnings index-generator.js"
+  },
+  "author": "Ash <email@ashleycripps.co.uk>",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@google-cloud/storage": "^5.0.0",
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "eslint": "^7.8.1"
+  }
+}


### PR DESCRIPTION
This is the small file that makes the simple website with links for
our metrics. It runs every time a new summary file is created
and replaces the `index.html` file at the root of the bucket