### PR TITLE
ansible: add locations for Flatpak Remmina

### DIFF
--- a/ansible/plugins/library/remmina_config.py
+++ b/ansible/plugins/library/remmina_config.py
@@ -84,6 +84,11 @@ def find_remmina():
     if os.path.isfile(config) and os.path.isdir(target):
         return (config, target)
 
+    config = os.path.expanduser('~/.var/app/org.remmina.Remmina/config/remmina/remmina.pref')
+    target = os.path.expanduser('~/.var/app/org.remmina.Remmina/data/remmina')
+    if os.path.isfile(config) and os.path.isdir(target):
+        return (config, target)
+
     config = os.path.expanduser('~/.remmina/remmina.pref')
     target = os.path.expanduser('~/.remmina')
     if os.path.isfile(config) and os.path.isdir(target):


### PR DESCRIPTION
Add config and target data locations for Remmina packaged as a
Flatpak (e.g. for Fedora).

Enables `ansible/playbooks/write-ssh-config.yml` to write Remmina config on a system using Flatpaks.