### PR TITLE
chore: master -> HEAD for renamed default branches

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -339,8 +339,8 @@ The [Node.js Moderation Policy] applies to this WG.
 
 The [Node.js Code of Conduct][] applies to this WG.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
-[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md
+[Node.js Code of Conduct]: https://github.com/nodejs/TSC/blob/HEAD/CODE_OF_CONDUCT.md
+[Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/HEAD/Moderation-Policy.md
 [Node.js Foundation calendar]: https://nodejs.org/calendar
 [the onboarding doc]: /ONBOARDING.md
 [IRC]: /README.md#nodejs-build-working-group

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -45,7 +45,7 @@ steps are executed, to avoid disrupting the machines.
 
 You can't run any playbooks on a host until you've manually created a
 `build:ansible/host_vars/HOST` file for that host (same name as the argument
-to limit, above). Use `host_vars/test-marist-zos13-s390x-templat` as an
+to limit, above). Use `host_vars/test-marist-zos13-s390x-template` as an
 example. The `secret:` doesn't have to be the real Jenkins secret until the
 worker actually has to connect to the master.
 
@@ -214,7 +214,7 @@ Where each item corresponds to a container to be set up and run on the host.
 
 Each `name` should exist as a node in Jenkins and the corresponding `secret`
 should be given.  The `os` determines the `Dockerfile` to use to build the
-host.  The templates for these can be found in `roles/docker/templates/`. 
+host.  The templates for these can be found in `roles/docker/templates/`.
 
 For testing purposes, the stanza above can be added into
 `host_vars/<docker_host>`, then the master record should be in the
@@ -223,7 +223,7 @@ For testing purposes, the stanza above can be added into
 Note that the Docker host itself doesn't need to be known by Jenkins, just the
 containers that are managed there.
 
-The docker-host playbook sets up services which are managed via `systemctl`. 
+The docker-host playbook sets up services which are managed via `systemctl`.
 If you log into the host sytsem you can view them with `systemctl | grep
 jenkins-` and start and stop individual ones using `systemctl start` and
 `systemctl stop` commands as and when required. For more information on

--- a/ansible/roles/package-upgrade/files/install-homebrew.sh
+++ b/ansible/roles/package-upgrade/files/install-homebrew.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install)"

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -445,7 +445,7 @@ server {
     rewrite ^/advisory-board                                      https://github.com/nodejs/TSC permanent;
     rewrite ^/about/advisory-board                                https://github.com/nodejs/TSC permanent;
     rewrite ^/about/organization/?$                               https://github.com/nodejs/TSC permanent;
-    rewrite ^/about/organization/tsc-meetings                     https://github.com/nodejs/TSC/tree/master/meetings permanent;
+    rewrite ^/about/organization/tsc-meetings                     https://github.com/nodejs/TSC/tree/HEAD/meetings permanent;
     rewrite ^/(en|es|uk)/foundation/?$                            https://foundation.nodejs.org/ permanent;
     rewrite ^/(en|uk)/foundation/case-studies/?$                  https://foundation.nodejs.org/resources permanent;
     rewrite ^/(en|uk)/foundation/members/?$                       https://foundation.nodejs.org/about/members permanent;

--- a/doc/jenkins-jobs.md
+++ b/doc/jenkins-jobs.md
@@ -11,7 +11,7 @@ be able to complete the validation.
 If validation fails an email notification is sent to the
 `release-validation-alert` email alias. If you would like to get these
 notifications submit a PR to have your email added for that alias in
-https://github.com/nodejs/email/blob/master/iojs.org/aliases.json.
+https://github.com/nodejs/email/blob/HEAD/iojs.org/aliases.json.
 
 This job needs to be updated each time a we roll over to a new Current
 release.

--- a/doc/resources.md
+++ b/doc/resources.md
@@ -185,7 +185,7 @@ jenkins-release-admins membership who do not have infra or release membership.
 
 ### [GitHub Bot][]
 
-The `github-bot` is the server that runs different [automation scripts](https://github.com/nodejs/github-bot/tree/master/scripts) within the Node.js Foundation GitHub organization. For example, the bot automatically applies labels to new pull requests in `nodejs/node`, and can trigger Jenkins builds or report their statuses on pull requests. Its Ansible configuration lives in [`playbooks/create-github-bot.yml`](https://github.com/nodejs/build/tree/master/ansible/playbooks/create-github-bot.yml)
+The `github-bot` is the server that runs different [automation scripts](https://github.com/nodejs/github-bot/tree/HEAD/scripts) within the Node.js Foundation GitHub organization. For example, the bot automatically applies labels to new pull requests in `nodejs/node`, and can trigger Jenkins builds or report their statuses on pull requests. Its Ansible configuration lives in [`playbooks/create-github-bot.yml`](https://github.com/nodejs/build/tree/master/ansible/playbooks/create-github-bot.yml)
 
 Those with `github-bot` access have access to the GitHub Bot's configuration,
 including GitHub and Jenkins secrets. The list of members is


### PR DESCRIPTION
Minor housekeeping for repos that already did the the master -> main renames. Used HEAD so it's flexible for any future default branch changes