### PR TITLE
www,webhook: add logrotate for github-webhook

### DIFF
--- a/ansible/www-standalone/resources/config/logrotate-github-webhook
+++ b/ansible/www-standalone/resources/config/logrotate-github-webhook
@@ -1,0 +1,23 @@
+/home/nodejs/github-webhook.log
+{
+        monthly
+        missingok
+        compresscmd /usr/bin/xz
+        uncompresscmd /usr/bin/unxz
+        compressext .xz
+        compress
+        notifempty
+        create 0640 nodejs nodejs
+        dateext
+        dateformat .%Y%m%d.%s
+        dateyesterday
+        maxsize 500M
+        sharedscripts
+        rotate 36500
+        prerotate
+                systemctl stop github-webhook
+        endscript
+        postrotate
+                systemctl start github-webhook
+        endscript
+}

--- a/ansible/www-standalone/tasks/webhook.yaml
+++ b/ansible/www-standalone/tasks/webhook.yaml
@@ -21,3 +21,13 @@
     state: restarted
     enabled: yes
   tags: webhook
+
+- name: GitHub Webhook | Copy logrotate config
+  copy:
+    src: ./resources/config/logrotate-github-webhook
+    dest: /etc/logrotate.d/github-webhook
+    mode: 0644
+    owner: root
+    group: root
+  tags: webhook
+


### PR DESCRIPTION
https://github.com/nodejs/build/issues/2760#issuecomment-1002242478

Long overdue. I've manually run this and it's 👌.

The main problem here is that I've put in a service stop and start. It's quite quick but this service is the parent of a docker build for the site. So if we happen to his this while the site is being built then there could be problems, so I'm not sure this is the best idea or approach.

I don't have time to go deeper into this but some thoughts:

* The service may not need to be stop & started, I don't recall if the log file is kept open or not, maybe this is a systemd redirect or maybe the service writes directly - someone could investigate this.
* We could add some kind of check to see whether it's running, not sure the best way to do this but we already have internal signalling in the service (iirc) so it doesn't double-run so maybe we can piggy back that somehow.

But for the time being, I think the risk is very low that this is going to be run (monthly) at exactly the same time the site is being built, it's not built _that_ often from the webhook. It's also not super critical (usually) and can be easily re-triggered from GitHub if needed. So IMO this is a quick fix that's worth doing now and improving later.