### PR TITLE
Update Windows Inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -110,20 +110,16 @@ hosts:
   - test:
 
     - azure:
-        msft-win10_vcbt2015-x64-1: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win10_vcbt2015-x64-2: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win10_vcbt2015-x64-3: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win10_vcbt2015-x64-4: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win10_vs2019-x64-1: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win10_vs2019-x64-2: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win10_vs2019-x64-3: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win10_vs2019-x64-4: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-1: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-2: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-3: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-4: {ip: nodejs.westus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-5: {ip: nodejs.eastus2.cloudapp.azure.com}
-        msft-win2016_vs2017-x64-6: {ip: nodejs.westus2.cloudapp.azure.com}
+        msft-win10_vs2019-x64-1: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win10_vs2019-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
+        msft-win10_vs2019-x64-3: {ip: nodejs.australiaeast.cloudapp.azure.com}
+        msft-win10_vs2019-x64-4: {ip: nodejs2.eastus.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-1: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-3: {ip: nodejs.australiaeast.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-4: {ip: nodejs2.eastus.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-5: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win2016_vs2017-x64-6: {ip: nodejs.westus3.cloudapp.azure.com}
 
     - digitalocean:
         debian8-x64-1: {ip: 159.203.103.52}
@@ -211,6 +207,8 @@ hosts:
         win10_vs2017-arm64-2: {}
 
     - nearform:
+        arm-win10_vs2019-arm64-1: {ip: 83.147.191.73}
+        arm-win10_vs2019-arm64-2: {ip: 83.147.191.74}
         macos10.15-x64-1: 
             ip: 83.147.191.70
             user: administrator

--- a/ansible/plugins/library/remmina_config.py
+++ b/ansible/plugins/library/remmina_config.py
@@ -46,6 +46,10 @@ username={{ metadata.ansible_user }}
 password={{ password }}
 colordepth=15
 scale=1
+window_width=800
+window_height=600
+window_maximize=1
+viewmode=1
 
 '''
 

--- a/ansible/roles/visual-studio/tasks/partials/wixtoolset.yml
+++ b/ansible/roles/visual-studio/tasks/partials/wixtoolset.yml
@@ -5,8 +5,9 @@
 #
 
 # https://github.com/wixtoolset/issues/issues/5661
-- name: install Dot Net 3.5
-  win_chocolatey: name=dotnet3.5
+# Disabled, as this currently crashes the playbook.
+#- name: install Dot Net 3.5
+#  win_chocolatey: name=dotnet3.5
 
 - name: install WiX Toolset
   win_chocolatey: name=wixtoolset


### PR DESCRIPTION
We changed the Azure subscription used for the CI machines, this PR updates the Ansible inventory. The new Windows ARM machines hosted by NearForm are also included (ref https://github.com/nodejs/build/issues/2540).

Two important changes were made:
- Removed VCBT2015 (not VS2015) machines and configurations, as the install package no longer works. Already removed from Jenkins as well. I believe testing with VS2015 provides enough coverage for a version so old.
- Only server images are supported on the new subscription, so I was not able to create Windows 10 machines. For now, I replaced it with Windows Server 2022. The server names don't yet reflect this everywhere, at least the VersonSelectorScript needs to be updated before the server names can change.

cc @nodejs/libuv, I swapped the VCBT2015 configuration to VS2019.
