### PR TITLE
ansible: add httplib2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -232,7 +232,7 @@ hosts:
             user: admin
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
-        intel-ubuntu1604-x64-1: {ip: 92.51.196.114}
+        intel-ubuntu1604-x64-1: {ip: 92.51.196.114, build_test_v8: yes}
         intel-ubuntu1604-x64-2: {ip: 92.51.196.115}
 
 

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -141,16 +141,6 @@
     state: link
     src: "/usr/local/bin/python2"
 
-# Required for V8 builds
-- name: rhel8 | update python package alternatives
-  community.general.alternatives:
-    link: /usr/bin/python
-    name: python
-    path: /usr/bin/python2
-  when:
-    - os == "rhel8"
-    - build_test_v8|default(False)
-
 - name: smartos17 | update gcc symlinks
   when: os == "smartos17"
   file:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -144,10 +144,6 @@ packages: {
     'gcc-c++,sudo,git,zip,unzip,iptables-services,GConf2-devel,openssl-devel,python3',
   ],
 
-  rhel8_s390x: [
-    'GConf2-devel,python2' # Needed for V8 builds
-  ],
-
   rhel8: [
     'ccache,cmake,gcc-c++,gcc-toolset-11,git,make,python3',
   ],

--- a/ansible/roles/bootstrap/tasks/partials/rhel7.yml
+++ b/ansible/roles/bootstrap/tasks/partials/rhel7.yml
@@ -1,0 +1,9 @@
+---
+
+# Red Hat Enterprise Linux 7
+
+- name: register Red Hat subscription
+  community.general.redhat_subscription:
+    activationkey: "{{ type }}"
+    org_id: "{{ rh_org }}"
+    state: present

--- a/ansible/roles/build-test-v8/tasks/main.yml
+++ b/ansible/roles/build-test-v8/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+- name: install packages required for V8 builds
+  include: "{{ v8deps_include }}"
+  loop_control:
+    loop_var: v8deps_include
+  with_first_found:
+    - files:
+      - "{{ role_path }}/tasks/partials/{{ os }}-{{ arch }}.yml"
+      - "{{ role_path }}/tasks/partials/{{ os }}.yml"
+      - "{{ role_path }}/tasks/partials/{{ os|stripversion }}.yml"
+      skip: true

--- a/ansible/roles/build-test-v8/tasks/partials/centos7.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/centos7.yml
@@ -1,0 +1,10 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+- name: install httplib2
+  ansible.builtin.yum:
+    name: ['python2-httplib2', 'python3-httplib2']
+    state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel7-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel7-s390x.yml
@@ -1,0 +1,33 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+# RHEL 7 doesn't have a package for pip and EPEL 7 doesn't support s390x.
+# Install pip via `get-pip.py`.
+- name: download pip install script
+  ansible.builtin.get_url:
+    dest: "{{ home }}/{{ server_user }}/get-pip.py"
+    url: https://bootstrap.pypa.io/pip/2.7/get-pip.py
+
+- name: install pip
+  ansible.builtin.shell:
+    cmd: python {{ home }}/{{ server_user }}/get-pip.py
+    creates: /usr/bin/pip2
+
+# With pip2 we're getting a `No module named glob` error when pep517 is used
+# (defaults to use). httplib2 0.18.0 is the last version that is installable
+# with `--no-use-pep517`.
+- name: install httplib2 for python 2
+  ansible.builtin.pip:
+    executable: pip2
+    extra_args: --no-use-pep517
+    name: httplib2==0.18.0
+    state: present
+
+- name: install httplib2 for python 3
+  ansible.builtin.pip:
+    executable: pip-3
+    name: httplib2
+    state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8.yml
@@ -1,0 +1,24 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+# V8 builds still require Python 2.
+- name: install packages required to build V8
+  ansible.builtin.dnf:
+    name: ['GConf2-devel', 'python2', 'python2-pip', 'python3-httplib2']
+    state: present
+
+- name: update python package alternatives
+  community.general.alternatives:
+    link: /usr/bin/python
+    name: python
+    path: /usr/bin/python2
+
+# RHEL 8 doesn't have a package for httplib2 for Python 2 so install via pip.
+- name: install httplib2
+  ansible.builtin.pip:
+    executable: pip2
+    name: httplib2
+    state: present

--- a/ansible/roles/build-test-v8/tasks/partials/ubuntu1604.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/ubuntu1604.yml
@@ -1,0 +1,10 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+- name: install httplib2
+  ansible.builtin.apt:
+    name: ['python-httplib2', 'python3-httplib2']
+    state: present

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -14,7 +14,7 @@ packages: {
   'freebsd': 'openjdk8-jre',
   'ibmi': 'openjdk-11-ea',
   'macos': 'adoptopenjdk8',
-  'rhel7': 'java-1.8.0-openjdk',
+  'rhel7': 'java-11-openjdk',
   'rhel8': 'java-17-openjdk',
   'smartos': 'openjdk8',
   'ubuntu': 'openjdk-8-jre-headless',
@@ -30,8 +30,7 @@ java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('
 adoptopenjdk: {
   aix71_ppc64: { arch: ppc64 },
   aix72_ppc64: { arch: ppc64 },
-  centos7_ppc64: {},
-  rhel7_s390x: {}
+  centos7_ppc64: {}
 }
 
 adoptopenjdk_arch: "{{ adoptopenjdk[os+'_'+arch].arch | default(ansible_architecture) }}"

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -46,8 +46,17 @@ case $NODE_NAME in
         ;;
       *)
         echo "Setting compiler for Node.js $NODEJS_MAJOR_VERSION on" `cat /etc/redhat-release`
-        # Default gcc on RHEL 8 is gcc 8
-        echo "Compiler left as system default:" `g++ -dumpversion`
+        # Default gcc on RHEL 8 is gcc 8.
+        if [ "$v8test" != "" ]; then
+          # For V8 builds make `gcc` and `g++` point to non-ccache shims.
+          export PATH=/usr/bin:$PATH
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+        else
+          export CC="gcc"
+          export CXX="g++"
+        fi
+        echo "Compiler left as system default:" `${CXX} -dumpversion`
         return
         ;;
     esac


### PR DESCRIPTION
V8's `gclient.py` now requires `httplib2`. Install it on all the
machines that the V8 CI can run on.

Fixes: https://github.com/nodejs/build/issues/2880