### PR TITLE
ansible: add ppc64le RHEL 8 instances

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -83,10 +83,11 @@ hosts:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
 
     - osuosl:
-        centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
         aix72-ppc64_be-1:
             ip: 140.211.9.77
             server_jobs: 6
+        centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
+        rhel8-ppc64_le-1: {ip: 140.211.168.185, user: cloud-user}
 
     - orka:
         macos10.15-x64-1:
@@ -249,7 +250,10 @@ hosts:
         centos7-ppc64_le-1: {ip: 140.211.168.32, user: centos, build_test_v8: yes}
         centos7-ppc64_le-2: {ip: 140.211.168.78, user: centos, build_test_v8: yes}
         centos7-ppc64_le-3: {ip: 140.211.168.239, user: centos, build_test_v8: yes}
-        centos7-ppc64_le-4: {ip: 140.211.168.194, user: centos, build_test_v8: yes}
+        rhel8-ppc64_le-1: {ip: 140.211.168.183, user: cloud-user, build_test_v8: yes}
+        rhel8-ppc64_le-2: {ip: 140.211.168.76, user: cloud-user, build_test_v8: yes}
+        rhel8-ppc64_le-3: {ip: 140.211.168.221, user: cloud-user, build_test_v8: yes}
+        rhel8-ppc64_le-4: {ip: 140.211.168.194, user: cloud-user, build_test_v8: yes}
 
     - orka:
         macos10.15-x64-1:

--- a/ansible/roles/baselayout/handlers/main.yml
+++ b/ansible/roles/baselayout/handlers/main.yml
@@ -4,6 +4,11 @@
 # generic handlers for baselayout stuff
 #
 
+- name: restart chronyd
+  ansible.builtin.service:
+    name: chronyd
+    state: restarted
+
 - name: restart sshd
   when: not os|startswith("macos")
   service: name="{{ sshd_service_name }}" state=restarted

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -75,6 +75,7 @@
     use: "{{ os|startswith(\"ibmi\")|ternary(\"yum\", omit) }}"
   loop_control:
     loop_var: package
+  notify: package updated
   with_items:
     # ansible doesn't like empty lists
     - "{{ packages[os+'_'+arch]|default('[]') }}"

--- a/ansible/roles/baselayout/tasks/partials/ntp/chrony.yml
+++ b/ansible/roles/baselayout/tasks/partials/ntp/chrony.yml
@@ -1,0 +1,18 @@
+---
+
+# ntpd via chrony
+
+- name: install chrony
+  ansible.builtin.package:
+    name: chrony
+    state: latest
+    update_cache: yes
+  notify:
+  - restart chronyd
+  - package updated
+
+- name: enable chronyd at start
+  ansible.builtin.service:
+    enabled: yes
+    name: chronyd
+    state: started

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -18,6 +18,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
+  chrony: ['rhel8'],
   systemd: ['debian8', 'debian9', 'debian10', 'ubuntu1604', 'ubuntu1804'],
   ntp_package: ['ubuntu1404']
 }

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
@@ -7,7 +7,7 @@
 # V8 builds still require Python 2.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['GConf2-devel', 'python2', 'python2-pip', 'python3-httplib2']
+    name: ['glib2-devel', 'python2', 'python2-pip']
     state: present
   notify: package updated
 
@@ -17,9 +17,14 @@
     name: python
     path: /usr/bin/python2
 
-# RHEL 8 doesn't have a package for httplib2 for Python 2 so install via pip.
-- name: install httplib2
+- name: install dependencies for V8 build tools (Python 2)
   ansible.builtin.pip:
     executable: pip2
+    name: httplib2
+    state: present
+
+- name: install dependencies for V8 build tools (Python 3)
+  ansible.builtin.pip:
+    executable: pip-3
     name: httplib2
     state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
@@ -9,6 +9,7 @@
   ansible.builtin.dnf:
     name: ['python2', 'python2-pip']
     state: present
+  notify: package updated
 
 - name: update python package alternatives
   community.general.alternatives:

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -42,6 +42,7 @@
     - not os|startswith("zos")
     - not os|startswith("macos")
   notify:
+    - package updated
     - restart Jenkins
   package:
     name: "{{ java_package_name }}"

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -358,6 +358,7 @@
   ansible.builtin.service:
     name: jenkins
     enabled: yes
+    state: started
   when:
     - not os|startswith("aix")
     - not os|startswith("ibmi")

--- a/ansible/roles/package-upgrade/handlers/main.yml
+++ b/ansible/roles/package-upgrade/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+
+# Package upgrade handler
+
+- name: package updated
+  include: "{{ handler_include }}"
+  loop_control:
+    loop_var: handler_include
+  notify: package updated
+  with_first_found:
+    - files:
+      - "{{ role_path }}/handlers/partials/{{ os }}-{{ arch }}.yml"
+      - "{{ role_path }}/handlers/partials/{{ os }}.yml"
+      - "{{ role_path }}/handlers/partials/{{ os|stripversion }}.yml"
+      skip: true

--- a/ansible/roles/package-upgrade/handlers/partials/rhel8.yml
+++ b/ansible/roles/package-upgrade/handlers/partials/rhel8.yml
@@ -1,0 +1,19 @@
+---
+
+# Red Hat Enterpise Linux 8 bootstrap handlers
+
+# If packages are updated, force a check-in with Subscription Manager to
+# reflect the current state.
+- name: clear rhsm cache
+  ansible.builtin.file:
+    name: /var/lib/rhsm/cache/profile.json
+    state: absent
+
+- name: stop rhsmcertd
+  ansible.builtin.systemd:
+    name: rhsmcertd
+    state: stopped
+
+- name: run rhsmcertd
+  ansible.builtin.command:
+    cmd: rhsmcertd --now

--- a/ansible/roles/package-upgrade/tasks/partials/dnf.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/dnf.yml
@@ -5,4 +5,7 @@
 #
 
   - name: upgrade installed packages
-    dnf: name=* state=latest
+    ansible.builtin.dnf:
+      name: "*"
+      state: latest
+    notify: package updated

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -44,6 +44,7 @@ def buildExclusions = [
 
   // Linux PPC LE ------------------------------------------
   [ /^centos7-ppcle/,                 anyType,     lt(10)  ],
+  [ /^centos7-ppcle/,                 anyType,     gte(18) ],
 
   // Linux S390X --------------------------------------------
   [ /s390x/,                          anyType,     lt(6)   ],


### PR DESCRIPTION
Add new ppc64le RHEL 8 instances. Repurpose test-osuosl-centos7-ppc64_le-4
as an additional RHEL 8 instance.

Also ensure time synchronization via `chrony` on RHEL 8, and add a handler
to run when packages are updated to sync with Red Hat Subscription Manager.

Refs: https://github.com/nodejs/build/issues/2741
Refs: https://github.com/nodejs/build/issues/2815