### PR TITLE
ansible: remove `iptables.save` on rhel8-s390x

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/bootstrap/tasks/partials/rhel8-s390x.yml
@@ -20,6 +20,14 @@
     name: firewalld
     state: absent
 
+# The presence of /etc/sysconfig/iptables.save appears to be interfering
+# with rules being loaded after a system reboot, so remove.
+- name: Firewall | remove iptables.save
+  ansible.builtin.file:
+    path: /etc/sysconfig/iptables.save
+    state: absent
+  notify: restart iptables
+
 - name: Firewall | add rule to allow accepting multicast
   lineinfile:
     dest: /etc/sysconfig/iptables


### PR DESCRIPTION
The presence of `/etc/sysconfig/iptables.save` on our RHEL 8 s390x
instances is interfering with the loading of our iptables rules
when the system reboots.

Refs: https://github.com/nodejs/build/issues/2893#issuecomment-1067054317