### PR TITLE
ansible: update OpenSSL to 3.0.2+quic

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -68,7 +68,7 @@ RUN mkdir -p /tmp/openssl_1.1.1m && \
     make install && \
     rm -rf /tmp/openssl_1.1.1m
 
-ENV OPENSSL3VER 3.0.1+quic
+ENV OPENSSL3VER 3.0.2+quic
 ENV OPENSSL3DIR /opt/openssl-$OPENSSL3VER
 # TODO(richardlau) remove OPENSSL300DIR when the CI has been updated to use OPENSSL3DIR
 ENV OPENSSL300DIR $OPENSSL3DIR

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -66,7 +66,7 @@ RUN mkdir -p /tmp/openssl_1.1.1m && \
     make install && \
     rm -rf /tmp/openssl_1.1.1m
 
-ENV OPENSSL3VER 3.0.1+quic
+ENV OPENSSL3VER 3.0.2+quic
 ENV OPENSSL3DIR /opt/openssl-$OPENSSL3VER
 # TODO(richardlau) remove OPENSSL300DIR when the CI has been updated to use OPENSSL3DIR
 ENV OPENSSL300DIR $OPENSSL3DIR


### PR DESCRIPTION
Otherwise, the tests using OpenSSL as a shared library would fail on CI.

Signed-off-by: Darshan Sen <raisinten@gmail.com>

cc @richardlau