### PR TITLE
ansible: fix path to ccache symlinks on M1 macs

### DIFF
--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -86,7 +86,7 @@
 # Currently does not work on the DTK for 11.0 - The unsupported warnings cause the task to fail
 - name: install packages (macos)
   when: os|startswith("macos")
-  become_user: administrator
+  become_user: "{{ ansible_user }}"
   community.general.homebrew: name="{{ package }}" state=present
   loop_control:
     loop_var: package

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -64,15 +64,15 @@
         state: present
 
 - name: Fetch java (Apple Silicon)
-  when: os|startswith("macos11") and arch == "arm64"
+  when: java.rc > 0 and os|startswith("macos11") and arch == "arm64"
   shell:
-    chdir: "/Users/administrator"
+    chdir: "/Users/{{ ansible_user }}"
     cmd: "curl -L -o zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz"
 
 - name: Extract java (Apple Silicon)
-  when: os|startswith("macos11") and arch == "arm64"
+  when: java.rc > 0 and os|startswith("macos11") and arch == "arm64"
   shell:
-    chdir: "/Users/administrator"
+    chdir: "/Users/{{ ansible_user }}"
     cmd: "tar -xf zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz"
 
 - name: install webupd8 oracle java 8 extras

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -6,7 +6,9 @@ export JOBS="{{ jobs_env }}"
 export OSTYPE=osx
 export ARCH="{{ arch }}"
 export DESTCPU="{{ arch }}"
-
-PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
+# Make sure `brew` is on the PATH to get the location of the ccache symlinks.
+export PATH="/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="$(brew --prefix)/opt/ccache/libexec:$PATH"
+{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/slave-agent.jnlp

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -93,7 +93,7 @@ java_path: {
   'macos10.15': 'java',
   'macos11': 'java',
   # Currently hardcoded untill adopt have their build available
-  'macos11.0': '/Users/administrator/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64/bin/java',
+  'macos11.0': '/Users/{{ ansible_user }}/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64/bin/java',
   'smartos15': '/opt/local/java/openjdk8/bin/java',
   'smartos16': '/opt/local/java/openjdk8/bin/java',
   'smartos17': '/opt/local/java/openjdk8/bin/java',

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -26,32 +26,32 @@
     when: os != "macos11.0"
 
   - name: Install Homebrew
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     script: files/install-homebrew.sh
     when: os != "macos11.0" and not brew.stat.exists
 
   - name: Install Homebrew
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     script: files/install-homebrew.sh
     when: os == "macos11.0" and not armbrew.stat.exists
 
   - name: Upgrade installed packages
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
 
   - name: Install brew cu
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     homebrew_tap:
       name: buo/cask-upgrade
 
   - name: Add AdoptOpenJDK Java Repo
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     homebrew_tap:
       name: AdoptOpenJDK/openjdk
 
   - name: Update Casks
-    become_user: administrator
+    become_user: "{{ ansible_user }}"
     homebrew_cask:
       upgrade_all: yes
 


### PR DESCRIPTION
Homebrew installs into a different path on M1 macs compared to x64.
Adjust the path to the ccache symlinks accordingly.

Refs: https://formulae.brew.sh/formula/ccache

cc @AshCripps 