### PR TITLE
ansible: updates for Linux arm64

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -40,6 +40,8 @@ hosts:
 
     - equinix:
         centos7-arm64-1: {ip: 139.178.85.110, server_jobs: 32}
+        ubuntu2004_docker-arm64-1: {ip: 145.40.80.210}
+        ubuntu2004_docker-arm64-2: {ip: 147.75.47.90}
 
     - ibm:
         aix71-ppc64_be-2:

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -17,6 +17,7 @@
         when: is_benchmark is defined and is_benchmark|bool == True }
     - jenkins-worker
     - { role: release-builder,
+        release_home_dir: "{{ home }}/{{ server_user }}",
         when: '"release" in group_names' }
 
   pre_tasks:

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -89,6 +89,17 @@
     - "{{ containers }}"
   when: containers is defined
 
+- name: set up for release builders
+  include_role:
+    name: release-builder
+  vars:
+    release_home_dir: "/{{ home }}/{{ server_user }}/{{ item.name }}/"
+  with_items:
+    - "{{ containers }}"
+  when:
+    - containers is defined
+    - "'release' in group_names"
+
 - name: create NODE_TEST_DIR directory
   file:
     path: "/home/{{ server_user }}/{{ item.name }}/tmp"

--- a/ansible/roles/docker/tasks/partials/repo/ubuntu2004.yml
+++ b/ansible/roles/docker/tasks/partials/repo/ubuntu2004.yml
@@ -1,0 +1,15 @@
+---
+
+#
+# add Docker repo
+#
+
+- name: "repo : add Ubuntu Docker repo key"
+  raw: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+- name: "repo : add Ubuntu Docker repo"
+  raw: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  register: has_updated_package_repo
+
+- name: "repo : update apt cache"
+  apt: update_cache=yes

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -1,0 +1,55 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV SHELL /bin/bash
+ENV PATH /usr/lib64/ccache:/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
+ENV DESTCPU {{ arch }}
+ENV ARCH {{ arch }}
+
+# ccache is not in the default repositories so get it from EPEL 8.
+RUN dnf install --disableplugin=subscription-manager -y \
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf update --disableplugin=subscription-manager -y \
+    && dnf install --disableplugin=subscription-manager -y \
+      ccache \
+      gcc-c++ \
+      git \
+      java-17-openjdk-headless \
+      make \
+      python3 \
+      procps-ng \
+      xz \
+    && dnf --disableplugin=subscription-manager clean all
+
+RUN groupadd -r -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }} \
+    && adduser -r -m -d /home/{{ server_user }}/ \
+      -g {{ server_user_gid.stdout_lines[0] }} \
+      -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
+
+# Relax crypto policies to allow Node.js tests to pass
+RUN update-crypto-policies --set LEGACY
+
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
+
+ENV PYTHON /usr/bin/python3
+
+RUN pip3 install tap2junit
+
+USER {{ server_user }}:{{ server_user }}
+
+ENV CCACHE_TEMPDIR /home/{{ server_user }}/.ccache/{{ item.name }}
+
+WORKDIR /home/{{ server_user }}
+
+CMD cd /home/{{ server_user }} \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java -Xmx{{ server_ram|default('128m') }} \
+          -jar /home/{{ server_user }}/slave.jar \
+          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
+          -secret {{ item.secret }}

--- a/ansible/roles/read-secrets/vars/main.yml
+++ b/ansible/roles/read-secrets/vars/main.yml
@@ -2,4 +2,8 @@
 
 # The path to the secrets repository. 
 # See also `ansible/plugins/inventory/nodejs_yaml.py`.
-secrets_repo_root: "{{ lookup('env', 'NODE_BUILD_SECRETS')|default('../../../../../secrets', True) }}"
+secrets_repo_root: >-
+  {{
+    lookup('env', 'NODE_BUILD_SECRETS') |
+    default((ansible_config_file | dirname, '..', 'secrets') | path_join, True)
+  }}

--- a/ansible/roles/release-builder/meta/argument_specs.yml
+++ b/ansible/roles/release-builder/meta/argument_specs.yml
@@ -3,3 +3,8 @@
 argument_specs:
   main:
     short_description: Set up specific to hosts that build releases.
+    options:
+      release_home_dir:
+        description: The user's HOME directory.
+        required: yes
+        type: str

--- a/ansible/roles/release-builder/tasks/main.yml
+++ b/ansible/roles/release-builder/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: create .ssh directory
   ansible.builtin.file:
-    dest: "{{ home }}/{{ server_user }}/.ssh"
+    dest: "{{ release_home_dir }}/.ssh"
     mode: "0700"
     owner: "{{ server_user }}"
     group: "{{ server_user }}"
@@ -15,14 +15,14 @@
 - name: copy key to access staging server
   ansible.builtin.copy:
     content: "{{ secrets.staging_key }}"
-    dest: "{{ home }}/{{ server_user }}/.ssh/id_rsa"
+    dest: "{{ release_home_dir }}/.ssh/id_rsa"
     mode: "0600"
     owner: "{{ server_user }}"
     group: "{{ server_user }}"
 
 - name: write ssh_config
   ansible.builtin.copy:
-    dest: "{{ home }}/{{ server_user }}/.ssh/config"
+    dest: "{{ release_home_dir }}/.ssh/config"
     src: "{{ role_path }}/files/ssh_config"
     mode: "0600"
     owner: "{{ server_user }}"
@@ -32,7 +32,7 @@
   ansible.builtin.known_hosts:
     name: direct.nodejs.org
     key: "{{ secrets.known_hosts }}"
-    path: "{{ home }}/{{ server_user }}/.ssh/known_hosts"
+    path: "{{ release_home_dir }}/.ssh/known_hosts"
     state: present
   become: yes
   become_user: "{{ server_user }}"

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -25,6 +25,7 @@ def buildExclusions = [
   [ /^centos[67]-(arm)?(64|32)-gcc6/, anyType,     lt(10)  ],
   [ /^centos[67]-(arm)?(64|32)-gcc6/, anyType,     gte(14) ], // 14.x: gcc6 builds stop
   [ /^centos7-(arm)?(64)-gcc8/,       anyType,     lt(14)  ], // 14.x: gcc8 builds start
+  [ /^centos7-(arm)?(64)-gcc8/,       anyType,     gte(18) ], // 18.x: centos7 builds stop
   [ /^centos6-32-gcc6/,               releaseType, gte(10) ], // 32-bit linux for <10 only
   [ /^centos7-64/,                    releaseType, lt(12)  ],
   [ /^centos7-64/,                    anyType,     gte(18) ],


### PR DESCRIPTION
Adds two `c2.large.arm` Ampere eMag machines configured to run two
containers each:
  - CentOS 7 container intended for Node.js earlier than 18
  - RHEL 8 container intended for Node.js 18 and later

Add one RHEL 8 container to each of the Equinix test servers.