### PR TITLE
ansible: arm cross compiler updates for Node.js 18

### DIFF
--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -56,7 +56,6 @@ function run {
   fi
   export CC="ccache ${!base_varname}gcc ${!flags_varname}"
   export CXX="ccache ${!base_varname}g++ ${!flags_varname}"
-  env | grep ccache
 }
 
 run $1

--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -7,33 +7,36 @@
 # cross-compiler-ubuntu1604-armv7-gcc-6
 # cross-compiler-ubuntu1804-armv7-gcc-6
 # cross-compiler-ubuntu1804-armv7-gcc-8
+# cross-compiler-rhel8-armv7-gcc-8-glibc-2.28
 
 rpi_newer_tools_base="/opt/raspberrypi/rpi-newer-crosstools/"
 base_4_9_4="${rpi_newer_tools_base}x64-gcc-4.9.4-binutils-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 base_6="${rpi_newer_tools_base}x64-gcc-6.5.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 base_8="${rpi_newer_tools_base}x64-gcc-8.3.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+base_8_glibc_2_28="${rpi_newer_tools_base}x64-gcc-8.3.0-glibc-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+
 flags_armv6="-march=armv6zk"
 flags_armv7="-march=armv7-a"
 
 function run {
   local label="$1"
 
-  export arm_type=$(echo $label | sed -E 's/^cross-compiler-ubuntu1[68]04-(armv[67])-gcc-.*$/\1/')
-  export gcc_version=$(echo $label | sed -E 's/^cross-compiler-ubuntu1[68]04-armv[67]-gcc-(4\.9\.4|6|8)/\1/')
+  export arm_type=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-(armv[67])-gcc-.*$/\2/')
+  export gcc_version=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-armv[67]-gcc-(4\.9\.4|6|8)/\2/')
   export git_branch="cc-${arm_type}"
+  export host_os=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-(armv[67])-gcc-.*$/\1/')
 
   if [[ ! "$arm_type" =~ ^armv[67]$ ]]; then
     echo "Could not determine ARM type from '$label'"
     exit 1
   fi
-  if [[ ! "$gcc_version" =~ ^(4\.9\.4|6|8)$ ]]; then
+  if [[ ! "$gcc_version" =~ ^(4\.9\.4|6|8|8-glibc-2.28)$ ]]; then
     echo "Could not determine ARM type from '$label'"
     exit 1
   fi
 
-  gcc_version_safe="$(echo $gcc_version | sed -E 's/\./_/g')"
-  gcc_host_version="$(echo $gcc_version | sed -E 's/\.4//g')" # 4.9.4 -> 4.9
-
+  gcc_version_safe="$(echo $gcc_version | sed -E 's/[\.-]/_/g')"
+  gcc_host_version="$(echo $gcc_version | sed -E 's/([^-]+).*$/\1/g' | sed -E 's/\.4//g')" # 4.9.4 -> 4.9
   base_varname="base_${gcc_version_safe}"
   flags_varname="flags_${arm_type}"
 
@@ -44,10 +47,16 @@ function run {
 
   export ARCH="${arm_type}l"
   export DESTCPU=arm
-  export CC_host="ccache gcc-${gcc_host_version} -m32"
-  export CXX_host="ccache g++-${gcc_host_version} -m32"
+  if [ "$host_os" = "rhel8" ]; then
+    export CC_host="ccache gcc -m32"
+    export CXX_host="ccache g++ -m32"
+  else
+    export CC_host="ccache gcc-${gcc_host_version} -m32"
+    export CXX_host="ccache g++-${gcc_host_version} -m32"
+  fi
   export CC="ccache ${!base_varname}gcc ${!flags_varname}"
   export CXX="ccache ${!base_varname}g++ ${!flags_varname}"
+  env | grep ccache
 }
 
 run $1

--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -52,7 +52,7 @@ function run {
     # Additional gcc versions are installed via gcc-toolset-<n> packages.
     # No such package exists for the default gcc version (8 on RHEL 8).
     if [ "${current_gcc_version}" != "${gcc_host_version}" ]; then
-      if . /opt/gcc-toolset-${gcc_host_version}/enable; then
+      if ! . /opt/gcc-toolset-${gcc_host_version}/enable; then
         echo "Host gcc version mismatch (wanted ${gcc_host_version} but got ${current_gcc_version})."
         exit 1
       fi

--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -52,8 +52,7 @@ function run {
     # Additional gcc versions are installed via gcc-toolset-<n> packages.
     # No such package exists for the default gcc version (8 on RHEL 8).
     if [ "${current_gcc_version}" != "${gcc_host_version}" ]; then
-      . /opt/gcc-toolset-${gcc_host_version}/enable
-      if [ "$?" != 0 ]; then
+      if . /opt/gcc-toolset-${gcc_host_version}/enable; then
         echo "Host gcc version mismatch (wanted ${gcc_host_version} but got ${current_gcc_version})."
         exit 1
       fi

--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -48,6 +48,16 @@ function run {
   export ARCH="${arm_type}l"
   export DESTCPU=arm
   if [ "$host_os" = "rhel8" ]; then
+    current_gcc_version="$(gcc -dumpversion)"
+    # Additional gcc versions are installed via gcc-toolset-<n> packages.
+    # No such package exists for the default gcc version (8 on RHEL 8).
+    if [ "${current_gcc_version}" != "${gcc_host_version}" ]; then
+      . /opt/gcc-toolset-${gcc_host_version}/enable
+      if [ "$?" != 0 ]; then
+        echo "Host gcc version mismatch (wanted ${gcc_host_version} but got ${current_gcc_version})."
+        exit 1
+      fi
+    fi
     export CC_host="ccache gcc -m32"
     export CXX_host="ccache g++ -m32"
   else

--- a/ansible/roles/docker/templates/debian10_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/debian10_armv7l.Dockerfile.j2
@@ -1,0 +1,49 @@
+FROM arm32v7/debian:10
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV SHELL /bin/bash
+ENV HOME /home/{{ server_user }}
+ENV PATH /usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
+ENV PYTHON python3
+ENV DESTCPU {{ arch }}
+ENV ARCH {{ arch }}
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
+      curl \
+      g++-8 \
+      gcc-8 \
+      git \
+      libfontconfig1 \
+      openjdk-11-jre-headless \
+      pkg-config \
+      procps \
+      python3-pip \
+      xz-utils
+
+# Prevent Node.js picking up the OS's openssl.cnf, https://github.com/nodejs/node/issues/27862
+ENV OPENSSL_CONF /dev/null
+
+RUN pip3 install tap2junit
+
+RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
+
+RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
+
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
+
+USER iojs:iojs
+
+ENV CCACHE_TEMPDIR /home/iojs/.ccache/{{ item.name }}
+
+CMD cd /home/iojs \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java -Xmx{{ server_ram|default('128m') }} \
+          -jar /home/{{ server_user }}/slave.jar \
+          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
+          -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -1,0 +1,65 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+ENV LC_ALL C
+ENV USER {{ server_user }}
+ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
+ENV SHELL /bin/bash
+ENV PATH /usr/lib64/ccache:/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
+ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
+ENV OSTYPE linux-gnu
+ENV OSVARIANT docker
+ENV DESTCPU {{ arch }}
+ENV ARCH {{ arch }}
+
+# ccache is not in the default repositories so get it from EPEL 8.
+RUN dnf install --disableplugin=subscription-manager -y \
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && dnf update --disableplugin=subscription-manager -y \
+    && dnf install --disableplugin=subscription-manager -y \
+      ccache \
+      gcc-c++ \
+      git \
+      glibc-devel.i686 \
+      java-17-openjdk-headless \
+      make \
+      libatomic.i686 \
+      libstdc++-devel \
+      libstdc++-devel.i686 \
+      python3 \
+      procps-ng \
+      xz \
+    && dnf --disableplugin=subscription-manager clean all
+
+RUN groupadd -r -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }} \
+    && adduser -r -m -d /home/{{ server_user }}/ \
+      -g {{ server_user_gid.stdout_lines[0] }} \
+      -u {{ server_user_uid.stdout_lines[0] }} {{ server_user }}
+
+# Relax crypto policies to allow Node.js tests to pass
+RUN update-crypto-policies --set LEGACY
+
+VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
+
+ENV PYTHON /usr/bin/python3
+
+RUN pip3 install tap2junit
+
+RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
+
+COPY cc-selector.sh /opt/raspberrypi/cc-selector.sh
+
+RUN chmod 755 /opt/raspberrypi/cc-selector.sh
+
+USER {{ server_user }}:{{ server_user }}
+
+ENV CCACHE_TEMPDIR /home/{{ server_user }}/.ccache/{{ item.name }}
+
+WORKDIR /home/{{ server_user }}
+
+CMD cd /home/{{ server_user }} \
+  && curl https://ci.nodejs.org/jnlpJars/slave.jar -O \
+  && java -Xmx{{ server_ram|default('128m') }} \
+          -jar /home/{{ server_user }}/slave.jar \
+          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/slave-agent.jnlp \
+          -secret {{ item.secret }}

--- a/ansible/roles/jenkins-worker/templates/rpi_buster.Dockerfile.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_buster.Dockerfile.j2
@@ -1,0 +1,64 @@
+FROM balenalib/rpi-raspbian:buster
+
+ENV LC_ALL=C \
+    USER={{ server_user }} \
+    JOBS={{ jobs_env }} \
+    SHELL=/bin/bash \
+    HOME=/home/{{ server_user }} \
+    PATH=/usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    NODE_COMMON_PIPE=/home/{{ server_user }}/test.pipe \
+    NODE_TEST_DIR=/home/{{ server_user }}/tmp \
+    OSTYPE=linux-gnu \
+    OSVARIANT=docker \
+    DESTCPU=arm \
+    ARCH={{ arch }} \
+    CCACHE_TEMPDIR=/home/{{ server_user }}/.ccache/{{ inventory_hostname }} \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
+      g++-8 \
+      gcc-8 \
+      git \
+      make \
+      ccache \
+      python2.7 \
+      python \
+      openssh-client \
+      gzip \
+      xz-utils \
+      curl \
+      libffi-dev \
+      zlib1g-dev && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-8 50 && \
+    update-alternatives --install /usr/bin/cpp cpp /usr/bin/gcc-8 50 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 50 && \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-8 50
+
+RUN mkdir /python && \
+    cd /python && \
+    curl https://github.com/python/cpython/archive/refs/tags/v3.9.4.tar.gz -L --output v3.9.4.tar.gz && \
+    tar xf v3.9.4.tar.gz && \
+    cd cpython-3.9.4 && \
+    ./configure && \
+    make install && \
+    rm -rf /python
+
+RUN addgroup \
+      --gid {{ server_user_gid.stdout_lines[0] }} \
+      {{ server_user }} && \
+    adduser \
+      --gid {{ server_user_gid.stdout_lines[0] }} \
+      --uid {{ server_user_uid.stdout_lines[0] }} \
+      --disabled-password \
+      --gecos {{ server_user }} \
+      {{ server_user }}
+
+VOLUME /home/{{ server_user }}/
+
+USER iojs:iojs
+
+ENTRYPOINT [ "tail", "-f", "/dev/null" ]

--- a/ansible/roles/jenkins-worker/templates/rpi_buster.Dockerfile.j2
+++ b/ansible/roles/jenkins-worker/templates/rpi_buster.Dockerfile.j2
@@ -61,4 +61,7 @@ VOLUME /home/{{ server_user }}/
 
 USER iojs:iojs
 
+# Prevent Node.js picking up the OS's openssl.cnf, https://github.com/nodejs/node/issues/27862
+ENV OPENSSL_CONF /dev/null
+
 ENTRYPOINT [ "tail", "-f", "/dev/null" ]

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -118,10 +118,12 @@ raspberry_pi: {
       { name: 'jessie', template: 'rpi_jessie.Dockerfile.j2' }
     ],
     armv7l: [
-      { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' }
+      { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' },
+      { name: 'buster', template: 'rpi_buster.Dockerfile.j2' }
     ],
     arm64: [
-      { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' }
+      { name: 'stretch', template: 'rpi_stretch.Dockerfile.j2' },
+      { name: 'buster', template: 'rpi_buster.Dockerfile.j2' }
     ]
   }
 }

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -62,6 +62,8 @@ def buildExclusions = [
   [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,      anyType, lt(14)  ],
   [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,      anyType, gte(16) ],
   [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,      anyType, lt(16)  ],
+  [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,      anyType, gte(18) ],
+  [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,anyType, lt(18)  ],
   [ /^ubuntu1604-arm64/,              anyType,     gte(14) ],
 
   // Windows -----------------------------------------------


### PR DESCRIPTION
Add a new RHEL 8 based container for cross compilation of armv7l
binaries for Node.js 18 using the recently added cross compiler
toolchain based on gcc 8 with glibc 2.28.

Adds a Debian 10 (Buster) container to the Pi's -- even though the Pi's
are running Debian 10 the tests are run in containers and prior to this
commit were running in Debian 9, which is on glibc 2.24.

---

The plan would be, at least initially, to continue testing older versions of Node.js in the stretch container but use the buster container for Node.js 18 onwards. Or do we think stretch is too old now we should move everything?