### PR TITLE
ansible: make happy with latest ansible@2.x

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -413,5 +413,4 @@
 
 - name: install monit
   when: os in needs_monit
-  include: monit.yml
-  static: false
+  include_tasks: monit.yml


### PR DESCRIPTION
this was blocking me from even running the main worker/create playbook with ansible 2.x; the change here lets it play at least and makes warnings go away