### PR TITLE
jenkins: temporarily exclude win32 for Node.js 18

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -73,6 +73,7 @@ def buildExclusions = [
   [ /vs2015/,                         releaseType, ltGte(6, 10)  ],
   [ /vs2017/,                         releaseType, ltGte(10, 14) ],
   [ /vs2019/,                         releaseType, lt(14)        ],
+  [ /vs2019-x86/,                     releaseType, gte(18)       ], // Temporary, https://github.com/nodejs/node/pull/42666
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2013(-\w+)?$/,                 testType,    gte(6)        ],
   [ /vs2015(-\w+)?$/,                 testType,    gte(10)       ],
@@ -82,6 +83,7 @@ def buildExclusions = [
   [ /vs2015-x86$/,                    testType,    gte(10)       ], // compile arm64/x86 only once
   [ /vs2017-x86$/,                    testType,    ltGte(10, 14) ],
   [ /vs2019-x86$/,                    testType,    lt(14)        ],
+  [ /vs2019-x86$/,                    testType,    gte(18)       ], // Temporary, https://github.com/nodejs/node/pull/42666
   [ /vs2019-arm64$/,                  testType,    lt(14)        ],
   // VS versions supported to build add-ons
   [ /vs2013-COMPILED_BY/,             testType,    gte(9)        ],


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/42666
Refs: https://github.com/nodejs/node/issues/42543#issuecomment-1094043762

cc @nodejs/platform-windows @nodejs/build @nodejs/v8-update 

---

This is the quick way to land https://github.com/nodejs/node/pull/42657 and get a clean CI for Node.js 18. The plan will be to reverse this as soon as possible when we're able to pick up a stable V8 which compiles on 32-bit Windows.