### PR TITLE
jenkins: only run sharedlibs_debug_x64 pre-18

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -110,6 +110,7 @@ def buildExclusions = [
 
   // Shared libs docker containers -------------------------
   [ /ubi81_sharedlibs/,               anyType,     lt(13)  ],
+  [ /sharedlibs_debug_x64/,           anyType,     gte(18) ],
   [ /sharedlibs_openssl3/,            anyType,     lt(15)  ],
   [ /sharedlibs_openssl111/,          anyType,     lt(11)  ],
   [ /sharedlibs_openssl110/,          anyType,     lt(9)   ],


### PR DESCRIPTION
Full debug x64 builds have been unreliable in the CI in the sharedlibs
containers and were recently "turned off" by making the job a no-op.
However the job was still being started even if it didn't do anything
but pass -- this change prevents Jenkins from starting 
`sharedlibs_debug_x64` runs.

Refs: https://github.com/nodejs/build/issues/2837

---

cc @mhdawson 

We may end up reintroducing a "lighter" debug build (suggested in https://github.com/nodejs/node/issues/41209#issuecomment-1001261679) later but that would probably be better in its own job and not part of node-test-commit-linux-containered.