### PR TITLE
doc: update Build WG Slack channel

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -71,8 +71,8 @@ all reflect on the Build WG.
 
 If you are interested in helping out with the Build WG, please reach out to
 existing members to let us know. The best means for communication with the Build
-WG are either here via GitHub issues or through the `#node-build` channel on
-Freenode [IRC][].
+WG are either here via GitHub issues or through the `#nodejs-build` channel on
+the OpenJS Foundation [Slack][].
 
 Membership is granted by way of a pull request adding a new individual to the
 members list on the README (e.g. [#524][]). New members can open such a pull
@@ -158,9 +158,9 @@ These Pull Requests must be:
   * Use the squash merge button workflow on Github
 
 
-[IRC], specifically `#node-build` is important for communicating with
+[Slack], specifically `#nodejs-build` is important for communicating with
 other Node.js project members, and how we receive many initial signals
-of downtime. IRC logs are maintained at http://logs.libuv.org/node-build
+of downtime.
 
 
 ### Special Access Requests
@@ -343,6 +343,6 @@ The [Node.js Code of Conduct][] applies to this WG.
 [Node.js Moderation Policy]: https://github.com/nodejs/TSC/blob/HEAD/Moderation-Policy.md
 [Node.js Foundation calendar]: https://nodejs.org/calendar
 [the onboarding doc]: /ONBOARDING.md
-[IRC]: /README.md#nodejs-build-working-group
+[Slack]: https://openjs-foundation.slack.com/archives/C03BJP63CH0
 [#524]: https://github.com/nodejs/build/pull/524
 [resources.md]: /doc/resources.md

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ companies that have donated miscellaneous hardware:
 
 
 If you would like to donate hardware to the Node.js Project, please reach
-out to the Build Working Group, via the [#build channel on the Node.js slack
+out to the Build Working Group, via the [#nodejs-build channel on the OpenJS Foundation Slack
 instance][1] or contact [Rod Vagg](mailto:rod@vagg.org) directly. The Build
 Working Group reserves the right to choose what hardware is actively used
 and how it is used, donating hardware does not guarantee its use within the
@@ -284,7 +284,7 @@ months after the release goes End-of-Life, in case further build or test runs
 are required. After that the configuration will be removed.
 
 
-[1]:    https://node-js.slack.com/archives/C16SCB5JQ
+[1]:    https://openjs-foundation.slack.com/archives/C03BJP63CH0
 [2]:    https://digitalocean.com/
 [3]:    https://www.rackspace.com/
 [5]:    https://www.mailgun.com/

--- a/doc/jenkins-guide.md
+++ b/doc/jenkins-guide.md
@@ -51,7 +51,7 @@ ansible-playbook playbooks/jenkins/worker/create.yml --limit test-rackspace-free
 If all goes according to plan, then Ansible should be able to run the
 playbook with no errors. If you do encounter problems, there are usually
 some WG members available in the
-[Node.js Build Slack channel](https://node-js.slack.com/archives/C16SCB5JQ), who can try and
+[Node.js Build Slack channel][], who can try and
 lend a hand.
 
 ## Security releases
@@ -129,7 +129,7 @@ Relevant logs:
 ## Solving problems
 
 Issues with the Jenkins clusters are usually reported to either the
-[Node.js Build Slack channel](https://node-js.slack.com/archives/C16SCB5JQ), or to the
+[Node.js Build Slack channel][], or to the
 [`nodejs/build` issue tracker](https://github.com/nodejs/build/issues).
 
 When trying to fix a worker, ensure that you `mark the node as offline`,
@@ -369,7 +369,7 @@ to its desired state, including refreshing and restarting the Jenkins
 agent configuration.
 
 If none of the above steps work, please post in the
-[Node.js Build Slack channel](https://node-js.slack.com/archives/C16SCB5JQ), or the
+[Node.js Build Slack channel][], or the
 [`nodejs/build` issue tracker](https://github.com/nodejs/build/issues), to allow
 for escalation and other WG members to troubleshoot.
 
@@ -381,3 +381,4 @@ take a look.
 [secrets repo]: https://github.com/nodejs-private/secrets
 [ci]: https://ci.nodejs.org/computer/test-softlayer-ubuntu1804_container-x64-1/
 [1]: https://ci.nodejs.org/computer/test-softlayer-ubuntu1804_container-x64-1/
+[Node.js Build Slack channel]: https://openjs-foundation.slack.com/archives/C03BJP63CH0


### PR DESCRIPTION
The Slack channel for the Build WG has been moved to #nodejs-build
on the OpenJS Foundation Slack instance.

Refs: https://openjs-foundation.slack.com/archives/C03BJP63CH0
Closes: https://github.com/nodejs/build/issues/2875