### PR TITLE
ansible: AIX updates

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -45,7 +45,7 @@ hosts:
 
     - ibm:
         aix71-ppc64_be-2:
-            ip: 169.48.19.173
+            ip: 169.59.74.10
             server_jobs: 6
         rhel7-s390x-1: {ip: 148.100.84.166, user: linux1}
         rhel8-s390x-1: {ip: 148.100.84.45, user: linux1}
@@ -143,13 +143,17 @@ hosts:
 
     - ibm:
         aix71-ppc64_be-3: 
-            ip: 169.48.22.38
+            ip: 169.48.23.70
             server_jobs: 6
         aix71-ppc64_be-4:  
-            ip: 169.48.22.51
+            ip: 169.59.74.12
             server_jobs: 6
         aix73-ppc64_be-1:
+            ansible_python_interpreter: /opt/freeware/bin/python3
+            ansible_remote_tmp: /tmp/.ansible
             ip: 163.68.64.114
+            remote_env:
+                PATH: /opt/freeware/bin:/usr/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin
             server_jobs: 6
         rhel7-s390x-1: {ip: 148.100.84.221, user: linux1, build_test_v8: yes}
         rhel7-s390x-2: {ip: 148.100.84.114, user: linux1, build_test_v8: yes}

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -85,7 +85,12 @@
   - "!test-ibm-ubuntu1804-x64-1"
   tasks:
     - name: remove node and npm packages
-      when: not os|startswith("win") and not os|startswith("zos") and not os|startswith("ibmi") and os != "macos11.0"
+      when:
+      - not os|startswith("aix")
+      - not os|startswith("ibmi")
+      - not os|startswith("win")
+      - not os|startswith("zos")
+      - os != "macos11.0"
       package:
         name: "{{ package }}"
         state: absent

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -28,10 +28,6 @@
     - "dscacheutil -flushcache"
   when: os|startswith("macos")
 
-- name: Set hostname to inventory_hostname AIX
-  command: " hostname {{ inventory_hostname }}"
-  when: os|startswith("aix")
-
 - name: disable joyent smartconnect
   when: os|startswith("smartos")
   notify: restart sshd
@@ -72,7 +68,8 @@
   package: 
     name: "{{ package }}"
     state: present
-    use: "{{ os|startswith(\"ibmi\")|ternary(\"yum\", omit) }}"
+    # Package manager mapping in ansible/roles/package-upgrade/vars/main.yml.
+    use: "{{ os|match_key(pm)|default(omit) }}"
   loop_control:
     loop_var: package
   notify: package updated

--- a/ansible/roles/baselayout/tasks/partials/ccache/aix.yml
+++ b/ansible/roles/baselayout/tasks/partials/ccache/aix.yml
@@ -50,11 +50,15 @@
     group: system
     state: link
   loop:
-    - { dest: gcc }
-    - { dest: g++ }
-    - { dest: gcov }
-    - { dest: cpp }
     - { dest: c++ }
+    - { dest: cpp }
+    - { dest: g++ }
+    - { dest: gcc }
+    - { dest: gcov }
+    - { dest: g++-6 }
+    - { dest: gcc-6 }
+    - { dest: g++-8 }
+    - { dest: gcc-8 }
   when: not has_ccache.stat.exists
 
 - name: "ccache : cleanup - aix tarball"

--- a/ansible/roles/baselayout/tasks/partials/ccache/aix73.yml
+++ b/ansible/roles/baselayout/tasks/partials/ccache/aix73.yml
@@ -1,0 +1,6 @@
+# Install ccache via AIX Toolbox
+
+- name: install ccache
+  ansible.builtin.dnf:
+    name: ccache-swig
+    state: present

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -76,7 +76,15 @@ packages: {
   ],
 
   aix: [
-    'bash,cmake,curl,gcc-c++,gcc6-c++,tar,unzip,git,make,sudo,python-setuptools,python3',
+    'bash,cmake,coreutils,curl,gcc-c++,tar,unzip,git,make,sudo,python-setuptools,python3',
+  ],
+
+  aix71: [
+    'gcc6-c++',
+  ],
+
+  aix72: [
+    'gcc6-c++',
   ],
 
   ibmi: [

--- a/ansible/roles/bootstrap/tasks/partials/aix.yml
+++ b/ansible/roles/bootstrap/tasks/partials/aix.yml
@@ -57,3 +57,19 @@
   shell:
     cmd: mount -v ahafs /aha /aha
   when: ahafs.matched == 0
+
+- name: Set maximum processes per user
+  community.general.aix_devices:
+    device: sys0
+    attributes:
+      maxuproc: "512"
+
+# Set consistent hostname with Ansible inventory.
+- name: Check hostname
+  ansible.builtin.command: hostname
+  changed_when: no
+  register: current_hostname
+
+- name: Set hostname to inventory_hostname AIX
+  ansible.builtin.command: hostname {{ inventory_hostname }}
+  when: current_hostname.stdout != inventory_hostname

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -39,6 +39,7 @@
 
 - name: install java
   when:
+    - java_package_name is defined and java_package_name != ""
     - not os|startswith("zos")
     - not os|startswith("macos")
   notify:
@@ -47,7 +48,8 @@
   package:
     name: "{{ java_package_name }}"
     state: latest
-    use: "{{ os|startswith(\"ibmi\")|ternary(\"yum\", omit) }}"
+    # Package manager mapping in ansible/roles/package-upgrade/vars/main.yml.
+    use: "{{ os|match_key(pm)|default(omit) }}"
 
 - name: install java tap (macOS)
   become_user: administrator

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -21,7 +21,7 @@ packages: {
   'ubuntu1404': 'oracle-java8-installer',
   }
 
-java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('missing') }}"
+java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default(omit) }}"
 
 # Add os_arch combinations here that should install and use AdoptOpenJDK
 # binaries. Override any variables in the dictionary. 
@@ -30,6 +30,7 @@ java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default('
 adoptopenjdk: {
   aix71_ppc64: { arch: ppc64 },
   aix72_ppc64: { arch: ppc64 },
+  aix73_ppc64: { arch: ppc64, version: 17 },
   centos7_ppc64: {}
 }
 

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix.yml
@@ -16,7 +16,7 @@
   when: pip_exists.stat.exists == False
 
 - name: install pip AIX71
-  raw: /usr/bin/python /home/iojs/get-pip.py
+  raw: /opt/freeware/bin/python3 /home/iojs/get-pip.py
   when: pip_exists.stat.exists == False and os == "aix71"
 
 - name: install pip AIX72

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix73.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/aix73.yml
@@ -1,0 +1,5 @@
+- name: install tap2junit
+  ansible.builtin.pip:
+    name: tap2junit
+    state: present
+    executable: /usr/bin/pip3

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -16,7 +16,7 @@ start )
               export HOME=/home/{{server_user}}; \
               export NODE_TEST_DIR=$HOME/tmp; \
               export NODE_COMMON_PIPE="$HOME/test.pipe"; \
-              export PATH="$PATH:/opt/freeware/bin"; \
+              export PATH="/opt/freeware/bin:/usr/opt/python3/bin/:$PATH"; \
               export OSTYPE=AIX72; \
               export JOBS={{ jobs_env }}; \
         /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
 init: {
-  aix: ['aix71', 'aix72'],
+  aix: ['aix71', 'aix72', 'aix73'],
   centos6: 'centos6',
   debian: 'debian7',
   freebsd: 'freebsd',

--- a/ansible/roles/package-upgrade/vars/main.yml
+++ b/ansible/roles/package-upgrade/vars/main.yml
@@ -5,9 +5,9 @@
 #
 
   pm: {
-    'yum': ['centos', 'rhel7', 'aix', 'ibmi'],
+    'yum': ['centos', 'rhel7', 'aix71', 'aix72', 'ibmi'],
     'apt': ['debian', 'ubuntu'],
-    'dnf': ['fedora', 'rhel8'],
+    'dnf': ['aix73', 'fedora', 'rhel8'],
     'pkg': 'freebsd',
     'pkgin': 'smartos',
     'chocolatey': 'win',

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -145,6 +145,15 @@ elif [ "$SELECT_ARCH" = "IBMI73" ]; then
 
 elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
   case $NODE_NAME in
+    *aix73* )
+      export COMPILER_LEVEL="10"
+      echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX 7.3"
+      export CC="ccache-swig gcc-${COMPILER_LEVEL}"
+      export CXX="ccache-swig g++-${COMPILER_LEVEL}"
+      export LINK="g++-${COMPILER_LEVEL}"
+      echo "Compiler set to:" `$CXX -dumpversion`
+      return
+      ;;
     *aix72* )
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX7.2"
       if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then


### PR DESCRIPTION
Replace AIX 7.1 VMs. Add set up for new AIX 7.3 VM.

Differences for AIX 7.3 from AIX 7.1/7.2 set up:
- `gcc-c+` package in [AIX Toolbox](https://www.ibm.com/support/pages/aix-toolbox-open-source-software-downloads-alpha) for AIX 7.3 is gcc 10. There are no earlier versions of gcc available for AIX 7.3 (we install `gcc6-c+` on AIX 7.2/7.1 but this is not available for 7.3 so we need to adjust the playbook accordingly).
- `ccache` doesn't exist in AIX toolbox (we are compiling it from source for AIX 7.2/7.1) but the toolbox does have a fork, `ccache-swig`, which this PR tries to use for AIX 7.3.
- Use Java 17 instead of 8 (since this is a new machine).
- AIX toolbox is migrating to `dnf` instead of `yum`. The AIX 7.3 instance we've been given appears to already have `dnf` installed.

Refs: https://github.com/nodejs/build/pull/2908