### PR TITLE
ansible: replace altra 2 with 3 in the inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -139,7 +139,7 @@ hosts:
 
     - equinix:
         ubuntu2004_docker-arm64-1: {ip: 145.40.81.219}
-        ubuntu2004_docker-arm64-2: {ip: 139.178.85.13}
+        ubuntu2004_docker-arm64-3: {ip: 145.40.99.31}
 
     - ibm:
         aix71-ppc64_be-3: 


### PR DESCRIPTION
As per https://github.com/nodejs/build/issues/2894 - we have been given a replacement machine for the one that was unreliable. I've provisioned it with the same set of docker hostnames as the other server so this should be a drop in replacement (Will need subsequent PR to update the hostname in the secrets repo).

Firewall rule has been replaced by Richard.

(In draft until machine has been successfully deployed)

Signed-off-by: Stewart X Addison <sxa@redhat.com>