### PR TITLE
jenkins: add workaround for groovy script & Java 11+

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -158,9 +158,9 @@ def canBuild = { nodeVersion, builderLabel, buildType ->
 
 int nodeMajorVersion = -1
 if (parameters['NODEJS_MAJOR_VERSION'])
-  nodeMajorVersion = parameters['NODEJS_MAJOR_VERSION'].toString().toInteger()
+  nodeMajorVersion = new String(parameters['NODEJS_MAJOR_VERSION']).toInteger()
 println "Node.js major version: $nodeMajorVersion"
-println "Node.js version: ${parameters['NODEJS_VERSION']}"
+println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"
 
 // NOTE: this assumes that the default "Slaves"->"Name" in the Configuration
 // Matrix is left as "nodes", if it's changed then `it.nodes` below won't work


### PR DESCRIPTION
The Matrix Groovy Execution Strategy plugin appears to have an issue
on Java 11+ where string parameters are appearing as byte arrays
instead of strings. Use the new String() constructor instead of
toString() to ensure we get string repesentation of the parameter.

Refs: https://github.com/jenkinsci/matrix-groovy-execution-strategy-plugin/issues/20
Refs: https://github.com/nodejs/build/issues/2984#issuecomment-1227537524

We need this to unblock the Java update.