### PR TITLE
jenkins: guard potentially unset parameter

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -160,7 +160,8 @@ int nodeMajorVersion = -1
 if (parameters['NODEJS_MAJOR_VERSION'])
   nodeMajorVersion = new String(parameters['NODEJS_MAJOR_VERSION']).toInteger()
 println "Node.js major version: $nodeMajorVersion"
-println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"
+if (parameters['NODEJS_VERSION'])
+  println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"
 
 // NOTE: this assumes that the default "Slaves"->"Name" in the Configuration
 // Matrix is left as "nodes", if it's changed then `it.nodes` below won't work


### PR DESCRIPTION
Guard against the `NODEJS_VERSION` parameter not being set, which
results in `parameters['NODEJS_VERSION']` being `null`.

Refs: https://ci.nodejs.org/job/node-compile-windows/46654/console

```
08:02:32 println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"
...
08:02:32 FATAL: Ambiguous method overloading for method java.lang.String#<init>.
08:02:32 Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
08:02:32 	[class [B]
08:02:32 	[class [C]
08:02:32 	[class java.lang.String]
08:02:32 groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method java.lang.String#<init>.
08:02:32 Cannot resolve which method to invoke for [null] due to overlapping prototypes between:
08:02:32 	[class [B]
08:02:32 	[class [C]
08:02:32 	[class java.lang.String]
08:02:32 	at groovy.lang.MetaClassImpl.doChooseMostSpecificParams(MetaClassImpl.java:3251)
```