### PR TITLE
Workaround for groovy script & Java 11+ in `citgm-smoker-nobuild`

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -158,7 +158,11 @@ def canBuild = { nodeVersion, builderLabel, buildType ->
 
 int nodeMajorVersion = -1
 if (parameters['NODEJS_MAJOR_VERSION'])
-  nodeMajorVersion = new String(parameters['NODEJS_MAJOR_VERSION']).toInteger()
+  if (parameters['NODEJS_MAJOR_VERSION'] instanceof Integer) {
+    nodeMajorVersion = parameters['NODEJS_MAJOR_VERSION']
+  } else {
+    nodeMajorVersion = (new String(parameters['NODEJS_MAJOR_VERSION'])).toInteger()
+  }
 println "Node.js major version: $nodeMajorVersion"
 if (parameters['NODEJS_VERSION'])
   println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"


### PR DESCRIPTION
This is a follow on to commit dce00d089e6266dd838eabec38d75e4f8dcd627e which doesn't work with the citgm-smoker-nobuild job where the default value is `v18` instead of `19.0.0` so it doesn't parse properly with the original solution. This almost certainly needs a bit of a rethink to get the value passed in in a consistent format if possible.

Fixes https://github.com/nodejs/build/issues/3023 (Subject to disclaimer in the last line of this description)

Looks to have broken the ability to run the citgm jobs. Once I fixed another issue in the citgm-smoker-nobuild job:
```
// SXA build#3023 // def verString = parameters['NODE_VERSION'].toString()
  def verString = new String(parameters['NODE_VERSION'])
```
I hit this. I've patched the job to run from my branch just now.

NOTE: It is unclear yet whether this fix is now breaking the parsing of the file and stopping it from only selecting the correct systems, but it's likely preferable as a workaround to the job failing to run at all.