### PR TITLE
ansible: add new OSUOSL arm64 release machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -87,7 +87,9 @@ hosts:
         aix72-ppc64_be-1:
             ip: 140.211.9.77
             server_jobs: 6
+        centos7-arm64-1: {ip: 140.211.169.7, server_jobs: 2, user: centos}
         centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
+        rhel8-arm64-1: {ip: 140.211.169.58, server_jobs: 2, user: cloud-user}
         rhel8-ppc64_le-1: {ip: 140.211.168.185, user: cloud-user}
 
     - orka:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -43,36 +43,12 @@ packages: {
   # partials/repo/centos7.yml for arm64
   centos7_arm64: [
     'git,python3', # git2u not available for aarch64 (yet)
-    'https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-runtime-6.1-1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-libs-0.168-3.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-runtime-3.0-8s.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-ltrace-0.7.91-17.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-strace-4.12-3.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-client-3.0-8s.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-gfortran-6.3.1-3.1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-binutils-2.27-12.el7.1.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-libelf-0.168-3.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-elfutils-0.168-3.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gdb-7.12.1-48.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-make-4.1-3.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-c++-6.3.1-3.1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-memstomp-0.1.5-5.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-dwz-0.12-1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-3.0-8s.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-toolchain-6.1-1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-gcc-6.3.1-3.1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-valgrind-3.12.0-1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-libstdc++-devel-6.3.1-3.1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-oprofile-1.1.0-4.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-systemtap-devel-3.0-8s.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-perftools-6.1-1.el7.aarch64.rpm,
-    https://buildlogs.centos.org/c7-devtoolset-6.aarch64/Packages/devtoolset-6-6.1-1.el7.aarch64.rpm',
   ],
   centos7_x64: ['devtoolset-6-libatomic-devel,git222,centos-release-scl,python3'],
   centos7_ppc64: ['cmake3,glib2-devel,git,python3'],
 
   centos7: [
-    'bzip2-devel,openssl-devel,ccache,gcc-c++,devtoolset-6,sudo,zlib-devel,libffi-devel,devtoolset-8,devtoolset-8-libatomic-devel',
+    'bzip2-devel,openssl-devel,ccache,gcc-c++,sudo,zlib-devel,libffi-devel,devtoolset-8,devtoolset-8-libatomic-devel',
   ],
 
   aix: [

--- a/ansible/roles/jenkins-worker/templates/systemd.service.j2
+++ b/ansible/roles/jenkins-worker/templates/systemd.service.j2
@@ -22,6 +22,8 @@ Environment="PATH=/home/{{ server_user }}/nghttp2/src:/home/{{ server_user }}/wr
 Environment="NODE_COMMON_PIPE=/home/{{ server_user }}/test.pipe"
 Environment="NODE_TEST_DIR=/home/{{ server_user }}/tmp"
 Environment="OSTYPE=linux-gnu"
+Environment="DESTCPU={{ arch }}"
+Environment="ARCH={{ arch }}"
 
 ExecStart=/usr/bin/java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/slave.jar \


### PR DESCRIPTION
Add two new OSUOSL hosted arm64 release machines to replace the Equinix ones that are going away at the end of November 2022.

Updates the playbook for centos7 to drop devtoolset-6 which is no longer required since Node.js 12 went End-of-Life (Node.js 14 and 16 use devtoolset-8 and Node.js 18 and later are not built on centos7).

Refs: https://github.com/nodejs/build/issues/3028