### PR TITLE
ansible: pin Python 3 to 3.10.8

### DIFF
--- a/ansible/group_vars/release.yml
+++ b/ansible/group_vars/release.yml
@@ -1,6 +1,7 @@
 jenkins_url: "https://ci-release.nodejs.org"
 # intentionally fetching `slave.jar` from ci.nodejs.org to avoid auth problems
 jenkins_worker_jar: "https://ci.nodejs.org/jnlpJars/slave.jar"
+jenkins_icon: "https://ci.nodejs.org/favicon.ico"
 server_user: "iojs"
 home: "/home"
 git_reference_path: "{{ home }}/{{ server_user }}/.ccache/node.shared.reference"

--- a/ansible/group_vars/test.yml
+++ b/ansible/group_vars/test.yml
@@ -1,5 +1,6 @@
 jenkins_url: "https://ci.nodejs.org"
 jenkins_worker_jar: "{{ jenkins_url }}/jnlpJars/slave.jar"
+jenkins_icon: "{{ jenkins_url }}/favicon.ico"
 server_user: iojs
 home: "/home"
 git_reference_path: "{{ home }}/{{ server_user }}/git/io.js.reference"

--- a/ansible/roles/baselayout-windows/tasks/main.yml
+++ b/ansible/roles/baselayout-windows/tasks/main.yml
@@ -13,7 +13,18 @@
     install_args: 'ADD_CMAKE_TO_PATH=System'
 
 - name: install Python 3
-  win_chocolatey: name=python
+  win_chocolatey:
+    install_args: Include_launcher=1
+    name: python3
+    pinned: yes
+    version: "3.10.8"
+
+- name: install Python 3
+  win_chocolatey:
+    install_args: Include_launcher=1
+    name: python
+    pinned: yes
+    version: "3.10.8"
 
 - name: install Python 2
   win_chocolatey: name=python2

--- a/ansible/roles/jenkins-worker-windows/tasks/main.yml
+++ b/ansible/roles/jenkins-worker-windows/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: download Jenkins icon
   win_get_url:
-    url: 'http://mirrors.jenkins-ci.org/art/jenkins-logo/favicon.ico'
+    url: '{{ jenkins_icon }}'
     dest: 'C:\jenkins.ico'
     force: no
 

--- a/ansible/roles/jenkins-worker-windows/tasks/main.yml
+++ b/ansible/roles/jenkins-worker-windows/tasks/main.yml
@@ -4,8 +4,8 @@
 # Install the Jenkins worker
 #
 
-- name: install Java 8
-  win_chocolatey: name=jdk8
+- name: install Java 17
+  win_chocolatey: name=Temurin17
 
 - name: download Jenkins icon
   win_get_url:


### PR DESCRIPTION
Node.js 14 is incompatible with Python 3.11. Pin Python 3 to 3.10.8.
Run Jenkins agent on Java 17.

---

Updated Windows CI hosts:
- [x]    release-rackspace-win2012r2-x64-1
- [x]    release-rackspace-win2012r2-x64-2
- [x]    release-rackspace-win2012r2_vs2019-x64-1
- [x]    release-rackspace-win2012r2_vs2019-x64-2
- [x]    test-azure_msft-win10_vs2019-x64-1
- [x]    test-azure_msft-win10_vs2019-x64-2
- [x]    test-azure_msft-win10_vs2019-x64-3
- [x]    test-azure_msft-win10_vs2019-x64-4
- [x]    test-azure_msft-win2016_vs2017-x64-1
- [x]    test-azure_msft-win2016_vs2017-x64-2
- [x]    test-azure_msft-win2016_vs2017-x64-3
- [x]    test-azure_msft-win2016_vs2017-x64-4
- [x]    test-azure_msft-win2016_vs2017-x64-5
- [x]    test-azure_msft-win2016_vs2017-x64-6
- [ ]    test-msft-win10_vs2017-arm64-1
- [ ]    test-msft-win10_vs2017-arm64-2
- [ ]    test-nearform_arm-win10_vs2019-arm64-1
- [ ]    test-nearform_arm-win10_vs2019-arm64-2
- [x]    test-rackspace-win2012r2_vs2013-x64-1
- [x]    test-rackspace-win2012r2_vs2013-x64-2
- [x]    test-rackspace-win2012r2_vs2015-x64-1
- [x]    test-rackspace-win2012r2_vs2015-x64-2
- [x]    test-rackspace-win2012r2_vs2017-x64-1
- [x]    test-rackspace-win2012r2_vs2017-x64-2
- [x]    test-rackspace-win2012r2_vs2017-x64-3
- [x]    test-rackspace-win2012r2_vs2017-x64-4
- [x]    test-rackspace-win2012r2_vs2019-x64-1
- [x]    test-rackspace-win2012r2_vs2019-x64-2
- [x]    test-rackspace-win2012r2_vs2019-x64-3
- [x]    test-rackspace-win2012r2_vs2019-x64-4
- [x]    test-rackspace-win2012r2_vs2019-x64-5
- [x]    test-rackspace-win2012r2_vs2019-x64-6

<details>
<summary>Outdated</summary>

We're using chocolatey to manage Python on the Windows machines and https://ci.nodejs.org/job/windows-update-reboot/ has updated the Windows machines to Python 3.11.0. Unfortunately, this has broken Node.js 14 builds:
- Firstly because of a hard version check: https://github.com/nodejs/node/pull/45191#issuecomment-1295858818
- Secondly, with the check removed building addons breaks due to the old version of node-gyp in npm 6: https://github.com/nodejs/node/pull/45231

So far it looks like the Node.js 14 build is only broken on 
- test-rackspace-win2012r2_vs2019-x64-4
- test-rackspace-win2012r2_vs2019-x64-5

even though other machines also appear to have been updated to Python 3.11.0. I think that is because those two machines were rebooted last week to try to solve disk space issues and the other machines will start to fail the next time they are rebooted.

In order to stop chocolatey updating Python 3 I've had to pin both `python` and `python3` packages (if I don't `cup -y all` still updates to Python 3.11.0). Unfortunately, to get the playbook to run the pinned task I had to uninstall Python 3.11.0 first:
e.g.
```
$ ansible -m win_chocolatey -a "name=python version=3.11.0 state=absent remove_dependencies=yes" -v test-rackspace-win2012r2_vs2019-x64-5
```

However, although the updated playbook does install Python 3.10.8 and pins it (checked with `choco pin list` and verified `cup -y all` doesn't update it) the playbook is now broken because `py.exe` is missing:
```
TASK [visual-studio : install PyInstaller] *****************************************************************************************************************
task path: /home/rlau/sandbox/github/build/ansible/roles/visual-studio/tasks/main.yml:48
redirecting (type: modules) ansible.builtin.win_command to ansible.windows.win_command
fatal: [test-rackspace-win2012r2_vs2019-x64-5]: FAILED! => {"changed": false, "cmd": "py -3 -m pip install https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz", "msg": "Exception calling \"SearchPath\" with \"1\" argument(s): \"Could not find file 'py.exe'.\"", "rc": 2}

PLAY RECAP *************************************************************************************************************************************************
test-rackspace-win2012r2_vs2019-x64-5 : ok=48   changed=16   unreachable=0    failed=1    skipped=11   rescued=0    ignored=0
```

I think I'll need some help here.
</details>

cc @joaocgreis @nodejs/platform-windows 
