### PR TITLE
template: update zlib to 1.2.13

### DIFF
--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -87,7 +87,7 @@ RUN mkdir -p /tmp/openssl-$OPENSSL3VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL3VER
 
-ENV ZLIBVER 1.2.12
+ENV ZLIBVER 1.2.13
 ENV ZLIB12DIR /opt/zlib_$ZLIBVER
 
 RUN mkdir -p /tmp/zlib_$ZLIBVER && \


### PR DESCRIPTION
`curl -sL https://zlib.net/zlib-1.2.12.tar.gz | tar zxv --strip=1` is 404