### PR TITLE
ansible: add new OSUOSL arm64 docker test host

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -261,6 +261,7 @@ hosts:
         rhel8-ppc64_le-2: {ip: 140.211.168.76, user: cloud-user, build_test_v8: yes}
         rhel8-ppc64_le-3: {ip: 140.211.168.221, user: cloud-user, build_test_v8: yes}
         rhel8-ppc64_le-4: {ip: 140.211.168.194, user: cloud-user, build_test_v8: yes}
+        ubuntu2004_docker-arm64-1: {ip: 140.211.169.11, user: ubuntu}
 
     - orka:
         macos10.15-x64-1:

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -82,12 +82,12 @@ RUN mkdir -p /tmp/openssl-$OPENSSL3VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL3VER
 
-ENV ZLIBVER 1.2.12
+ENV ZLIBVER 1.2.13
 ENV ZLIB12DIR /opt/zlib_$ZLIBVER
 
 RUN mkdir -p /tmp/zlib_$ZLIBVER && \
     cd /tmp/zlib_$ZLIBVER && \
-    curl -sL https://zlib.net/zlib-$ZLIBVER.tar.gz | tar zxv --strip=1 && \
+    curl -sL https://zlib.net/fossils/zlib-$ZLIBVER.tar.gz | tar zxv --strip=1 && \
     ./configure --prefix=$ZLIB12DIR && \
     make -j 6 && \
     make install && \


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/3028

---

Existing arm64 docker test hosts at Equinix are being migrated to a new data facility. This host at OSUOSL will hopefully tide us over until the migration completes, and afterwards be available as a fallback.