### PR TITLE
fix: removed empty space

### DIFF
--- a/doc/ssh.md
+++ b/doc/ssh.md
@@ -21,9 +21,9 @@ for build working group members.
    comments:
 
     ```
-     # begin: node.js template
+    # begin: node.js template
 
-     # end: node.js template
+    # end: node.js template
     ```
 4. Follow the instructions in the [ansible guide](../ansible/README.md) to
    install ansible on your local machine.


### PR DESCRIPTION
### Main changes

Removed empty space. 

### Context

If you are copy/pasting from github web is hard to detect the dead space in some editors. This dead space triggers [the error](https://github.com/nodejs/build/blob/main/ansible/plugins/library/ssh_config.py#L103) `Your ssh config lacks template stubs. Check README.md for instructions.` 