### PR TITLE
fix: Anchored ubuntu version to support Python 2.7 in Github Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Lint
 on: [push, pull_request]
 jobs:
   Python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 2
       matrix:


### PR DESCRIPTION
### Main changes

- Update Github actions runner from `ubuntu-latest` to `ubuntu-20.04`

### Context
- [See discussion around ubuntu versions](https://github.com/actions/setup-python/issues/543)
- [Fail detected in nodejs/build](https://github.com/nodejs/build/actions/runs/3519497549/jobs/5899537570)