### PR TITLE
chore: upgrade github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.7]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
### Main changes
- Upgraded: `actions/setup-python@v1` -> `actions/setup-python@v4`
- Upgraded `actions/checkout@v2` -> `actions/checkout@v3`

### Context

- https://github.com/nodejs/build/pull/3086#issuecomment-1323683587