### PR TITLE
chore: Removed python2.7 from gh actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,9 @@ jobs:
       matrix:
         python-version: [2.7, 3.7]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,16 +3,12 @@ on: [push, pull_request]
 jobs:
   Python:
     runs-on: ubuntu-20.04
-    strategy:
-      max-parallel: 2
-      matrix:
-        python-version: [2.7, 3.7]
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.7
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
### Main changes
- Drop support for Python 2.7 in Github actions (bf699f951d7f941f61b1b207649c4de78764b8c1)

### Context
This PR was originated in https://github.com/nodejs/build/pull/3086#issuecomment-1323683587 and the Python 2.7 drop should be confirmed in #2659

### Notes
This PR is polluted with the payload for #3092, please focus the review on bf699f951d7f941f61b1b207649c4de78764b8c1 only. 
