### PR TITLE
chore: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/*"
+  pull_request:
 jobs:
   Python:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Add Dependabot to update the Actions files. They are already mostly pinned to major versions, so there shouldn't be much noise from this.
Branch filter on the one job is to prevent double builds for the Dependabot branches