### PR TITLE
ansible: update smartos hosts to Java 11

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -47,7 +47,7 @@
     - restart Jenkins
   package:
     name: "{{ java_package_name }}"
-    state: latest
+    state: "{{ 'present' if os|match_key(pm) == 'pkgin' else 'latest' }}"
     # Package manager mapping in ansible/roles/package-upgrade/vars/main.yml.
     use: "{{ os|match_key(pm)|default(omit) }}"
 

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -17,7 +17,7 @@ packages: {
   'macos': 'temurin17',
   'rhel7': 'java-11-openjdk',
   'rhel8': 'java-17-openjdk',
-  'smartos': 'openjdk8',
+  'smartos': 'openjdk11',
   'ubuntu': 'openjdk-17-jre-headless',
   'ubuntu1604': 'openjdk-8-jre-headless',
   'ubuntu1404': 'oracle-java8-installer',

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -87,11 +87,8 @@ java_path: {
   'macos10.15': 'java',
   'macos11': 'java',
   'macos11.0': 'java',
-  'smartos15': '/opt/local/java/openjdk8/bin/java',
-  'smartos16': '/opt/local/java/openjdk8/bin/java',
-  'smartos17': '/opt/local/java/openjdk8/bin/java',
-  'smartos18': '/opt/local/java/openjdk8/bin/java',
-  'smartos20': '/opt/local/java/openjdk8/bin/java',
+  'smartos18': '/opt/local/java/openjdk11/bin/java',
+  'smartos20': '/opt/local/java/openjdk11/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 


### PR DESCRIPTION
Update smartos CI hosts to Java 11. Remove obsolete entries for older versions of smartos.

Refs: https://github.com/nodejs/build/issues/3030

---

Updated
- [x] release-joyent-smartos18-x64-2
- [x] release-joyent-smartos20-x64-2
- [x] test-joyent-smartos18-x64-3
- [x] test-joyent-smartos18-x64-4
- [x] test-joyent-smartos20-x64-3
- [x] test-joyent-smartos20-x64-4