### PR TITLE
Fix detection of RUN_ARM64_TESTS in Windows test jobs

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -193,7 +193,7 @@ combinations.each{
   }
   // Run tests on Windows ARM64 only if explicitly requested
   if (builderLabel =~ /^win.*COMPILED_BY.*-arm64$/) {
-    if (!parameters['RUN_ARM64_TESTS'].toString().equalsIgnoreCase("true")){
+    if (!new String(parameters['RUN_ARM64_TESTS']).equalsIgnoreCase("true")){
       println "Skipping $builderLabel because RUN_ARM64_TESTS is not selected"
       return
     }


### PR DESCRIPTION
This is preventing correct detection of when the RUN_ARM64_TESTS is checked in https://ci.nodejs.org/job/node-test-binary-windows-js-suites/  similar to the changes we had to make in  https://github.com/nodejs/build/pull/3019/files when updating the version of java on the server.

Without this change you get this error because the value is a byte array `[116, 114, 117, 101]`.
```
17:15:46 Skipping win10-arm64-COMPILED_BY-vs2019-arm64 because RUN_ARM64_TESTS is not selected
```
regardless of whether the box is checked.

Signed-off-by: Stewart X Addison <sxa@redhat.com>