### PR TITLE
jenkins: handle no matches in download-test.sh

### DIFF
--- a/jenkins/download-test.sh
+++ b/jenkins/download-test.sh
@@ -30,6 +30,11 @@ fi
 # If the provided NODE_VERSION is inexact, e.g. `v8`, get the most recent matching version.
 LINK=`rsync rsync://unencrypted.nodejs.org/nodejs/$downloadDir/ | grep $NODE_VERSION | sort -t. -k 1,1n -k 2,2n -k 3,3n | tail -1 | awk '{print $5}'`
 
+if [ -z "$LINK" ]; then
+  echo "No matches found for '$NODE_VERSION' in https://unencrypted.nodejs.org/nodejs/$downloadDir/"
+  exit 1
+fi
+
 # Remove old files
 rm -rf v*
 [ "$tapFile" ] && rm -rf "$tapFile" && echo "TAP version 13" > $tapFile


### PR DESCRIPTION
If no matches for `NODE_VERSION` are found, bail out of the script. Previously if no matches were found the following rsync would attempt to download the entire `downloadDir`, e.g., for `release`, every release we've done!

---

See https://ci.nodejs.org/job/validate-downloads/2011/console which ran out of disk space trying to rsync everything in `release` because mirroring from www to unencrypted was broken (due to the IP change for unencrypted -- I've now updated the firewall on www for the unencrypted's new IP address) and the new versions were not mirrored to unencrypted.