### PR TITLE
jenkins: fix shellcheck linter CI

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -60,7 +60,6 @@ case $NODE_NAME in
         return
         ;;
     esac
-    return
     ;;
 esac
 


### PR DESCRIPTION
Recently released shellcheck 0.9.0 adds a new check:
```
SC2317 (info): Command appears to be unreachable. Check usage (or
ignore if invoked indirectly).
```

Fix the one instance of this that is causing the CI to now fail with the updated version of shellcheck.

Refs: https://github.com/koalaman/shellcheck/commit/642ad8612597b28af4026bde289985583fddb69d