### PR TITLE
ansible: update IP addresses for "joyent" machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -167,7 +167,7 @@ hosts:
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
         ubuntu1804-x64-2: {ip: 50.97.245.9}
 
-    - joyent:
+    - equinix_mnx:
         smartos18-x64-3: {ip: 147.28.162.102}
         smartos18-x64-4: {ip: 147.28.162.103}
         smartos20-x64-3: {ip: 147.28.162.107}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -21,9 +21,9 @@ hosts:
         ubuntu2004-x64-1: {ip: 169.60.150.91, alias: ansible}
 
     - joyent:
-        debian10-x64-1: {ip: 147.75.88.62, alias: grafana}
-        smartos15-x64-1: {ip: 139.178.83.227, alias: backup}
-        ubuntu1604-x64-1: {ip: 147.75.88.57, alias: unencrypted}
+        debian10-x64-1: {ip: 147.28.162.110, alias: grafana}
+        smartos15-x64-1: {ip: 147.28.183.83, alias: backup}
+        ubuntu1604-x64-1: {ip: 147.28.162.105, alias: unencrypted}
 
     - rackspace:
         debian8-x64-1: {ip: 23.253.100.79, alias: gh-bot}
@@ -51,9 +51,9 @@ hosts:
         ibmi73-ppc64_be-1: {ip: 65.183.160.62, user: nodejs}
 
     - joyent:
-        smartos18-x64-2: {ip: 147.75.88.53}
-        smartos20-x64-2: {ip: 147.75.88.60}
-        ubuntu1804_docker-x64-1: {ip: 147.75.88.56, user: ubuntu}
+        smartos18-x64-2: {ip: 147.28.162.101}
+        smartos20-x64-2: {ip: 147.28.162.108}
+        ubuntu1804_docker-x64-1: {ip: 147.28.162.104, user: ubuntu}
 
     - macstadium:
         macos11.0-arm64-1:
@@ -168,11 +168,11 @@ hosts:
         ubuntu1804-x64-2: {ip: 50.97.245.9}
 
     - joyent:
-        smartos18-x64-3: {ip: 147.75.88.54}
-        smartos18-x64-4: {ip: 147.75.88.55}
-        smartos20-x64-3: {ip: 147.75.88.59}
-        smartos20-x64-4: {ip: 147.75.88.61}
-        ubuntu1804-x64-1: {ip: 147.75.88.51, user: ubuntu}
+        smartos18-x64-3: {ip: 147.28.162.102}
+        smartos18-x64-4: {ip: 147.28.162.103}
+        smartos20-x64-3: {ip: 147.28.162.107}
+        smartos20-x64-4: {ip: 147.28.162.109}
+        ubuntu1804-x64-1: {ip: 147.28.162.99, user: ubuntu}
 
     - macstadium:
         macos11.0-arm64-3:


### PR DESCRIPTION
Updates "joyent" labeled machines with their updated IP addresses.

Refs: https://github.com/nodejs/build/issues/3108

Also renames the test machines with new label "equinix_mnx" to more accurately reflect where they are now hosted. We'll need to rename the release and infra machines too but I won't have time to do that this year.

---

Currently re-ansibling machines to pick up the name change (this list has the old names):
- [x] test-joyent-smartos18-x64-3
- [x] test-joyent-smartos18-x64-4
- [x] test-joyent-smartos20-x64-3
- [x] test-joyent-smartos20-x64-4
- [x] test-joyent-ubuntu1804-x64-1