### PR TITLE
ansible: update install-homebrew script

### DIFF
--- a/ansible/roles/package-upgrade/files/install-homebrew.sh
+++ b/ansible/roles/package-upgrade/files/install-homebrew.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install)"
+yes | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
The Ruby Homebrew installer is now disabled.

See https://raw.githubusercontent.com/Homebrew/install/HEAD/install

```
#!/usr/bin/ruby

abort <<EOS
Error: The Ruby Homebrew installer is now disabled and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

EOS
```