### PR TITLE
fix: deprecation errors in macos 10.x

### DIFF
--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -41,19 +41,9 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    when: 
+    ignore_errors: 
       - os == "macos10.15" 
       - os == "macos10.14"
-    ignore_errors: true
-
-
-  - name: Upgrade installed packages
-    become_user: "{{ ansible_user }}"
-    homebrew:
-      upgrade_all: yes
-    when: 
-      - os != "macos10.15" 
-      - os != "macos10.14"   
 
   - name: Install brew cu
     become_user: "{{ ansible_user }}"

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -41,7 +41,9 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    when: os == "macos10.15" || os == "macos10.14"
+    when: 
+      - os == "macos10.15" 
+      - os == "macos10.14"
     ignore_errors: true
 
 
@@ -49,7 +51,9 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    when: os != "macos10.15" || os != "macos10.14"   
+    when: 
+      - os != "macos10.15" 
+      - os != "macos10.14"   
 
   - name: Install brew cu
     become_user: "{{ ansible_user }}"

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -41,9 +41,7 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    ignore_errors: 
-      - os == "macos10.15" 
-      - os == "macos10.14"
+    ignore_errors: os == "macos10.15" or os == "macos10.14"
 
   - name: Install brew cu
     become_user: "{{ ansible_user }}"

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -36,10 +36,20 @@
     script: files/install-homebrew.sh
     when: os == "macos11.0" and not armbrew.stat.exists
 
+  # Ignoring deprecation errors in MacOS 10.x
+  - name: Upgrade installed packages 
+    become_user: "{{ ansible_user }}"
+    homebrew:
+      upgrade_all: yes
+    when: os != "macos11.0"
+    ignore_errors: true
+
+
   - name: Upgrade installed packages
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
+    when: os == "macos11.0"    
 
   - name: Install brew cu
     become_user: "{{ ansible_user }}"

--- a/ansible/roles/package-upgrade/tasks/partials/brew.yml
+++ b/ansible/roles/package-upgrade/tasks/partials/brew.yml
@@ -41,7 +41,7 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    when: os != "macos11.0"
+    when: os == "macos10.15" || os == "macos10.14"
     ignore_errors: true
 
 
@@ -49,7 +49,7 @@
     become_user: "{{ ansible_user }}"
     homebrew:
       upgrade_all: yes
-    when: os == "macos11.0"    
+    when: os != "macos10.15" || os != "macos10.14"   
 
   - name: Install brew cu
     become_user: "{{ ansible_user }}"


### PR DESCRIPTION
### Main changes:

Duplicated brew Upgrade installed packages step in order to allow failure due deprecation (`You are using macOS 10.14.\nWe (and Apple) do not provide support for this old version.`) in macos10.x but keep macos11 the same

### Context: 
- Fix https://github.com/nodejs/build/issues/3119#issuecomment-1359162400

### Notes

I am not sure if there is a more elegant way to condition `ignore_errors` rather than duplicate tasks 😅