### PR TITLE
meta: add Stefan Stojanovic to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ to the resources we manage.
 - [@richardlau](https://github.com/richardlau) - Richard Lau
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 - [@Starefossen](https://github.com/Starefossen) - Hans Kristian Flaatten
+- [@StefanStojanovic](https://github.com/StefanStojanovic) - Stefan Stojanovic
 - [@sxa](https://github.com/sxa) - Stewart X Addison
 - [@targos](https://github.com/targos) - Michaël Zasso
 - [@Trott](https://github.com/Trott) - Rich Trott


### PR DESCRIPTION
I would like to add Stefan Stojanović (@StefanStojanovic) to the Build WG, giving him test level access. I can handle any task that requires higher access for now.

Stefan has been working with me on Node.js, focusing on Windows, and he has more bandwidth than I've had recently. I will help him ramp up and would we're aiming to have him increasingly help more.

He'll start by creating a small guide on how to provision a Windows machine for testing, to unblock https://github.com/nodejs/build/issues/3137 and allow other people to do it as well.

