### PR TITLE
ansible: update V8 builders to Python 3.9

### DIFF
--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
@@ -5,9 +5,10 @@
 #
 
 # V8 builds still require Python 2.
+# Newer V8 builds require Python 3.8, or later.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['glib2-devel', 'python2', 'python2-pip']
+    name: ['glib2-devel', 'python2', 'python2-pip', 'python39']
     state: present
   notify: package updated
 
@@ -16,6 +17,12 @@
     link: /usr/bin/python
     name: python
     path: /usr/bin/python2
+
+- name: update python3 package alternatives
+  community.general.alternatives:
+    link: /usr/bin/python3
+    name: python3
+    path: /usr/bin/python3.9
 
 - name: install dependencies for V8 build tools (Python 2)
   ansible.builtin.pip:

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
@@ -4,10 +4,11 @@
 # Install packages for V8 builds.
 #
 
-# V8 builds still require Python 2.
+# Older V8 builds still require Python 2.
+# Newer V8 builds require Python 3.8, or later.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['GConf2-devel', 'python2', 'python2-pip', 'python3-httplib2']
+    name: ['GConf2-devel', 'python2', 'python2-pip', 'python39', 'python3-httplib2']
     state: present
   notify: package updated
 
@@ -16,6 +17,12 @@
     link: /usr/bin/python
     name: python
     path: /usr/bin/python2
+
+- name: update python3 package alternatives
+  community.general.alternatives:
+    link: /usr/bin/python3
+    name: python3
+    path: /usr/bin/python3.9
 
 # RHEL 8 doesn't have a package for httplib2 for Python 2 so install via pip.
 - name: install httplib2

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
@@ -5,9 +5,10 @@
 #
 
 # V8 builds still require Python 2.
+# Newer V8 builds require Python 3.8, or later.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['python2', 'python2-pip']
+    name: ['python2', 'python2-pip', 'python39']
     state: present
   notify: package updated
 
@@ -16,6 +17,12 @@
     link: /usr/bin/python
     name: python
     path: /usr/bin/python2
+
+- name: update python3 package alternatives
+  community.general.alternatives:
+    link: /usr/bin/python3
+    name: python3
+    path: /usr/bin/python3.9
 
 - name: install dependencies for V8 build tools (Python 2)
   ansible.builtin.pip:


### PR DESCRIPTION
Recent upstream V8 changes now require at least Python 3.8 to run the V8 test runner.

Refs: https://github.com/nodejs/node-v8/issues/244#issuecomment-1401830840
Refs: https://chromium-review.googlesource.com/c/v8/v8/+/4181030

---

I've deployed this onto all of the RHEL 8 ppc64le, s390x and x64 test machines. (We don't currently run the V8 CI on the RHEL8 x64 machines because the builds on those take a lot longer than on the Nearform-hosted Intel machine(s).)