### PR TITLE
Fix update of release CI worker jar

### DIFF
--- a/ansible/group_vars/release.yml
+++ b/ansible/group_vars/release.yml
@@ -1,6 +1,5 @@
 jenkins_url: "https://ci-release.nodejs.org"
-# intentionally fetching `slave.jar` from ci.nodejs.org to avoid auth problems
-jenkins_worker_jar: "https://ci.nodejs.org/jnlpJars/slave.jar"
+jenkins_worker_jar: "{{ jenkins_url }}/jnlpJars/slave.jar"
 jenkins_icon: "https://ci.nodejs.org/favicon.ico"
 server_user: "iojs"
 home: "/home"

--- a/ansible/playbooks/jenkins/worker/upgrade-jar.yml
+++ b/ansible/playbooks/jenkins/worker/upgrade-jar.yml
@@ -4,7 +4,9 @@
 # upgrade `slave.jar` at jenkins workers
 #
 
--  hosts: test
+-  hosts:
+    - test
+    - release
 
    tasks:
     - name: download slave.jar


### PR DESCRIPTION
- jenkins: download release worker jar from ci-release
- jenkins: allow to upgrade jar of release CI workers
