### PR TITLE
Feat: Added Orka release machine macos11

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -94,6 +94,11 @@ hosts:
             ip: 199.7.167.101
             port: 8825
             user: administrator
+        macos11-x64-1:
+            ansible_python_interpreter: /usr/bin/python3
+            ip: 199.7.167.100
+            port: 8822
+            user: administrator
 
     - requireio:
         rvagg-debian10-armv6l_pi1p-1: {ip: 192.168.2.40, user: pi, alias: iojs-ns-pi1p-1 }


### PR DESCRIPTION
### Main changes

Added machine release-orka-macos11-x64-1 (995678ca6ef769619694f859bb4692e52246a161) with base image: `macos11-x64-1_11012023`. This base image is a backup from `test-orka-macos1014-x64-1` [Full context](https://github.com/nodejs/build/issues/3112#issuecomment-1378632482)

### Context
This PR is related to https://github.com/nodejs/build/issues/3179#issuecomment-1421125920

### Pending Actions

I can't perform the following actions, as release access required
- [ ] re-ansible the machine
- [ ] We need to include the machine in the `build/infra/inventory.yml` in the secrets repo.