### PR TITLE
Chore: IP replacement for macstadium release arm machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -58,7 +58,7 @@ hosts:
     - macstadium:
         macos11.0-arm64-1:
             ansible_python_interpreter: /usr/bin/python3
-            ip: 207.254.38.74
+            ip: 207.254.55.235
             user: administrator
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin


### PR DESCRIPTION
### Main changes

- There is a new machine with IP `207.254.55.235` that replace the IP `207.254.38.74`, but the machine keeps the same name `release-macstadium-macos11.0-arm64-1`
- The new machine has a different hardware `AS/M1/8C/16G/1T/SSD/10G` with product reference `Mac mini G5K`. The old machine has the hardware `AS/M1/8C/8G/256G/SSD/1G` with product reference `Mac mini G5A`

### Context
- Related to https://github.com/nodejs/build/issues/3179#issuecomment-1421499359


### Pending Actions

I can't perform the following actions, as release access required
- [ ] re-ansible the machine
- [ ] We need to include the machine in the `build/infra/inventory.yml` in the secrets repo.


