### PR TITLE
IP replacement for test-macstadium-macos11.0-arm64-4

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -183,7 +183,7 @@ hosts:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin
         macos11.0-arm64-4:
             ansible_python_interpreter: /usr/bin/python3
-            ip: 207.254.38.89
+            ip: 207.254.55.248
             user: administrator
             remote_env:
                 PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin


### PR DESCRIPTION
### Main changes

- There is a new machine with IP `207.254.55.248` that replace the IP `207.254.38.89`, but the machine keeps the same name `test-macstadium-macos11.0-arm64-4`
- The new machine has a different hardware `AS/M1/8C/16G/256G/SSD/10G` with product reference `Mac mini G5J`. The old machine has the hardware `AS/M1/8C/8G/256G/SSD/1G` with product reference `Mac mini G5A`

### Context
- Related to https://github.com/nodejs/build/issues/3179#issuecomment-1421499359
- Related to https://github.com/nodejs/build/issues/3084

### Pending Actions

- [ ] Ensure that the machine is online and available in the network (current status: waiting for provision)
- [ ] re-ansible the machine
- [ ] Include the machine in the `build/test/inventory.yml` in the secrets repo.
- [ ] Check the machine in Jenkins (current status: blocked by #3186)