### PR TITLE
ansible: add lib as application/octet-stream type

### DIFF
--- a/ansible/www-standalone/tasks/nginx.yaml
+++ b/ansible/www-standalone/tasks/nginx.yaml
@@ -84,6 +84,7 @@
     line: '{{ item }}'
     insertafter: '^types.*'
   with_items:
+    - 'application/octet-stream lib;'
     - 'application/octet-stream pkg;'
     - 'application/x-xz xz;'
     - 'application/gzip gz;'


### PR DESCRIPTION
Serve `.lib` files with `application/octet-stream` content-type.

Refs: https://github.com/nodejs/build/issues/3194