### PR TITLE
www: create script to free space by removing old builds

### DIFF
--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Node.js www server space pruning script.
+# Runs against a subdirectory of /home/dist/nodejs and removes old builds:
+# - For anything over 2 calendar years ago, retain only the build dated first of the month
+# - For anything in last 2 calendar years but not the last two months, retain date numbers ending in 1
+# - Keep everything from the last two months.
+#
+
+[ $# -lt 2 ] && echo Usage: $0 '[nightly|v8-canary]' '[show|delete]' && exit 1
+PRODUCT=$1
+[ "$1" != "nightly" -a "$1" != "v8-canary" ] && echo Parameter mist be one of: nightly v8-canary && exit 1
+if [ "$2" = "show" ]; then
+  RMCOMMAND="echo rm -rv"
+elif [ "$2" = "delete" ]; then
+  RMCOMMAND="rm -rv"
+else
+  echo Second parameter must be \"show\" or \"delete\"
+  exit 1
+fi
+# Location to start the search for candidates for removal
+cd "/home/dist/nodejs/$PRODUCT" || exit 1
+
+THISYEAR=`date +%Y`
+LASTYEAR=`date --date="1 year ago" +%Y`
+THISMONTH=`date +%Y%m`
+LASTMONTH=`date --date="1 month ago" +%Y%m`
+case $PRODUCT in
+	v8-canary) STARTVERSION=9;;
+	nightly) STARTVERSION=5;;
+esac
+for VERSION in `seq $STARTVERSION 20`; do
+
+   # Determine the latest nightly for this version so it is never removed
+   LATEST=`ls -1d v${VERSION}.* | tail -1`
+   [ -z "$LATEST" -o ! -d "$LATEST" ] && echo Could not validate latest version "$LATEST" for Node v${VERSION} && exit 1
+
+   # Versions that aren't from the last two calendar years - keep 1st of the month
+   SELECTED=`ls -1d v${VERSION}.* | egrep -v "${PRODUCT}$THISYEAR|${PRODUCT}$LASTYEAR" | grep -v ${PRODUCT}20....01 | grep -v "${LATEST}"`
+   SELECTEDCOUNT=`echo $SELECTED | wc -w`
+   echo V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from two calendar years ago
+   if [ $SELECTEDCOUNT -ne 0 ]; then
+     ${RMCOMMAND} $SELECTED
+   fi
+
+   # Versions from the last two calendar years except last two months
+   # Keep every date number ending in 1 (So 01 11 21 31)
+   SELECTED=`ls -1d v${VERSION}.* | egrep    "${PRODUCT}$THISYEAR|${PRODUCT}$LASTYEAR" | egrep -v "${PRODUCT}${THISMONTH}|${PRODUCT}${LASTMONTH}" | grep -v ${PRODUCT}20.....1 | grep -v "${LATEST}"`
+   SELECTEDCOUNT=`echo $SELECTED | wc -w`
+   echo V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from the last two calendar years
+   if [ $SELECTEDCOUNT -ne 0 ]; then
+     ${RMCOMMAND} ${SELECTED}
+   fi
+done
+

--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -33,7 +33,7 @@ for VERSION in `seq $STARTVERSION 20`; do
 
    # Determine the latest nightly for this version so it is never removed
    LATEST=`ls -1d v${VERSION}.* | tail -1`
-   [ -z "$LATEST" -o ! -d "$LATEST" ] && echo Could not validate latest version "$LATEST" for Node v${VERSION} && exit 1
+   [ -z "$LATEST" -o ! -d "$LATEST" ] && echo "Could not validate latest version ${LATEST} for Node v${VERSION}" && exit 1
 
    # Versions that aren't from the last two calendar years - keep 1st of the month
    SELECTED=`ls -1d v${VERSION}.* | egrep -v "${PRODUCT}${THISYEAR}|${PRODUCT}${LASTYEAR}" | grep -v ${PRODUCT}20....01 | grep -v "${LATEST}"`

--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -8,8 +8,8 @@
 #
 
 [ $# -lt 2 ] && echo Usage: $0 '[nightly|v8-canary]' '[show|delete]' && exit 1
-PRODUCT=$1
 [ "$1" != "nightly" -a "$1" != "v8-canary" ] && echo Parameter mist be one of: nightly v8-canary && exit 1
+PRODUCT=$1
 if [ "$2" = "show" ]; then
   RMCOMMAND="echo rm -rv"
 elif [ "$2" = "delete" ]; then

--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -21,10 +21,10 @@ fi
 # Location to start the search for candidates for removal
 cd "/home/dist/nodejs/$PRODUCT" || exit 1
 
-THISYEAR=`date +%Y`
-LASTYEAR=`date --date="1 year ago" +%Y`
-THISMONTH=`date +%Y%m`
-LASTMONTH=`date --date="1 month ago" +%Y%m`
+THISYEAR=`date -u +%Y`
+LASTYEAR=`date -u --date="1 year ago" +%Y`
+THISMONTH=`date -u +%Y%m`
+LASTMONTH=`date -u --date="1 month ago" +%Y%m`
 case $PRODUCT in
 	v8-canary) STARTVERSION=9;;
 	nightly) STARTVERSION=5;;

--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -36,7 +36,7 @@ for VERSION in `seq $STARTVERSION 20`; do
    [ -z "$LATEST" -o ! -d "$LATEST" ] && echo Could not validate latest version "$LATEST" for Node v${VERSION} && exit 1
 
    # Versions that aren't from the last two calendar years - keep 1st of the month
-   SELECTED=`ls -1d v${VERSION}.* | egrep -v "${PRODUCT}$THISYEAR|${PRODUCT}$LASTYEAR" | grep -v ${PRODUCT}20....01 | grep -v "${LATEST}"`
+   SELECTED=`ls -1d v${VERSION}.* | egrep -v "${PRODUCT}${THISYEAR}|${PRODUCT}${LASTYEAR}" | grep -v ${PRODUCT}20....01 | grep -v "${LATEST}"`
    SELECTEDCOUNT=`echo $SELECTED | wc -w`
    echo V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from two calendar years ago
    if [ $SELECTEDCOUNT -ne 0 ]; then

--- a/tools/wwwspace/prune.sh
+++ b/tools/wwwspace/prune.sh
@@ -7,15 +7,15 @@
 # - Keep everything from the last two months.
 #
 
-[ $# -lt 2 ] && echo Usage: $0 '[nightly|v8-canary]' '[show|delete]' && exit 1
+[ $# -lt 2 ] && echo Usage: $0 '[nightly|v8-canary]' '[dry-run|delete]' && exit 1
 [ "$1" != "nightly" -a "$1" != "v8-canary" ] && echo Parameter mist be one of: nightly v8-canary && exit 1
 PRODUCT=$1
-if [ "$2" = "show" ]; then
+if [ "$2" = "dry-run" ]; then
   RMCOMMAND="echo rm -rv"
 elif [ "$2" = "delete" ]; then
   RMCOMMAND="rm -rv"
 else
-  echo Second parameter must be \"show\" or \"delete\"
+  echo "Second parameter must be \"dry-run\" or \"delete\""
   exit 1
 fi
 # Location to start the search for candidates for removal
@@ -38,7 +38,7 @@ for VERSION in `seq $STARTVERSION 20`; do
    # Versions that aren't from the last two calendar years - keep 1st of the month
    SELECTED=`ls -1d v${VERSION}.* | egrep -v "${PRODUCT}${THISYEAR}|${PRODUCT}${LASTYEAR}" | grep -v ${PRODUCT}20....01 | grep -v "${LATEST}"`
    SELECTEDCOUNT=`echo $SELECTED | wc -w`
-   echo V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from two calendar years ago
+   echo "V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from two calendar years ago"
    if [ $SELECTEDCOUNT -ne 0 ]; then
      ${RMCOMMAND} $SELECTED
    fi
@@ -46,8 +46,8 @@ for VERSION in `seq $STARTVERSION 20`; do
    # Versions from the last two calendar years except last two months
    # Keep every date number ending in 1 (So 01 11 21 31)
    SELECTED=`ls -1d v${VERSION}.* | egrep    "${PRODUCT}$THISYEAR|${PRODUCT}$LASTYEAR" | egrep -v "${PRODUCT}${THISMONTH}|${PRODUCT}${LASTMONTH}" | grep -v ${PRODUCT}20.....1 | grep -v "${LATEST}"`
-   SELECTEDCOUNT=`echo $SELECTED | wc -w`
-   echo V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from the last two calendar years
+   SELECTEDCOUNT=`echo "$SELECTED" | wc -w`
+   echo "V$VERSION: Selected $SELECTEDCOUNT of `ls -1d v${VERSION}.* | wc -l` from the last two calendar years"
    if [ $SELECTEDCOUNT -ne 0 ]; then
      ${RMCOMMAND} ${SELECTED}
    fi


### PR DESCRIPTION
Script as described in https://github.com/nodejs/build/issues/3125

This is the script which will clear up the nightlies and v8-canary directories so they do not constantly increase the disk space. If we are happy with this logic we can determine how to run it - either
- As a part of the release process before or after copying new builds there
- Via a regular cron job
- Something else?