### PR TITLE
Windows ansible updates

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -108,6 +108,12 @@ hosts:
         msft-win10_vs2019-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
         msft-win10_vs2019-x64-3: {ip: nodejs.australiaeast.cloudapp.azure.com}
         msft-win10_vs2019-x64-4: {ip: nodejs2.eastus.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-1: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-2: {ip: nodejs2.eastus.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-3: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-4: {ip: nodejs2.eastus.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-5: {ip: nodejs.westeurope.cloudapp.azure.com}
+        msft-win11_vs2019-arm64-6: {ip: nodejs2.eastus.cloudapp.azure.com}
         msft-win2016_vs2017-x64-1: {ip: nodejs.westeurope.cloudapp.azure.com}
         msft-win2016_vs2017-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
         msft-win2016_vs2017-x64-3: {ip: nodejs.australiaeast.cloudapp.azure.com}

--- a/ansible/roles/bootstrap/tasks/partials/win.yml
+++ b/ansible/roles/bootstrap/tasks/partials/win.yml
@@ -46,3 +46,17 @@
       name: Enabled
       data: 0
       type: dword
+
+- block:
+  - name: disable Let's Finish Setting up Your Device screen
+    win_regedit:
+      path: 'HKCU:\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement'
+      name: ScoobeSystemSettingEnabled
+      data: 0
+      type: dword
+  - name: disable Windows Welcome Experience
+    win_regedit:
+      path: 'HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
+      name: SubscribedContent-310093Enabled
+      data: 0
+      type: dword

--- a/ansible/roles/visual-studio/tasks/partials/vs2019.yml
+++ b/ansible/roles/visual-studio/tasks/partials/vs2019.yml
@@ -8,10 +8,11 @@
 - name: install Visual Studio Community 2019
   win_chocolatey: name=visualstudio2019community
 
+# Note: The .NET SDK was added as a prerequisite for WiX4 - https://github.com/nodejs/node/pull/45943
 - name: install Visual Studio Community 2019 Native Desktop Workload
   win_chocolatey:
       name: visualstudio2019-workload-nativedesktop
-      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64'
+      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK'
 
 - name: install WiX Toolset
   import_tasks: 'wixtoolset.yml'


### PR DESCRIPTION
This PR contains a few changes for Windows machines in the CI:

- We've noticed there were problems running ansible against RackSpace Windows test machines. @joaocgreis investigated and fixed that. He also updated the manual steps guide so others do not run into this same issue.
- This PR also adds Windows 11 ARM64 machines to the inventory. This is a follow on PR for https://github.com/nodejs-private/secrets/pull/246 which already updated the secrets repo.
- Non-server Windows versions eg. Windows 10 and 11, are showing a **finish setting up device** screen after rebooting occasionally, and this was leaving newly added Windows 11 ARM64 machines offline after running [windows-update-reboot](https://ci.nodejs.org/view/All/job/windows-update-reboot/). That behavior is disabled now, and this is already deployed to the machines that needed the fix.
- .NET SDK is now installed in addition to the Native Desktop Workload. This is a prerequisite for landing a migration to WiX4 PR https://github.com/nodejs/node/pull/45943. This is already deployed to the Rackspace Win2012r2 VS2019 machines used for compilation and the PR was compiled successfully after that https://ci.nodejs.org/job/node-test-commit-windows-fanned/53615/. The plan is to update other VS2019 machines in CI after this PR lands.