### PR TITLE
chore(nginx): improve try_files, fix rewrites, increase file cache

### DIFF
--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -172,8 +172,6 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
-
-        try_files $uri =404;
     }
 
     location ^~ /documentation {

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -28,7 +28,7 @@ server {
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
 
-    error_page 404 = /404.html;
+    error_page 404 /404.html;
 
     location ~ ^/(?!(dist/|dist$|\.json$)) {
         rewrite ^ https://$host$uri permanent;
@@ -90,7 +90,7 @@ server {
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
 
-    error_page 404 = @localized_404;
+    error_page 404 @localized_404;
 
     location = / {
         rewrite ^ /en break;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -12,6 +12,7 @@ server {
 
     keepalive_timeout 60;
     server_tokens off;
+    log_not_found off;
     
     gzip on;
     gzip_static on;
@@ -66,6 +67,7 @@ server {
 
     keepalive_timeout 60;
     server_tokens off;
+    log_not_found off;
 
     resolver 8.8.4.4 8.8.8.8 valid=300s;
     resolver_timeout 10s;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -179,6 +179,7 @@ server {
 
     location ^~ /metrics {
         alias /home/dist/metrics;
+        autoindex on;
         default_type text/plain;
     }
     

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -56,8 +56,6 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
-        
-        try_files $uri $uri/ =404;
     }
 }
 
@@ -135,12 +133,6 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
-        
-        try_files $uri $uri/ =404;
-    }
-
-    location ^~ /documentation {
-        rewrite ^/documentation/api(.*)$ /api$1 redirect;
     }
 
     location ^~ /download {
@@ -158,8 +150,6 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
-
-        try_files $uri $uri/ =404;
     }
 
     location ^~ /docs {
@@ -170,8 +160,6 @@ server {
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
-
-        try_files $uri $uri/ =404;
     }
 
     location ^~ /api {
@@ -184,12 +172,14 @@ server {
 
         try_files $uri =404;
     }
+    
+    location ^~ /documentation {
+        rewrite ^/documentation/api(.*)$ /api$1 redirect;
+    }
 
     location ^~ /metrics {
         alias /home/dist/metrics;
         default_type text/plain;
-        
-        try_files $uri =404;
     }
     
     location = /github-webhook.log {

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -205,7 +205,13 @@ server {
         # If this was a rewritten i18n request from @english_fallback, use the localized 404
         # Otherwise, fallback to the English 404 file
         try_files /$lang/404.html /en/404.html =404;
-    } 
+    }
+
+    location = /traffic-manager {
+        access_log off;
+
+        return 204;
+    }
 
     rewrite ^/.well-known/security.txt$                           https://$server_name/security.txt last;
 

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -136,7 +136,7 @@ server {
             add_header access-control-allow-origin *;
         }
         
-        try_files $uri =404;
+        try_files $uri $uri/ =404;
     }
 
     location ^~ /documentation {
@@ -151,13 +151,15 @@ server {
         alias /home/dist/nodejs;
         autoindex on;
         default_type text/plain;
+        open_file_cache_errors on;
+
         add_header X-Robots-Tag noindex;
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
         }
 
-        try_files $uri =404;
+        try_files $uri $uri/ =404;
     }
 
     location ^~ /docs {
@@ -169,12 +171,11 @@ server {
             add_header access-control-allow-origin *;
         }
 
-        try_files $uri =404;
+        try_files $uri $uri/ =404;
     }
 
     location ^~ /api {
         alias /home/dist/nodejs/docs/latest/api;
-        autoindex on;
         default_type text/plain;
 
         location ~ \.json$ {
@@ -186,7 +187,6 @@ server {
 
     location ^~ /metrics {
         alias /home/dist/metrics;
-        autoindex on;
         default_type text/plain;
         
         try_files $uri =404;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -97,8 +97,6 @@ server {
     }
 
     location / {
-        error_page 404 = @localized_404;
-
         rewrite ^/(.*)/$ /$1 permanent;
 
         try_files $uri $uri.html @english_fallback;
@@ -167,8 +165,6 @@ server {
     }
 
     location ^~ /api {
-        error_page 404 = @localized_404;
-
         alias /home/dist/nodejs/docs/latest/api;
         default_type text/plain;
 

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -80,7 +80,7 @@ server {
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/javascript text/xml application/xml application/xml+rss image/svg+xml;
     
-    open_file_cache max=10000 inactive=300s;
+    open_file_cache max=100000 inactive=300s;
     open_file_cache_valid 120s;
     open_file_cache_min_uses 2;
     open_file_cache_errors off;
@@ -99,7 +99,7 @@ server {
     location / {
         rewrite ^/(.*)/$ /$1 permanent;
 
-        try_files $uri $uri.html $uri/ @english_fallback;
+        try_files $uri $uri.html @english_fallback;
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
@@ -136,10 +136,10 @@ server {
             add_header access-control-allow-origin *;
         }
         
-        try_files $uri $uri/ =404;
+        try_files $uri =404;
     }
 
-    location ^~ /documentation/ {
+    location ^~ /documentation {
         rewrite ^/documentation/api(.*)$ /api$1 redirect;
     }
 
@@ -157,7 +157,7 @@ server {
             add_header access-control-allow-origin *;
         }
 
-        try_files $uri $uri/ =404;
+        try_files $uri =404;
     }
 
     location ^~ /docs {
@@ -169,7 +169,7 @@ server {
             add_header access-control-allow-origin *;
         }
 
-        try_files $uri $uri/ =404;
+        try_files $uri =404;
     }
 
     location ^~ /api {
@@ -181,7 +181,7 @@ server {
             add_header access-control-allow-origin *;
         }
 
-        try_files $uri $uri/ =404;
+        try_files $uri =404;
     }
 
     location ^~ /metrics {
@@ -189,7 +189,7 @@ server {
         autoindex on;
         default_type text/plain;
         
-        try_files $uri $uri/ =404;
+        try_files $uri =404;
     }
     
     location = /github-webhook.log {
@@ -215,18 +215,19 @@ server {
         try_files /$lang/404.html /en/404.html =404;
     } 
 
-    rewrite ^/.well-known/security.txt$                           https://$server_name/security.txt permanent;
+    rewrite ^/.well-known/security.txt$                           https://$server_name/security.txt last;
+
     rewrite ^/about/security/?$                                   https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security permanent;
-    rewrite ^/contribute/?$                                       https://$server_name/en/get-involved/ permanent;
+    rewrite ^/contribute/?$                                       https://$server_name/en/get-involved permanent;
     rewrite ^/contribute/accepting_contributions.html$            https://github.com/nodejs/dev-policy permanent;
     
     # @todo: use next.js to do these rewrites
     # it might require special rewriting to let next.js handle the rewrites instead of nginx
-    rewrite ^/contribute/becoming_collaborator.html$              https://$server_name/en/get-involved/ permanent;
-    rewrite ^/contribute/code_contributions/?$                    https://$server_name/en/get-involved/ permanent;
-    rewrite ^/contribute/code_contributions/workflow.html$        https://$server_name/en/get-involved/ permanent;
-    rewrite ^/documentation(.*)$                                  https://$server_name/en/docs/ permanent;
-    rewrite ^/foundation/blog.html$                               https://$server_name/en/blog/ permanent;
+    rewrite ^/contribute/becoming_collaborator.html$              https://$server_name/en/get-involved permanent;
+    rewrite ^/contribute/code_contributions/?$                    https://$server_name/en/get-involved permanent;
+    rewrite ^/contribute/code_contributions/workflow.html$        https://$server_name/en/get-involved permanent;
+    rewrite ^/documentation(.*)$                                  https://$server_name/en/docs permanent;
+    rewrite ^/foundation/blog.html$                               https://$server_name/en/blog permanent;
     rewrite ^/images/foundation-visual-guidelines.pdf$            https://$server_name/static/documents/foundation-visual-guidelines.pdf permanent;
     rewrite ^/images/logos/js-black(.*)$                          https://$server_name/static/images/logos/js-black$1 permanent;
     rewrite ^/images/logos/nodejs-(.*)$                           https://$server_name/static/images/logos/nodejs-$1 permanent;
@@ -235,20 +236,20 @@ server {
     rewrite ^/video(.*)$                                          https://$server_name/static/video$1 permanent;
     rewrite ^/changelog.html$                                     https://github.com/nodejs/node/blob/HEAD/CHANGELOG.md permanent;
     rewrite ^/api.html$                                           https://$server_name/api/ permanent;
-    rewrite ^/index.html$                                         https://$server_name/ permanent;
+    rewrite ^/index.html$                                         https://$server_name/en permanent;
 
     rewrite ^/(20\d\d/\d\d/\d\d/.*)$                              https://nodejs.org/en/blog/$1 permanent;
 
     # @todo: use next.js to do these rewrites
     # it might require special rewriting to let next.js handle the rewrites instead of nginx
-    rewrite ^/about/?$                                            https://$server_name/en/about/ permanent;
+    rewrite ^/about/?$                                            https://$server_name/en/about permanent;
     rewrite ^/about/releases/?$                                   https://github.com/nodejs/release#release-schedule permanent;
     rewrite ^/en/about/releases/?$                                https://github.com/nodejs/release#release-schedule permanent;
-    rewrite ^/about/resources/?$                                  https://$server_name/en/about/resources/ permanent;
+    rewrite ^/about/resources/?$                                  https://$server_name/en/about/resources permanent;
     rewrite ^/about/security/?$                                   https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security permanent;
-    rewrite ^/about/trademark/?$                                  https://$server_name/en/about/trademark/ permanent;
-    rewrite ^/blog/?$                                             https://$server_name/en/blog/ permanent;
-    rewrite ^/community/?$                                        https://$server_name/en/get-involved/ permanent;
+    rewrite ^/about/trademark/?$                                  https://$server_name/en/about/trademark permanent;
+    rewrite ^/blog/?$                                             https://$server_name/en/blog permanent;
+    rewrite ^/community/?$                                        https://$server_name/en/get-involved permanent;
     rewrite ^/en/security                                         https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security permanent;
     rewrite ^/en/docs/inspector/?$                                https://$server_name/en/docs/guides/debugging-getting-started/ permanent;
 
@@ -262,9 +263,9 @@ server {
     # Asset rewrites
     # @todo: rewrite the /static/ folder to / (as the /public/ folder is automatically indexed by next.js)
     rewrite ^/layouts/css/styles\.css$                            https://$server_name/static/css/styles.css permanent;
-    rewrite ^/(static/)?favicon\.ico$                             https://$server_name/static/images/favicons/favicon.ico permanent;
-    rewrite ^/(static/)?favicon\.png$                             https://$server_name/static/images/favicons/favicon-32x32.png permanent;
-    rewrite ^/(static/)?apple-touch-icon.*\.png$                  https://$server_name/static/images/favicons/apple-touch-icon.png permanent;
+    rewrite ^/(static/)?favicon\.ico$                             https://$server_name/static/images/favicons/favicon.png permanent;
+    rewrite ^/(static/)?favicon\.png$                             https://$server_name/static/images/favicons/favicon.png permanent;
+    rewrite ^/(static/)?apple-touch-icon.*\.png$                  https://$server_name/static/images/favicons/favicon.png permanent;
     rewrite ^/trademark-policy.pdf$                               https://$server_name/static/documents/trademark-policy.pdf permanent;
 
     # @todo: rewrite the /static/ folder to / (as the /public/ folder is automatically indexed by next.js)
@@ -355,7 +356,7 @@ server {
     listen *:443 ssl http2;
     server_name doc.nodejs.org docs.nodejs.org;
 
-    return 301 https://nodejs.org/en/docs/;
+    return 301 https://nodejs.org/en/docs;
 }
 
 server {
@@ -393,52 +394,52 @@ server {
     listen *:443 ssl http2;
     server_name blog.nodejs.org;
 
-    rewrite ^/\d+/\d+/\d+/(?:node-v(?:ersion-)?|version-)(\d+)[-\.](\d+)[-\.](\d+).*$ https://nodejs.org/en/blog/release/v$1.$2.$3/ permanent;
+    rewrite ^/\d+/\d+/\d+/(?:node-v(?:ersion-)?|version-)(\d+)[-\.](\d+)[-\.](\d+).*$ https://nodejs.org/en/blog/release/v$1.$2.$3 permanent;
 
     # @todo: check if these redirects can be done through next.js
-    rewrite ^/2015/05/16/node-leaders-are-building-an-open-foundation/$ https://nodejs.org/en/blog/community/node-leaders-building-open-neutral-foundation/ permanent;
-    rewrite ^/2015/05/16/the-nodejs-foundation-benefits-all/$ https://nodejs.org/en/blog/community/foundation-benefits-all/ permanent;
-    rewrite ^/2014/01/17/nodejs-road-ahead/$ https://nodejs.org/en/blog/nodejs-road-ahead/ permanent;
-    rewrite ^/2013/12/03/bnoordhuis-departure/$ https://nodejs.org/en/blog/uncategorized/bnoordhuis-departure/ permanent;
-    rewrite ^/2013/11/26/npm-post-mortem/$ https://nodejs.org/en/blog/npm/2013-outage-postmortem/ permanent;
-    rewrite ^/2013/10/22/cve-2013-4450-http-server-pipeline-flood-dos/$ https://nodejs.org/en/blog/vulnerability/http-server-pipeline-flood-dos/ permanent;
-    rewrite ^/2015/05/08/transitions/$ https://nodejs.org/en/blog/community/transitions/ permanent;
-    rewrite ^/2015/05/08/next-chapter/$ https://nodejs.org/en/blog/community/next-chapter/ permanent;
-    rewrite ^/2013/02/08/peer-dependencies/$ https://nodejs.org/en/blog/npm/peer-dependencies/ permanent;
-    rewrite ^/2012/12/21/streams2/$ https://nodejs.org/en/blog/feature/streams2/ permanent;
-    rewrite ^/2012/09/30/bert-belder-libuv-lxjs-2012/$ https://nodejs.org/en/blog/video/bert-belder-libuv-lxjs-2012/ permanent;
-    rewrite ^/2012/05/08/bryan-cantrill-instrumenting-the-real-time-web/$ https://nodejs.org/en/blog/video/bryan-cantrill-instrumenting-the-real-time-web/ permanent;
-    rewrite ^/2012/05/07/http-server-security-vulnerability-please-upgrade-to-0-6-17/$ https://nodejs.org/en/blog/vulnerability/http-server-security-vulnerability-please-upgrade-to-0-6-17/ permanent;
-    rewrite ^/2012/05/02/multi-server-continuous-deployment-with-fleet/$ https://nodejs.org/en/blog/module/multi-server-continuous-deployment-with-fleet/ permanent;
-    rewrite ^/2012/04/25/profiling-node-js/$ https://nodejs.org/en/blog/uncategorized/profiling-node-js/ permanent;
-    rewrite ^/2012/03/28/service-logging-in-json-with-bunyan/$ https://nodejs.org/en/blog/module/service-logging-in-json-with-bunyan/ permanent;
-    rewrite ^/2012/02/27/managing-node-js-dependencies-with-shrinkwrap/$ https://nodejs.org/en/blog/npm/managing-node-js-dependencies-with-shrinkwrap/ permanent;
-    rewrite ^/2011/12/15/growing-up/$ https://nodejs.org/en/blog/uncategorized/growing-up/ permanent;
-    rewrite ^/2011/10/26/version-0-6/$ https://nodejs.org/en/blog/uncategorized/version-0-6/ permanent;
-    rewrite ^/2011/10/05/an-easy-way-to-build-scalable-network-programs/$ https://nodejs.org/en/blog/uncategorized/an-easy-way-to-build-scalable-network-programs/ permanent;
-    rewrite ^/2011/09/23/libuv-status-report/$ https://nodejs.org/en/blog/uncategorized/libuv-status-report/ permanent;
-    rewrite ^/2011/09/08/ldapjs-a-reprise-of-ldap/$ https://nodejs.org/en/blog/uncategorized/ldapjs-a-reprise-of-ldap/ permanent;
-    rewrite ^/2011/08/29/some-new-node-projects/$ https://nodejs.org/en/blog/uncategorized/some-new-node-projects/ permanent;
-    rewrite ^/2011/08/12/the-videos-from-node-meetup/$ https://nodejs.org/en/blog/uncategorized/the-videos-from-node-meetup/ permanent;
-    rewrite ^/2011/08/03/node-meetup-this-thursday/$ https://nodejs.org/en/blog/uncategorized/node-meetup-this-thursday/ permanent;
-    rewrite ^/2011/07/11/evolving-the-node-js-brand/$ https://nodejs.org/en/blog/uncategorized/evolving-the-node-js-brand/ permanent;
-    rewrite ^/2011/06/24/porting-node-to-windows-with-microsoft.+s-help/$ https://nodejs.org/en/blog/uncategorized/porting-node-to-windows-with-microsofts-help/ permanent;
-    rewrite ^/2011/05/01/npm-1-0-released/$ https://nodejs.org/en/blog/npm/npm-1-0-released/ permanent;
-    rewrite ^/2011/04/29/trademark/$ https://nodejs.org/en/blog/uncategorized/trademark/ permanent;
-    rewrite ^/2011/04/28/node-office-hours-cut-short/$ https://nodejs.org/en/blog/uncategorized/node-office-hours-cut-short/ permanent;
-    rewrite ^/2011/04/07/npm-1-0-link/$ https://nodejs.org/en/blog/npm/npm-1-0-link/ permanent;
-    rewrite ^/2011/04/05/development-environment/$ https://nodejs.org/en/blog/uncategorized/development-environment/ permanent;
-    rewrite ^/2014/12/05/listening-to-the-community/$ https://nodejs.org/en/blog/advisory-board/listening-to-the-community/ permanent;
-    rewrite ^/2014/12/03/advisory-board-update/$ https://nodejs.org/en/blog/advisory-board/advisory-board-update/ permanent;
-    rewrite ^/2011/03/25/jobs-nodejs-org/$ https://nodejs.org/en/blog/uncategorized/jobs-nodejs-org/ permanent;
-    rewrite ^/2011/03/24/npm-1-0-global-vs-local-installation/$ https://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation/ permanent;
-    rewrite ^/2011/03/24/office-hours/$ https://nodejs.org/en/blog/uncategorized/office-hours/ permanent;
-    rewrite ^/2011/03/18/npm-1-0-the-new-ls/$ https://nodejs.org/en/blog/npm/npm-1-0-the-new-ls/ permanent;
-    rewrite ^/2011/03/18/welcome-to-the-node-blog/$ https://nodejs.org/en/blog/video/welcome-to-the-node-blog/ permanent;
-    rewrite ^/2014/07/31/v8-memory-corruption-stack-overflow/$ https://nodejs.org/en/blog/vulnerability/v8-memory-corruption-stack-overflow/ permanent;
-    rewrite ^/2014/07/29/building-nodejs-together/$ https://nodejs.org/en/blog/community/building-nodejs-together/ permanent;
-    rewrite ^/2014/06/16/openssl-and-breaking-utf-8-change/$ https://nodejs.org/en/blog/vulnerability/openssl-and-utf8/ permanent;
-    rewrite ^/2014/06/11/notes-from-the-road/$ https://nodejs.org/en/blog/uncategorized/notes-from-the-road/ permanent;
+    rewrite ^/2015/05/16/node-leaders-are-building-an-open-foundation/$ https://nodejs.org/en/blog/community/node-leaders-building-open-neutral-foundation permanent;
+    rewrite ^/2015/05/16/the-nodejs-foundation-benefits-all/$ https://nodejs.org/en/blog/community/foundation-benefits-all permanent;
+    rewrite ^/2014/01/17/nodejs-road-ahead/$ https://nodejs.org/en/blog/nodejs-road-ahead permanent;
+    rewrite ^/2013/12/03/bnoordhuis-departure/$ https://nodejs.org/en/blog/uncategorized/bnoordhuis-departure permanent;
+    rewrite ^/2013/11/26/npm-post-mortem/$ https://nodejs.org/en/blog/npm/2013-outage-postmortem permanent;
+    rewrite ^/2013/10/22/cve-2013-4450-http-server-pipeline-flood-dos/$ https://nodejs.org/en/blog/vulnerability/http-server-pipeline-flood-dos permanent;
+    rewrite ^/2015/05/08/transitions/$ https://nodejs.org/en/blog/community/transitions permanent;
+    rewrite ^/2015/05/08/next-chapter/$ https://nodejs.org/en/blog/community/next-chapter permanent;
+    rewrite ^/2013/02/08/peer-dependencies/$ https://nodejs.org/en/blog/npm/peer-dependencies permanent;
+    rewrite ^/2012/12/21/streams2/$ https://nodejs.org/en/blog/feature/streams2 permanent;
+    rewrite ^/2012/09/30/bert-belder-libuv-lxjs-2012/$ https://nodejs.org/en/blog/video/bert-belder-libuv-lxjs-2012 permanent;
+    rewrite ^/2012/05/08/bryan-cantrill-instrumenting-the-real-time-web/$ https://nodejs.org/en/blog/video/bryan-cantrill-instrumenting-the-real-time-web permanent;
+    rewrite ^/2012/05/07/http-server-security-vulnerability-please-upgrade-to-0-6-17/$ https://nodejs.org/en/blog/vulnerability/http-server-security-vulnerability-please-upgrade-to-0-6-17 permanent;
+    rewrite ^/2012/05/02/multi-server-continuous-deployment-with-fleet/$ https://nodejs.org/en/blog/module/multi-server-continuous-deployment-with-fleet permanent;
+    rewrite ^/2012/04/25/profiling-node-js/$ https://nodejs.org/en/blog/uncategorized/profiling-node-js permanent;
+    rewrite ^/2012/03/28/service-logging-in-json-with-bunyan/$ https://nodejs.org/en/blog/module/service-logging-in-json-with-bunyan permanent;
+    rewrite ^/2012/02/27/managing-node-js-dependencies-with-shrinkwrap/$ https://nodejs.org/en/blog/npm/managing-node-js-dependencies-with-shrinkwrap permanent;
+    rewrite ^/2011/12/15/growing-up/$ https://nodejs.org/en/blog/uncategorized/growing-up permanent;
+    rewrite ^/2011/10/26/version-0-6/$ https://nodejs.org/en/blog/uncategorized/version-0-6 permanent;
+    rewrite ^/2011/10/05/an-easy-way-to-build-scalable-network-programs/$ https://nodejs.org/en/blog/uncategorized/an-easy-way-to-build-scalable-network-programs permanent;
+    rewrite ^/2011/09/23/libuv-status-report/$ https://nodejs.org/en/blog/uncategorized/libuv-status-report permanent;
+    rewrite ^/2011/09/08/ldapjs-a-reprise-of-ldap/$ https://nodejs.org/en/blog/uncategorized/ldapjs-a-reprise-of-ldap permanent;
+    rewrite ^/2011/08/29/some-new-node-projects/$ https://nodejs.org/en/blog/uncategorized/some-new-node-projects permanent;
+    rewrite ^/2011/08/12/the-videos-from-node-meetup/$ https://nodejs.org/en/blog/uncategorized/the-videos-from-node-meetup permanent;
+    rewrite ^/2011/08/03/node-meetup-this-thursday/$ https://nodejs.org/en/blog/uncategorized/node-meetup-this-thursday permanent;
+    rewrite ^/2011/07/11/evolving-the-node-js-brand/$ https://nodejs.org/en/blog/uncategorized/evolving-the-node-js-brand permanent;
+    rewrite ^/2011/06/24/porting-node-to-windows-with-microsoft.+s-help/$ https://nodejs.org/en/blog/uncategorized/porting-node-to-windows-with-microsofts-help permanent;
+    rewrite ^/2011/05/01/npm-1-0-released/$ https://nodejs.org/en/blog/npm/npm-1-0-released permanent;
+    rewrite ^/2011/04/29/trademark/$ https://nodejs.org/en/blog/uncategorized/trademark permanent;
+    rewrite ^/2011/04/28/node-office-hours-cut-short/$ https://nodejs.org/en/blog/uncategorized/node-office-hours-cut-short permanent;
+    rewrite ^/2011/04/07/npm-1-0-link/$ https://nodejs.org/en/blog/npm/npm-1-0-link permanent;
+    rewrite ^/2011/04/05/development-environment/$ https://nodejs.org/en/blog/uncategorized/development-environment permanent;
+    rewrite ^/2014/12/05/listening-to-the-community/$ https://nodejs.org/en/blog/advisory-board/listening-to-the-community permanent;
+    rewrite ^/2014/12/03/advisory-board-update/$ https://nodejs.org/en/blog/advisory-board/advisory-board-update permanent;
+    rewrite ^/2011/03/25/jobs-nodejs-org/$ https://nodejs.org/en/blog/uncategorized/jobs-nodejs-org permanent;
+    rewrite ^/2011/03/24/npm-1-0-global-vs-local-installation/$ https://nodejs.org/en/blog/npm/npm-1-0-global-vs-local-installation permanent;
+    rewrite ^/2011/03/24/office-hours/$ https://nodejs.org/en/blog/uncategorized/office-hours permanent;
+    rewrite ^/2011/03/18/npm-1-0-the-new-ls/$ https://nodejs.org/en/blog/npm/npm-1-0-the-new-ls permanent;
+    rewrite ^/2011/03/18/welcome-to-the-node-blog/$ https://nodejs.org/en/blog/video/welcome-to-the-node-blog permanent;
+    rewrite ^/2014/07/31/v8-memory-corruption-stack-overflow/$ https://nodejs.org/en/blog/vulnerability/v8-memory-corruption-stack-overflow permanent;
+    rewrite ^/2014/07/29/building-nodejs-together/$ https://nodejs.org/en/blog/community/building-nodejs-together permanent;
+    rewrite ^/2014/06/16/openssl-and-breaking-utf-8-change/$ https://nodejs.org/en/blog/vulnerability/openssl-and-utf8 permanent;
+    rewrite ^/2014/06/11/notes-from-the-road/$ https://nodejs.org/en/blog/uncategorized/notes-from-the-road permanent;
 
     rewrite ^/(feed/)?release/?$                 https://nodejs.org/en/feed/releases.xml permanent;
     rewrite ^/(feed/)?vulnerability/?$           https://nodejs.org/en/feed/vulnerability.xml permanent;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -166,6 +166,7 @@ server {
 
     location ^~ /api {
         alias /home/dist/nodejs/docs/latest/api;
+        autoindex on;
         default_type text/plain;
 
         location ~ \.json$ {

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -165,6 +165,8 @@ server {
     }
 
     location ^~ /api {
+        error_page 404 @localized_404;
+
         alias /home/dist/nodejs/docs/latest/api;
         default_type text/plain;
 

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -15,7 +15,6 @@ server {
     log_not_found off;
     
     gzip on;
-    gzip_static on;
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/javascript text/xml application/xml application/xml+rss image/svg+xml;
     
@@ -28,8 +27,6 @@ server {
     default_type text/plain;
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
-    
-    error_page 404 /404.html;
 
     location ~ ^/(?!(dist/|dist$|\.json$)) {
         rewrite ^ https://$host$uri permanent;
@@ -41,6 +38,8 @@ server {
     
     # website requests will never be served through here
     location / {
+        error_page 404 /404.html;
+
         try_files $uri $uri/ =404;
 
         location ~ \.json$ {
@@ -76,7 +75,6 @@ server {
     error_log /var/log/nginx/nodejs/nodejs.org-error.log;
 
     gzip on;
-    gzip_static on;
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/javascript text/xml application/xml application/xml+rss image/svg+xml;
     
@@ -86,8 +84,6 @@ server {
     open_file_cache_errors off;
     
     set $lang en;
-
-    error_page 404 @localized_404;
 
     root /home/www/nodejs;
     default_type text/plain;
@@ -99,6 +95,8 @@ server {
     }
 
     location / {
+        error_page 404 @localized_404;
+
         rewrite ^/(.*)/$ /$1 permanent;
 
         try_files $uri $uri.html @english_fallback;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -28,6 +28,8 @@ server {
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
 
+    error_page 404 = /404.html;
+
     location ~ ^/(?!(dist/|dist$|\.json$)) {
         rewrite ^ https://$host$uri permanent;
     }
@@ -87,6 +89,8 @@ server {
     default_type text/plain;
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
+
+    error_page 404 = @localized_404;
 
     location = / {
         rewrite ^ /en break;
@@ -205,7 +209,7 @@ server {
 
         # If this was a rewritten i18n request from @english_fallback, use the localized 404
         # Otherwise, fallback to the English 404 file
-        rewrite ^ /$lang/404.html break;
+        try_files /$lang/404.html /en/404.html =404;
     } 
 
     rewrite ^/.well-known/security.txt$                           https://$server_name/security.txt last;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -13,16 +13,16 @@ server {
     keepalive_timeout 60;
     server_tokens off;
     log_not_found off;
-    
+
     gzip on;
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/javascript text/xml application/xml application/xml+rss image/svg+xml;
-    
+
     open_file_cache max=10000 inactive=300s;
     open_file_cache_valid 120s;
     open_file_cache_min_uses 2;
     open_file_cache_errors off;
-    
+
     root /home/www/nodejs;
     default_type text/plain;
     index index.html;
@@ -31,15 +31,13 @@ server {
     location ~ ^/(?!(dist/|dist$|\.json$)) {
         rewrite ^ https://$host$uri permanent;
     }
-    
+
     location = /404.html {
         add_header Cache-Control "private, no-store, max-age=0" always;
     }
-    
+
     # website requests will never be served through here
     location / {
-        error_page 404 /404.html;
-
         try_files $uri $uri/ =404;
 
         location ~ \.json$ {
@@ -77,25 +75,25 @@ server {
     gzip on;
     gzip_disable "MSIE [1-6]\.";
     gzip_types text/plain text/css application/javascript text/xml application/xml application/xml+rss image/svg+xml;
-    
+
     open_file_cache max=100000 inactive=300s;
     open_file_cache_valid 120s;
     open_file_cache_min_uses 2;
     open_file_cache_errors off;
-    
+
     set $lang en;
 
     root /home/www/nodejs;
     default_type text/plain;
     index index.html;
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
-    
+
     location = / {
         rewrite ^ /en break;
     }
 
     location / {
-        error_page 404 @localized_404;
+        error_page 404 = @localized_404;
 
         rewrite ^/(.*)/$ /$1 permanent;
 
@@ -105,7 +103,7 @@ server {
             add_header access-control-allow-origin *;
         }
     }
-    
+
     # specific rule for handling next.js requests without overrides
     location ^~ /static {
         access_log off;
@@ -121,7 +119,7 @@ server {
 
         try_files $uri =404;
     }
-    
+
     location ^~ /dist {
         sendfile on;
         sendfile_max_chunk 1m;
@@ -165,7 +163,7 @@ server {
     }
 
     location ^~ /api {
-        error_page 404 @localized_404;
+        error_page 404 = @localized_404;
 
         alias /home/dist/nodejs/docs/latest/api;
         default_type text/plain;
@@ -176,7 +174,7 @@ server {
 
         try_files $uri =404;
     }
-    
+
     location ^~ /documentation {
         rewrite ^/documentation/api(.*)$ /api$1 redirect;
     }
@@ -186,12 +184,12 @@ server {
         autoindex on;
         default_type text/plain;
     }
-    
+
     location = /github-webhook.log {
         alias /home/nodejs/github-webhook.log;
         default_type text/plain;
     }
-    
+
     location @english_fallback {
         # Store the original language of the request
         # We'll use this for the 404 in the try_files in @localized_404
@@ -199,7 +197,7 @@ server {
             set $lang $1;
         }
 
-        rewrite ^/(ar|be|ca|de|es|fa|fr|gl|id|it|ja|ka|ko|nl|pt-br|ro|ru|tr|uk|zh-cn|zh-tw)/(.*)$ /en/$2;
+        rewrite ^/(ar|be|ca|de|es|fa|fr|gl|id|it|ja|ka|ko|nl|pt-br|ro|ru|tr|uk|zh-cn|zh-tw)/(.*)$ /en/$2 last;
     }
 
     location @localized_404 {
@@ -207,7 +205,7 @@ server {
 
         # If this was a rewritten i18n request from @english_fallback, use the localized 404
         # Otherwise, fallback to the English 404 file
-        try_files /$lang/404.html /en/404.html =404;
+        rewrite ^ /$lang/404.html break;
     } 
 
     rewrite ^/.well-known/security.txt$                           https://$server_name/security.txt last;
@@ -215,7 +213,7 @@ server {
     rewrite ^/about/security/?$                                   https://github.com/nodejs/node/blob/HEAD/SECURITY.md#security permanent;
     rewrite ^/contribute/?$                                       https://$server_name/en/get-involved permanent;
     rewrite ^/contribute/accepting_contributions.html$            https://github.com/nodejs/dev-policy permanent;
-    
+
     # @todo: use next.js to do these rewrites
     # it might require special rewriting to let next.js handle the rewrites instead of nginx
     rewrite ^/contribute/becoming_collaborator.html$              https://$server_name/en/get-involved permanent;

--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -82,6 +82,8 @@ server {
     open_file_cache_valid 120s;
     open_file_cache_min_uses 2;
     open_file_cache_errors off;
+    
+    set $lang en;
 
     error_page 404 @localized_404;
 


### PR DESCRIPTION
This PR updates the cache_file cache to `100000`, fixes rewrites by removing their `/` trailing slash, and remove unnecessary `try_files` from known failing conditions.