### PR TITLE
jenkins: unset LIBPATH on AIX in select-compiler.sh

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -166,6 +166,7 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
   export CC="gcc-${COMPILER_LEVEL}"
   export CXX="g++-${COMPILER_LEVEL}"
   export LINK="g++-${COMPILER_LEVEL}"
+  unset LIBPATH
   export PATH="/opt/ccache-3.7.4/libexec:/opt/freeware/bin:$PATH"
   echo "Compiler set to GCC" `$CXX -dumpversion`
 


### PR DESCRIPTION
Hopefully fixes broken [node-test-node-addon-api-new jobs on AIX](https://ci.nodejs.org/job/node-test-node-addon-api-new/nodes=aix72-ppc64/).

[node-test-commit-aix](https://ci.nodejs.org/job/node-test-commit-aix/) unsets LIBPATH with this comment:
```console
# LIBPATH must be set to /opt/freeware/lib for the git plugin to work, however
# it must be unset for the build.  The ansible start script sets the libpath
# so that when git runs its set, but we must unset it here otherwise it
# causes the build to find the 32 bit stdc++ library instead of the 64 bit one
# that we need when running binaries (like mksnapshot) since our target is 64 bit
unset LIBPATH
```

`select-compiler.sh` was previously unsetting LIBPATH prior to https://github.com/nodejs/build/pull/3205
https://github.com/nodejs/build/pull/3205/files#diff-9f85ac8aaf936da8062466648fef7b7f930a32362ff3d65e6ed74a8cf3cc4495L161