### PR TITLE
jenkins: run ARM64 Windows tests on Node.js >=19

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -84,6 +84,7 @@ def buildExclusions = [
   [ /vs2017-x86$/,                    testType,    ltGte(10, 14) ],
   [ /vs2019-x86$/,                    testType,    lt(14)        ],
   [ /vs2019-arm64$/,                  testType,    lt(14)        ],
+  [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(19)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
   [ /vs2013-COMPILED_BY/,             testType,    gte(9)        ],
   [ /vs2015-COMPILED_BY/,             testType,    gte(19)       ],
@@ -188,13 +189,6 @@ combinations.each{
   if (nodeMajorVersion >= 4) {
     if (!canBuild(nodeMajorVersion, builderLabel, _buildType)) {
       println "Skipping $builderLabel for Node.js $nodeMajorVersion"
-      return
-    }
-  }
-  // Run tests on Windows ARM64 only if explicitly requested
-  if (builderLabel =~ /^win.*COMPILED_BY.*-arm64$/) {
-    if (!new String(parameters['RUN_ARM64_TESTS']).equalsIgnoreCase("true")){
-      println "Skipping $builderLabel because RUN_ARM64_TESTS is not selected"
       return
     }
   }


### PR DESCRIPTION
After adding ARM64 Windows machines to CI and stabilizing the tests, it is time to complete https://github.com/nodejs/build/issues/3046 and enable the tests to run by default.

This PR makes it so, but only for Node.js 19 and above, as the tests are not stable on LTS versions.

This is currently in use in Jenkins. This was applied in https://github.com/nodejs/jenkins-config-test/compare/f94d4652ce4d902263f0967922f6a1482c8a48c4...3133da6f058c16b56e02370500e135c16fb79740 and I will revert the url changes once this lands.

Fixes: https://github.com/nodejs/build/issues/3046