### PR TITLE
Adding ARM64 Windows MSI to Jenkins

### DIFF
--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -19,8 +19,17 @@ if not defined DISABLE_CLCACHE if exist C:\clcache\dist\clcache_main\clcache_mai
 
 :: Call vcbuild
 if "%nodes:~-6%" == "-arm64" (
-  :: Building MSI is not yet supported for ARM64
-  set "VCBUILD_EXTRA_ARGS=arm64 release"
+  :: Building MSI is not yet supported for ARM64 with WiX 3.
+  :: Since PR with WiX 4 migration changed folder structure,
+  :: this check can determine which WiX is used for the MSI.
+  :: Refs: https://github.com/nodejs/node/pull/45943
+  if exist tools\msvs\msi\nodemsi.wixproj (
+    :: WiX 3 - doesn't build ARM64 MSI
+    set "VCBUILD_EXTRA_ARGS=arm64 release"
+  ) else (
+    :: WiX 4 - builds ARM64 MSI
+    set "VCBUILD_EXTRA_ARGS=arm64 %VCBUILD_EXTRA_ARGS%"
+  )
 ) else if "%nodes:~-4%" == "-x86" (
   set "VCBUILD_EXTRA_ARGS=x86 %VCBUILD_EXTRA_ARGS%"
 ) else (


### PR DESCRIPTION
This PR is a continuation of [WiX4 PR](https://github.com/nodejs/node/pull/45943) that implements a runtime detection of the WiX version used for the MSI (required because of the LTS versions). If WiX4 is detected, the MSI for Windows ARM64 is created.

We've created a temporary job for testing these changes before opening PR [here](https://ci.nodejs.org/view/All/job/joaocgreis-node-compile-windows/). As visible from runs, detection works as expected.

Refs: https://github.com/nodejs/node/pull/45943