### PR TITLE
ansible: add gcc-toolset-10-libatomic-devel on RHEL8

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -134,7 +134,7 @@ packages: {
   ],
 
   rhel8: [
-    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-11,git,make,python3',
+    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,git,make,python3',
   ],
 
   smartos: [


### PR DESCRIPTION
V8 CI requires libatomic.

---

e.g. https://ci.nodejs.org/job/node-test-commit-v8-linux/5239/nodes=rhel8-s390x,v8test=v8test/console
```console
13:42:18 FAILED: torque 
13:42:18 python3 "../../build/toolchain/gcc_link_wrapper.py" --output="./torque" -- g++ -pie -Werror -Wl,--fatal-warnings -Wl,--build-id -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -m64 -rdynamic -Wl,-z,defs -Wl,--as-needed -pie -Wl,--disable-new-dtags -Wl,-O2 -Wl,--gc-sections -o "./torque" -Wl,--start-group @"./torque.rsp"  -Wl,--end-group  -latomic -ldl -lpthread -lrt
13:42:18 /opt/rh/gcc-toolset-10/root/usr/bin/ld: cannot find -latomic
13:42:18 collect2: error: ld returned 1 exit status
```
