### PR TITLE
Add Windows ARM64 assets to release

### DIFF
--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -11,7 +11,7 @@ const app = express()
 app.use(bodyParser.json())
 
 const extensionRe = /\.(tar\.gz|tar\.xz|pkg|msi|exe|zip|7z)$/
-const uriRe = /(\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9.]+)[.-]([^? ]+))))/
+const uriRe = /(\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|win-arm64|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9.]+)[.-]([^? ]+))))/
 const versionRe = /^v[0-9.]+$/
 
 function determineOS (path, file, fileType) {

--- a/ansible/www-standalone/tools/metrics/download-counts.awk
+++ b/ansible/www-standalone/tools/metrics/download-counts.awk
@@ -24,7 +24,7 @@ BEGIN {
 
 {
   success = match($0, \
-      / \[([^:]+).* "?GET (\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9\.]+)[\-\.]([^\? ]+))))(\?[^ ]+)? HTTP\/[12]\.[01][" ]/ \
+      / \[([^:]+).* "?GET (\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|win-arm64|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9\.]+)[\-\.]([^\? ]+))))(\?[^ ]+)? HTTP\/[12]\.[01][" ]/ \
     , m \
   )
 

--- a/ansible/www-standalone/tools/promote/expected_assets/v19.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v19.x
@@ -25,8 +25,11 @@ node-{VERSION}-win-x64.7z
 node-{VERSION}-win-x64.zip
 node-{VERSION}-win-x86.7z
 node-{VERSION}-win-x86.zip
+node-{VERSION}-win-arm64.7z
+node-{VERSION}-win-arm64.zip
 node-{VERSION}-x64.msi
 node-{VERSION}-x86.msi
+node-{VERSION}-arm64.msi
 win-x64/
 win-x64/node.exe
 win-x64/node.lib
@@ -37,3 +40,8 @@ win-x86/node.exe
 win-x86/node.lib
 win-x86/node_pdb.7z
 win-x86/node_pdb.zip
+win-arm64/
+win-arm64/node.exe
+win-arm64/node.lib
+win-arm64/node_pdb.7z
+win-arm64/node_pdb.zip


### PR DESCRIPTION
This change brings Windows ARM64 one step closer to being a tier 2 supported platform, as described in https://github.com/nodejs/node/pull/47233.

With these changes, Windows ARM64 assets will get picked when releasing the following versions of NodeJS. Please note that these changes are partial, the rest of the required changes (eg. modifying the release job) will be done by @joaocgreis.