### PR TITLE
jenkins: release ARM64 Windows for Node.js >= 19

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -74,6 +74,7 @@ def buildExclusions = [
   [ /vs2015/,                         releaseType, ltGte(6, 10)  ],
   [ /vs2017/,                         releaseType, ltGte(10, 14) ],
   [ /vs2019/,                         releaseType, lt(14)        ],
+  [ /vs2019-arm64/,                   releaseType, lt(19)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2013(-\w+)?$/,                 testType,    gte(6)        ],
   [ /vs2015(-\w+)?$/,                 testType,    gte(10)       ],


### PR DESCRIPTION
Build official ARM64 releases only for Node.js >= 19.

Once https://github.com/nodejs/node/pull/47233 lands, I will apply the changes from https://ci-release.nodejs.org/job/joaocgreis-iojs+release/ to the main job.

This can land sooner because nothing changes unless the job is changed as well.

Refs: https://github.com/nodejs/build/pull/3262

