### PR TITLE
ansible: use explicit python version on containers

### DIFF
--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -22,7 +22,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
       git \
       java-17-openjdk-headless \
       make \
-      python3 \
+      python3.8 \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -26,7 +26,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
       libatomic.i686 \
       libstdc++-devel \
       libstdc++-devel.i686 \
-      python3 \
+      python3.8 \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -22,7 +22,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
       git \
       java-17-openjdk-headless \
       make \
-      python3 \
+      python3.8 \
       openssl-devel \
       procps-ng \
     && dnf --disableplugin=subscription-manager clean all

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     gcc-8 \
     git \
     curl \
-    python-pip \
     python3-pip \
     libfontconfig1 \
     libtool \
@@ -29,8 +28,6 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 # openjdk-17-jre-headless pulls in ca-certificates-java which conflicts with
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
-
-RUN pip install tap2junit
 
 RUN pip3 install tap2junit
 

--- a/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
@@ -15,7 +15,6 @@ RUN apt-get update \
     gcc-8 \
     git \
     curl \
-    python-pip \
     python3-pip \
     python-all \
     libfontconfig1 \
@@ -28,8 +27,7 @@ RUN apt-get update \
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
 
-RUN pip install tap2junit \
-  && pip3 install tap2junit
+RUN pip3 install tap2junit
 
 RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install apt-utils -y && \
       git \
       pkg-config \
       curl \
-      python-pip \
+      python3.8 \
       python3-pip \
       libfontconfig1 \
       libtool \
@@ -32,9 +32,6 @@ RUN apt-get update && apt-get install apt-utils -y && \
 # openjdk-17-jre-headless pulls in ca-certificates-java which conflicts with
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
-
-
-RUN pip install tap2junit
 
 RUN pip3 install tap2junit
 


### PR DESCRIPTION
the default installed python version for these environments is 3.6.8, 
the minimal supported version for the latest `tap2junit` is 3.7
this forces the installation of a later version

ref: https://github.com/nodejs/build/issues/3268