### PR TITLE
ansible: use explicit tap2junit version on containers

### DIFF
--- a/ansible/roles/docker/templates/alpine311.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine311.Dockerfile.j2
@@ -42,7 +42,7 @@ RUN apk add --no-cache --virtual .build-deps \
         libtool \
         autoconf
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/alpine312.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine312.Dockerfile.j2
@@ -40,7 +40,7 @@ RUN apk add --no-cache --virtual .build-deps \
         libtool \
         autoconf
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/centos7.Dockerfile.j2
+++ b/ansible/roles/docker/templates/centos7.Dockerfile.j2
@@ -27,7 +27,7 @@ RUN yum -y update && \
       libtool \
       automake
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN groupadd --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/debian10_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/debian10_armv7l.Dockerfile.j2
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
 # Prevent Node.js picking up the OS's openssl.cnf, https://github.com/nodejs/node/issues/27862
 ENV OPENSSL_CONF /dev/null
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -45,7 +45,7 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 ENV PYTHON /usr/bin/python3
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 USER {{ server_user }}:{{ server_user }}
 

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -43,7 +43,7 @@ VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 ENV PYTHON /usr/bin/python3
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -37,7 +37,7 @@ RUN update-crypto-policies --set LEGACY
 
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 USER iojs:iojs
 

--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -20,13 +20,10 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     git \
     openjdk-8-jre-headless \
     curl \
-    python-pip \
     python3-pip \
     libfontconfig1
 
-RUN pip install tap2junit
-
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu1604_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_arm_cross.Dockerfile.j2
@@ -14,7 +14,6 @@ RUN apt-get update \
     git \
     openjdk-8-jre-headless \
     curl \
-    python-pip \
     python3-pip \
     python-all \
     python-software-properties \
@@ -25,8 +24,7 @@ RUN apt-get update \
     gcc-6-multilib \
     g++-6-multilib
 
-RUN pip install tap2junit \
-  && pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
 
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&\
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2 &&\
     update-alternatives  --set python3 /usr/bin/python3.8
 

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     gcc-8 \
     git \
     curl \
+    python3.8 \
     python3-pip \
     libfontconfig1 \
     libtool \
@@ -29,7 +30,11 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
 
-RUN pip3 install tap2junit
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&\
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2 &&\
+    update-alternatives  --set python3 /usr/bin/python3.8
+
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
@@ -15,6 +15,7 @@ RUN apt-get update \
     gcc-8 \
     git \
     curl \
+    python3.8 \
     python3-pip \
     python-all \
     libfontconfig1 \
@@ -27,7 +28,11 @@ RUN apt-get update \
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
 
-RUN pip3 install tap2junit
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&\
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2 &&\
+    update-alternatives  --set python3 /usr/bin/python3.8
+
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -33,7 +33,11 @@ RUN apt-get update && apt-get install apt-utils -y && \
 # something in the list of package above when installed at the same time.
 RUN apt-get install -y openjdk-17-jre-headless
 
-RUN pip3 install tap2junit
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 &&\
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2 &&\
+    update-alternatives  --set python3 /usr/bin/python3.8
+
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     libtool \
     automake
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
       python-is-python3 \
       libfontconfig1
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install apt-utils -y && \
       libtool \
       automake
 
-RUN pip3 install tap2junit
+RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -30,3 +30,5 @@ packages: {
     'docker-ce',
   ],
 }
+
+tap2junit_version: 0.1.6


### PR DESCRIPTION
Due to docker layer caching, it makes more sense to pin to a specific version than rebuild the entire image