### PR TITLE
ansible: update RHEL 8 cross compiler container

### DIFF
--- a/ansible/roles/docker/files/cc-selector.sh
+++ b/ansible/roles/docker/files/cc-selector.sh
@@ -8,12 +8,14 @@
 # cross-compiler-ubuntu1804-armv7-gcc-6
 # cross-compiler-ubuntu1804-armv7-gcc-8
 # cross-compiler-rhel8-armv7-gcc-8-glibc-2.28
+# cross-compiler-rhel8-armv7-gcc-10-glibc-2.28
 
 rpi_newer_tools_base="/opt/raspberrypi/rpi-newer-crosstools/"
 base_4_9_4="${rpi_newer_tools_base}x64-gcc-4.9.4-binutils-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 base_6="${rpi_newer_tools_base}x64-gcc-6.5.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 base_8="${rpi_newer_tools_base}x64-gcc-8.3.0/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 base_8_glibc_2_28="${rpi_newer_tools_base}x64-gcc-8.3.0-glibc-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
+base_10_glibc_2_28="${rpi_newer_tools_base}x64-gcc-10.3.0-glibc-2.28/arm-rpi-linux-gnueabihf/bin/arm-rpi-linux-gnueabihf-"
 
 flags_armv6="-march=armv6zk"
 flags_armv7="-march=armv7-a"
@@ -22,7 +24,7 @@ function run {
   local label="$1"
 
   export arm_type=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-(armv[67])-gcc-.*$/\2/')
-  export gcc_version=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-armv[67]-gcc-(4\.9\.4|6|8)/\2/')
+  export gcc_version=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-armv[67]-gcc-(4\.9\.4|6|8|10)/\2/')
   export git_branch="cc-${arm_type}"
   export host_os=$(echo $label | sed -E 's/^cross-compiler-(ubuntu1[68]04|rhel8)-(armv[67])-gcc-.*$/\1/')
 
@@ -30,7 +32,7 @@ function run {
     echo "Could not determine ARM type from '$label'"
     exit 1
   fi
-  if [[ ! "$gcc_version" =~ ^(4\.9\.4|6|8|8-glibc-2.28)$ ]]; then
+  if [[ ! "$gcc_version" =~ ^(4\.9\.4|6|8|8-glibc-2.28|10-glibc-2.28)$ ]]; then
     echo "Could not determine ARM type from '$label'"
     exit 1
   fi
@@ -52,7 +54,7 @@ function run {
     # Additional gcc versions are installed via gcc-toolset-<n> packages.
     # No such package exists for the default gcc version (8 on RHEL 8).
     if [ "${current_gcc_version}" != "${gcc_host_version}" ]; then
-      if ! . /opt/gcc-toolset-${gcc_host_version}/enable; then
+      if ! . /opt/rh/gcc-toolset-${gcc_host_version}/enable; then
         echo "Host gcc version mismatch (wanted ${gcc_host_version} but got ${current_gcc_version})."
         exit 1
       fi

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -22,14 +22,21 @@ RUN dnf install --disableplugin=subscription-manager -y \
       git \
       glibc-devel.i686 \
       java-17-openjdk-headless \
-      make \
       libatomic.i686 \
       libstdc++-devel \
       libstdc++-devel.i686 \
+      make \
       python3.8 \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all
+
+RUN dnf install --disableplugin=subscription-manager -y \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.x86_64.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.x86_64.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.i686.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.x86_64.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-runtime-10.1-0.el8.x86_64.rpm
 
 RUN groupadd -r -g {{ server_user_gid.stdout_lines[0] }} {{ server_user }} \
     && adduser -r -m -d /home/{{ server_user }}/ \
@@ -45,7 +52,7 @@ ENV PYTHON /usr/bin/python3
 
 RUN pip3 install tap2junit=={{ tap2junit_version }}
 
-RUN git clone https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
+RUN git clone --depth=1 https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 
 COPY cc-selector.sh /opt/raspberrypi/cc-selector.sh
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -56,6 +56,7 @@ def buildExclusions = [
   [ /^debian8-docker-armv7$/,         releaseType, lt(10)  ],
   [ /^debian8-docker-armv7$/,         anyType,     gte(12) ],
   [ /^debian9-docker-armv7$/,         anyType,     lt(10)  ],
+  [ /^debian10-armv7l$/,              anyType,     gte(20) ], // gcc 10 requires newer libstdc++
   [ /^pi1-docker$/,                   releaseType, gte(10) ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-4.9/, anyType, gte(12) ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,   anyType, lt(12)  ],
@@ -65,6 +66,8 @@ def buildExclusions = [
   [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,      anyType, lt(16)  ],
   [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,      anyType, gte(18) ],
   [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,anyType, lt(18)  ],
+  [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,anyType, gte(20) ],
+  [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/,anyType, lt(20) ],
   [ /^ubuntu1604-arm64/,              anyType,     gte(14) ],
 
   // Windows -----------------------------------------------


### PR DESCRIPTION
Update RHEL 8 container used for cross compiling for armv7. 
Add logic to select gcc 10 toolchain for Node.js 20 onwards. 
Install gcc-toolset-10 host compiler.

Refs: https://github.com/rvagg/rpi-newer-crosstools/pull/2
Refs: https://github.com/orgs/nodejs/discussions/45892
Refs: https://github.com/nodejs/node/issues/47067