### PR TITLE
ci: restrict Python linting runs

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,24 +1,29 @@
-name: Lint
+name: Lint Python
 on:
   push:
     branches-ignore:
       - "dependabot/*"
+    paths:
+      - '**/*.py'
+      - '.flake8'
+      - .github/workflows/lint-python.yml
   pull_request:
+    paths:
+      - '**/*.py'
+      - '.flake8'
+      - .github/workflows/lint-python.yml
 jobs:
   Python:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # pip install -r requirements.txt  # TODO: Add tap2junit
+        pip install flake8
     - name: Lint with flake8
       run: |
-        pip install flake8
         flake8 --version
         flake8 .


### PR DESCRIPTION
This workflow really only checks for python issues, so renamed the file and restricted it to only run when the files are impacted.