### PR TITLE
ansible: fix tap2junit installation for RHEL 8

### DIFF
--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel8.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel8.yml
@@ -1,0 +1,16 @@
+---
+
+#
+# install tap2junit from pip
+#
+
+- name: install pip
+  ansible.builtin.dnf: 
+    name: python3-pip
+    state: present
+
+- name: install tap2junit
+  ansible.builtin.pip:
+    executable: /usr/bin/pip3
+    name: tap2junit=={{ tap2junit_version }}
+    state: present


### PR DESCRIPTION
`tap2junit` 0.1.6 requires Python >=3.7.

Use the installed `python3` (currently Python 3.9) rather than `/usr/libexec/platform-python` which is Python 3.6.8.

Fixes: https://github.com/nodejs/build/issues/3306