### PR TITLE
jenkins: cache x64 node.exe for arm64 license file

### DIFF
--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -29,6 +29,21 @@ if "%nodes:~-6%" == "-arm64" (
   ) else (
     :: WiX 4 - builds ARM64 MSI
     set "VCBUILD_EXTRA_ARGS=arm64 %VCBUILD_EXTRA_ARGS%"
+
+    :: ARM64 MSI needs x64 node.exe to generate the license file.
+    :: It is downloaded from vcbuild.bat and is known to hang,
+    :: thus failing the build after timing out (1-2% runs).
+    :: Downloading it from here and updating it weekly should
+    :: decrease, if not remove, these types of CI failures.
+    :: Download and cache x64 node.exe.
+    mkdir C:\node_exe_cache
+    forfiles /p "C:\node_exe_cache" /m "node.exe" /d -7 /c "cmd /c del @path"
+    if not exist C:\node_exe_cache\node.exe (
+      curl -L https://nodejs.org/dist/latest/win-x64/node.exe -o C:\node_exe_cache\node.exe
+    )
+    :: Copy it to where vcbuild expects.
+    mkdir temp-vcbuild
+    copy C:\node_exe_cache\node.exe temp-vcbuild\node-x64-cross-compiling.exe
   )
 ) else if "%nodes:~-4%" == "-x86" (
   set "VCBUILD_EXTRA_ARGS=x86 %VCBUILD_EXTRA_ARGS%"


### PR DESCRIPTION
After promoting Windows on ARM64 to a tier 2 platform, as a part of the compilation job in the CI, the ARM64 MSI installer is created. The first node-test-commit-windows-fanned build that did this was 54061. Since then, I've been monitoring all ARM64 builds, and until now, there's been a bit over 750 (the last build checked is 54823).

I noticed that 15 builds, roughly 2%, failed when downloading the x64 node.exe used for generating the license file. Changes proposed here tend to minimize, if not remove errors by caching the x64 node.exe and updating it weekly.

I've already tested these changes in my [job that tests migrating to VS2022](https://ci.nodejs.org/view/All/job/mefi-node-compile-windows-vs2022/) (another topic for another day) and saw no issues.