### PR TITLE
ansible: do not hardcode `/home`

### DIFF
--- a/ansible/roles/jenkins-worker/meta/main.yml
+++ b/ansible/roles/jenkins-worker/meta/main.yml
@@ -7,11 +7,11 @@ dependencies:
   - role: user-create
   - role: github
     vars:
-      user_home_dir: "/home/{{ server_user }}"
+      user_home_dir: "{{ home }}/{{ server_user }}"
   - role: java-base
   - role: build-test-v8
     when: build_test_v8|default(False)
     vars:
-      tools_dest_dir: "/home/{{ server_user }}/build-tools"
-      tools_git_dir: "/home/{{ server_user }}"
+      tools_dest_dir: "{{ home }}/{{ server_user }}/build-tools"
+      tools_git_dir: "{{ home }}/{{ server_user }}"
       tools_user: "{{ server_user }}"


### PR DESCRIPTION
When invoking dependent roles from the `jenkins-worker` role, do not hardcode `/home` as the user's directory may be in a different parent directory.