### PR TITLE
ansible: update `git-wrapper` for z/OS

### DIFF
--- a/ansible/roles/jenkins-worker/templates/git-wrapper.j2
+++ b/ansible/roles/jenkins-worker/templates/git-wrapper.j2
@@ -5,6 +5,10 @@ export _TAG_REDIR_ERR=txt
 export _TAG_REDIR_IN=txt
 export _TAG_REDIR_OUT=txt
 
+if [[ $WORKSPACE != "" ]]; then
+  chtag -t -c iso8859-1 "$WORKSPACE/.git/config"
+fi
+
 if [[ $1 == "rev-parse" ]]; then
   {{ git_cmd }} "$@" | cat
 elif [[ $1 == "whatchanged" ]]; then


### PR DESCRIPTION
Tag `.git/config` as iso8859-1 to prevent it being interpreted as EBCDIC.

Refs: https://github.com/nodejs/build/issues/3320#issuecomment-1520565578