### PR TITLE
ansible: remove AIX 7.1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -39,9 +39,6 @@ hosts:
         rhel8-x64-1: {ip: 159.203.115.217}
 
     - ibm:
-        aix71-ppc64_be-2:
-            ip: 169.59.74.10
-            server_jobs: 6
         aix72-ppc64_be-1:
             ip: 169.54.113.163
             remote_env:
@@ -152,12 +149,6 @@ hosts:
         ubuntu2204-x64-2: {ip: 145.40.96.123, alias: jenkins-workspace-8}
 
     - ibm:
-        aix71-ppc64_be-3: 
-            ip: 169.48.23.70
-            server_jobs: 6
-        aix71-ppc64_be-4:  
-            ip: 169.59.74.12
-            server_jobs: 6
         aix72-ppc64_be-1:
             ip: 169.54.113.142
             remote_env:

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -55,10 +55,6 @@ packages: {
     'bash,cmake,coreutils,curl,gcc-c++,tar,unzip,git,make,sudo,python-setuptools,python3.9',
   ],
 
-  aix71: [
-    'gcc6-c++',
-  ],
-
   aix72: [
     'gcc6-c++,gcc8-c++,gcc10-c++'
   ],

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -31,7 +31,6 @@ java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default(o
 # e.g. on AIX ansible_architecture is 'chrp' on some of our hosts so we
 # override arch to be on the safe side.
 adoptopenjdk: {
-  aix71_ppc64: { arch: ppc64 },
   aix72_ppc64: { arch: ppc64 },
   aix73_ppc64: { arch: ppc64 },
   centos7_ppc64: {}

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
 init: {
-  aix: ['aix71', 'aix72', 'aix73'],
+  aix: ['aix72', 'aix73'],
   centos6: 'centos6',
   debian: 'debian7',
   freebsd: 'freebsd',

--- a/ansible/roles/package-upgrade/vars/main.yml
+++ b/ansible/roles/package-upgrade/vars/main.yml
@@ -5,7 +5,7 @@
 #
 
   pm: {
-    'yum': ['centos', 'rhel7', 'aix71', 'aix72', 'ibmi'],
+    'yum': ['centos', 'rhel7', 'aix72', 'ibmi'],
     'apt': ['debian', 'ubuntu'],
     'dnf': ['aix73', 'fedora', 'rhel8'],
     'pkgng': 'freebsd',

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -165,9 +165,6 @@ elif [ "$SELECT_ARCH" = "AIXPPC" ]; then
     *aix72* )
       echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX 7.2"
       ;;
-    *aix71* )
-      echo "Setting compiler for Node version $NODEJS_MAJOR_VERSION on AIX 7.1"
-      ;;
   esac
 
   export CC="gcc-${COMPILER_LEVEL}"


### PR DESCRIPTION
AIX 7.1 is no longer used in the CI once Node.js 14 reaches End-of-Life.

Refs: https://github.com/nodejs/build/issues/3325