### PR TITLE
chore: remove production and add shallow clone

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -17,7 +17,7 @@ clonedir=/home/www/github/${site}
 
 if [ ! -d "${clonedir}" ]; then
   repo="${site}.org"
-  git clone https://github.com/nodejs/${repo}.git $clonedir
+  git clone --depth 2 https://github.com/nodejs/${repo}.git $clonedir
 fi
 
 if [ "$site" == "nodejs" ]; then
@@ -51,7 +51,7 @@ docker run \
       npm config set loglevel http && \
       npm config set cache /npm/ && \
       cd /website/ && \
-      npm install --cache-min 1440 --production && \
+      npm ci --prefer-offline && \
       $build_cmd \
     ' \
   "


### PR DESCRIPTION
This PR fixes the behaviour mentioned here: https://github.com/nodejs/nodejs.org/issues/5381 as when doing Next.js builds, Next.js requires development dependencies, such as TypeScript in order to operate.

This PR removes the outdated/deprecated `--production` flag and adds `--prefer-online`, it also makes the install be based on the lockfile by making it `npm ci` instead of `npm install`.

This PR also makes the clone process shallow as we don't need the git history here. We make a depth of 2 as Nextra/Next.js requires that.