### PR TITLE
ansible: updates for IBM i

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/ibmi73.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/ibmi73.yml
@@ -1,7 +1,15 @@
 ---
 
-- name: ibmi73 | install IBM i 7.3 repo
-  get_url:
-    url: https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/ibm-7.3.repo
-    dest: /QOpenSys/etc/yum/repos.d/ibm-7.3.repo
-    mode: 0644
+- name: ibmi73 | remove old repositories
+  ansible.builtin.yum_repository:
+    name: "{{ item }}"
+    reposdir: /QOpenSys/etc/yum/repos.d
+    state: absent
+  loop:
+    - ibm
+    - ibm-7.3
+
+- name: ibmi73 | install IBM i repositories
+  ansible.builtin.yum:
+    name: ibmi-repos
+    state: present

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -56,7 +56,7 @@ packages: {
   ],
 
   ibmi: [
-    'autoconf,automake,ca-certificates-mozilla,tar-gnu,gzip,ccache,cmake,coreutils-gnu,gcc10,gcc10-cplusplus,gcc10-cpp,git,libstdcplusplus6-10-devel,m4-gnu,openssl-devel,python3,python3-pip,sed-gnu,zlib-devel,icu-devel,c-ares-devel,brotli-devel,grep-gnu,pkg-config,xz',
+    'autoconf,automake,ca-certificates-mozilla,tar-gnu,gzip,ccache,cmake,coreutils-gnu,gcc10,gcc10-cplusplus,gcc10-cpp,git,libstdcplusplus6-10-devel,m4-gnu,openssl-devel,python2-setuptools,python3,python3-pip,python39,python39-pip,python39-setuptools,sed-gnu,zlib-devel,icu-devel,c-ares-devel,brotli-devel,grep-gnu,pkg-config,xz',
   ],
 
   debian8: [

--- a/ansible/roles/github/tasks/main.yml
+++ b/ansible/roles/github/tasks/main.yml
@@ -7,7 +7,7 @@
     dest: "{{ user_home_dir }}/.ssh"
     mode: "0700"
     owner: "{{ server_user }}"
-    group: "{{ server_user }}"
+    group: "{{ (os|startswith('zos') or os|startswith('ibmi'))|ternary(omit, server_user) }}"
     state: directory
 
 - name: write github.com entry in known_hosts

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ibmi.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/ibmi.yml
@@ -5,5 +5,8 @@
 #
 
 - name: install tap2junit
-  shell:
-    cmd: "pip3 install tap2junit"
+  ansible.builtin.pip:
+    executable: /QOpenSys/pkgs/bin/pip3.9
+    name: tap2junit
+    state: present
+    version: "{{ tap2junit_version }}"


### PR DESCRIPTION
Update to use current yum repositories for IBM i 7.3. 
Install Python 3.9, and use it to install `tap2junit`. 
Do not set group on the `.ssh` directory on platforms such as IBM i and z/OS where we do not create a group.

Refs: https://github.com/nodejs/build/issues/2937
Refs: https://ibmi-oss-docs.readthedocs.io/en/latest/yum/IBM_REPOS.html