### PR TITLE
www: use node:lts-bullseye in build-site.sh

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -37,7 +37,7 @@ git checkout origin/main
 nodeuid=$(grep ^nodejs: /etc/passwd | awk -F: '{print $3}')
 nodegid=$(grep ^nodejs: /etc/passwd | awk -F: '{print $4}')
 
-docker pull node:lts
+docker pull node:lts-bullseye
 docker run \
   --rm \
   -v ${clonedir}:/website/ \


### PR DESCRIPTION
Temporarily switch to `node:lts-bullseye` while we investigate why the website build is broken with `node:lts`/`node:lts-bookworm`.

Refs: https://github.com/nodejs/build/issues/3382