### PR TITLE
www: use node:lts-bullseye in build-site.sh

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -42,7 +42,7 @@ docker run \
   --rm \
   -v ${clonedir}:/website/ \
   -v /home/nodejs/.npm:/npm/ \
-  node:lts \
+  node:lts-bullseye \
   bash -c " \
     apt-get update && apt-get install -y rsync && \
     addgroup nodejs --gid ${nodeuid} && \


### PR DESCRIPTION
Temporarily switch to `node:lts-bullseye` while we investigate why the website build is broken with `node:lts`/`node:lts-bookworm`.

Refs: https://github.com/nodejs/build/pull/3383
Refs: https://github.com/nodejs/build/issues/3382

---

I missed a reference 😞 