### PR TITLE
ansible: install `jq` on `jenkins-workspace`

### DIFF
--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -155,3 +155,9 @@
     executable: pip3
     state: latest
 
+# Required to submit builds to Coverity.
+- name: Install jq
+  ansible.builtin.package:
+    name: jq
+    state: latest
+    update_cache: yes


### PR DESCRIPTION
The new upload method for Coverity requires parsing a JSON response from the new Coverity API.

Refs: https://github.com/nodejs/build/issues/3343