### PR TITLE
ansible: add role to update known_hosts on windows

### DIFF
--- a/ansible/playbooks/create-windows-custom-vm.yml
+++ b/ansible/playbooks/create-windows-custom-vm.yml
@@ -7,6 +7,7 @@
 - hosts:
   - "*-win*"
   gather_facts: yes
+  gather_subset: min
 
   roles:
     - bootstrap

--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -32,6 +32,8 @@
 
 - hosts:
   - "*-win*"
+  gather_facts: yes
+  gather_subset: min
 
   roles:
     - bootstrap
@@ -39,6 +41,7 @@
     - baselayout-windows
     - visual-studio
     - jenkins-worker-windows
+    - github-windows
 
   pre_tasks:
     - name: check if secret is properly set

--- a/ansible/roles/github-windows/tasks/main.yml
+++ b/ansible/roles/github-windows/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+
+# Set up hosts to be able to checkout/fetch from github.com via SSH.
+
+- name: Check if current user already has a .ssh directory
+  win_stat: path='{{ansible_facts["env"]["USERPROFILE"]}}\.ssh'
+  register: ssh_stat
+
+- name: Create a .ssh directory for current user if missing
+  win_file:
+    path: '{{ansible_facts["env"]["USERPROFILE"]}}\.ssh'
+    state: directory
+  when: not ssh_stat.stat.exists
+
+- name: Check if current user already has a known_hosts file
+  win_stat: path='{{ansible_facts["env"]["USERPROFILE"]}}\.ssh\known_hosts'
+  register: known_hosts_stat
+
+- name: Create a known_hosts for current user if missing
+  win_copy:
+    src: '../github/files/github_known_hosts'
+    dest: '{{ansible_facts["env"]["USERPROFILE"]}}\.ssh\known_hosts'
+  when: not known_hosts_stat.stat.exists
+
+- name: Add github known hosts to known_hosts file if present
+  win_lineinfile:
+    path: '{{ansible_facts["env"]["USERPROFILE"]}}\.ssh\known_hosts'
+    line: '{{item}}'
+    state: present
+  loop: "{{lookup('file', '../github/files/github_known_hosts').splitlines()}}"
+  when: known_hosts_stat.stat.exists
+
+- name: Remove github bad hosts from known_hosts file if present
+  win_lineinfile:
+    path: '{{ansible_facts["env"]["USERPROFILE"]}}\.ssh\known_hosts'
+    line: '{{item}}'
+    state: absent
+  loop: "{{lookup('file', '../github/files/github_bad_hosts').splitlines()}}"
+  when: known_hosts_stat.stat.exists


### PR DESCRIPTION
Added github-windows role. based on an already existing github role. It does the same job on Windows and is used in jenkins-worker/create.yml playbook.

Refs: https://github.com/nodejs/build/pull/3265