### PR TITLE
ansible,doc,win: document update creds process

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -603,25 +603,16 @@ Invoke-WebRequest "https://raw.githubusercontent.com/ansible/ansible/devel/examp
 
 #### Port Configuration
 
-Delete the unencrypted WinRM endpoint:
-
-```powershell
-winrm delete winrm/config/Listener?Address=*+Transport=HTTP
-```
-
-On Rackspace hosts, it is necessary to change the port to match the value found in secrets (change 12345):
-
-```powershell
-winrm set winrm/config/Listener?Address=*+Transport=HTTPS '@{Port="12345"}'
-```
+After creating new machines, the [`update-windows.yml`](playbooks/update-windows.yml) playbook should be run to:
+- Make sure the unencrypted WinRM endpoint is deleted on every machine. Check with:
+  ```console
+  ansible -f 50 'test-*-win*' -m win_shell -a 'winrm enumerate winrm/config/listener'
+  ```
+  The HTTP endpoint should not appear. Only the HTTPS endpoint should be present.
+- On Rackspace hosts, make sure to change the ports, username, and password as described in the playbook.
 
 On Azure, changing the ports is done in the Load Balancer configuration using the Azure Portal.
-
-To see the status of running listeners:
-
-```powershell
-winrm enumerate winrm/config/listener
-```
+The username and password are set during the creation of the VM in the Azure Portal.
 
 #### Test
 

--- a/ansible/playbooks/update-windows.yml
+++ b/ansible/playbooks/update-windows.yml
@@ -21,6 +21,13 @@
 # Changing credentials on release machines breaks access to the code signing
 # certificate, so it need to be re-installed after running this.
 #
+# Generate a random valid Windows username with:
+# cat /dev/urandom | tr -dc 'a-z' | head -c12 ; echo
+# Generate a random valid Windows password with:
+# cat /dev/urandom | tr -dc 'a-z' | head -c1 ; cat /dev/urandom | tr -dc '[:alnum:]~@%^*_+=:,.?/' | head -c23 ; echo
+# Generate random valid ports by going to:
+# https://www.random.org/integers/?num=100&min=10000&max=49151&col=2&base=10&format=html&rnd=new
+#
 
 
 - hosts:
@@ -30,6 +37,10 @@
     autologon_regpath: 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
 
   tasks:
+    - name: delete the unencrypted WinRM endpoint
+      win_shell: "winrm delete winrm/config/Listener?Address=*+Transport=HTTP"
+      ignore_errors: true # Deleting unencrypted WinRM endpoint fails if already deleted. Just ignore it.
+
     - name: set automatic logon user name
       when: '(new_user is defined) and (new_user|length > 0)'
       win_regedit:


### PR DESCRIPTION
While creating new Windows machines for the CI, I noticed that the part of the `MANUAL_STEPS` regarding the removal of HTTP WinRM ports can be automated. As a result, this change was made.