### PR TITLE
www: raise file limit

### DIFF
--- a/ansible/www-standalone/tasks/nginx.yaml
+++ b/ansible/www-standalone/tasks/nginx.yaml
@@ -72,6 +72,14 @@
     regexp: "worker_connections"
   tags: nginx
 
+- name: nginx | Increase number of files
+  lineinfile:
+    line: "worker_rlimit_nofile 4096;"
+    dest: "/etc/nginx/nginx.conf"
+    insertafter: "worker_processes"
+    regexp: "worker_rlimit_nofile"
+  tags: nginx
+
 - name: nginx | Delete default config
   file:
     path: /etc/nginx/sites-enabled/default


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/3259

---

I've manually updated the `nginx.conf` on the server, restarted nginx and confirmed via `cat /proc/<pid>/limits` that the soft limit is now raised.

Let's see if it makes any difference to the server stability.