### PR TITLE
ansible: install V8 build deps for Python 3

### DIFF
--- a/ansible/roles/build-test-v8/tasks/partials/centos7.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/centos7.yml
@@ -8,3 +8,9 @@
   ansible.builtin.yum:
     name: ['python2-httplib2', 'python3-httplib2']
     state: present
+
+- name: install dependencies for V8 build tools (Python 3)
+  ansible.builtin.pip:
+    executable: pip-3
+    name: ['httplib2', 'six']
+    state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel7-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel7-s390x.yml
@@ -33,8 +33,8 @@
     name: httplib2==0.18.0
     state: present
 
-- name: install httplib2 for python 3
+- name: install dependencies for V8 build tools (Python 3)
   ansible.builtin.pip:
     executable: pip-3
-    name: httplib2
+    name: ['httplib2', 'six']
     state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
@@ -33,5 +33,5 @@
 - name: install dependencies for V8 build tools (Python 3)
   ansible.builtin.pip:
     executable: pip-3
-    name: httplib2
+    name: ['httplib2','six']
     state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
@@ -8,7 +8,7 @@
 # Newer V8 builds require Python 3.8, or later.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['GConf2-devel', 'python2', 'python2-pip', 'python39', 'python3-httplib2']
+    name: ['GConf2-devel', 'python2', 'python2-pip', 'python39']
     state: present
   notify: package updated
 
@@ -24,9 +24,14 @@
     name: python3
     path: /usr/bin/python3.9
 
-# RHEL 8 doesn't have a package for httplib2 for Python 2 so install via pip.
-- name: install httplib2
+- name: install dependencies for V8 build tools (Python 2)
   ansible.builtin.pip:
     executable: pip2
     name: httplib2
+    state: present
+
+- name: install dependencies for V8 build tools (Python 3)
+  ansible.builtin.pip:
+    executable: pip-3
+    name: ['httplib2', 'six']
     state: present


### PR DESCRIPTION
Ensure `httplib2` and `six` modules are installed for Python 3 on machines with the `build-test-v8` role.

Refs: https://github.com/nodejs/node/issues/48728
Refs: https://github.com/nodejs/node/pull/48710#issuecomment-1628953014