### PR TITLE
chore(nginx): move redirected subdomains to Cloudflare rules

### DIFF
--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -443,30 +443,6 @@ server {
 server {
     listen *:80;
     listen *:443 ssl http2;
-    server_name doc.nodejs.org docs.nodejs.org;
-
-    return 301 https://nodejs.org/en/docs;
-}
-
-server {
-    listen *:80;
-    listen *:443 ssl http2;
-    server_name api.nodejs.org;
-
-    return 301 https://nodejs.org/api/;
-}
-
-server {
-    listen *:80;
-    listen *:443 ssl http2;
-    server_name dist.nodejs.org;
-
-    return 301 https://nodejs.org/dist/;
-}
-
-server {
-    listen *:80;
-    listen *:443 ssl http2;
     server_name foundation.nodejs.org;
 
     # these are 1:1 redirects from pages being served on the old foundation.nodejs.org to OpenJS Foundation website


### PR DESCRIPTION
Rules created in https://dash.cloudflare.com/07be8d2fbc940503ca1be344714cb0d1/nodejs.org/rules/redirect-rules

![CleanShot 2023-07-18 at 09 08 11](https://github.com/nodejs/build/assets/2352663/2138eef0-a00f-49db-a90e-70652587d6a8)

Example:
![CleanShot 2023-07-18 at 09 08 26](https://github.com/nodejs/build/assets/2352663/5a6f9f08-e638-43b6-983b-e5dc18722289)
