### PR TITLE
fix(website): optimize and fix build-site.sh

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -51,7 +51,7 @@ docker run \
       npm config set loglevel http && \
       npm config set cache /npm/ && \
       cd /website/ && \
-      npm ci && \
+      npm ci --ignore-scripts && \
       $build_cmd \
     ' \
   "


### PR DESCRIPTION
Ignore npm install scripts. This makes the dependencies install faster
and avoids a crash that happens when Playwright attempts to install
browsers.
