### PR TITLE
chore: only production dependencies and omit funding and audit checks

### DIFF
--- a/ansible/www-standalone/resources/scripts/build-site.sh
+++ b/ansible/www-standalone/resources/scripts/build-site.sh
@@ -51,7 +51,7 @@ docker run \
       npm config set loglevel http && \
       npm config set cache /npm/ && \
       cd /website/ && \
-      npm ci --ignore-scripts && \
+      npm ci --omit=dev --no-audit --no-fund --ignore-scripts && \
       $build_cmd \
     ' \
   "


### PR DESCRIPTION
This PR omits the installation of `devDependencies` at all since we don't need them for a successful build. The CI on `nodejs.org` uses the same arguments (In case a PR breaks these, the CI checks on `nodejs.org` would prevent this from being deployed).

We also removed the funding and audit checks as they're not required during this webhook.