### PR TITLE
chore: fix cache headers for nodejs.org

### DIFF
--- a/ansible/www-standalone/resources/config/nodejs.org
+++ b/ansible/www-standalone/resources/config/nodejs.org
@@ -33,6 +33,7 @@ server {
     index index.html;
 
     # We set a default cache for browsers of 1 hour and ask Cloudflare to cache for 4 hours
+    # When updating this, make sure to also updated the repeated lines further down
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
 
     error_page 404 /404.html;
@@ -50,6 +51,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 
@@ -68,6 +72,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 }
@@ -109,6 +116,7 @@ server {
     index index.html;
     
     # We set a default cache for browsers of 1 hour, and ask Cloudflare to cache for 4 hours
+    # When updating this, make sure to also updated the repeated lines further down
     add_header Cache-Control "public, max-age=3600, s-maxage=14400";
 
     # Sets a custom 404 error page for the whole Server region
@@ -146,6 +154,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 
@@ -193,6 +204,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 
@@ -214,8 +228,14 @@ server {
 
         add_header X-Robots-Tag noindex;
 
+        # Set cache-control again as it won't be inherited due to add_header being used
+        add_header Cache-Control "public, max-age=3600, s-maxage=14400";
+
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 
@@ -229,6 +249,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 
@@ -242,6 +265,9 @@ server {
 
         location ~ \.json$ {
             add_header access-control-allow-origin *;
+
+            # Set cache-control again as it won't be inherited due to add_header being used
+            add_header Cache-Control "public, max-age=3600, s-maxage=14400";
         }
     }
 


### PR DESCRIPTION
As noted in http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header, `add_header` directives are only inherited from parent levels when `add_header` is not used in the current level.

```
curl -sI https://node-js-origin/download/release/latest/node-v20.5.0.tar.gz | grep cache-control

curl -sI https://node-js-origin/dist/latest/node-v20.5.0.tar.gz | grep cache-control            
cache-control: public, max-age=3600, s-maxage=14400
```

There are some blocks that use `add_header`, so we need to set the cache header again as it will not be inherited otherwise.