### PR TITLE
jenkins: remove outdated labels from VersionSelectorScript.groovy

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -20,11 +20,10 @@ def buildExclusions = [
   // Machine Label,                   Build Type,  Node Version
 
   // Linux -------------------------------------------------
-  [ /^centos7-(arm)?(64|32)-gcc48/,   anyType,     gte(16) ],
-  [ /^centos7-(arm)?(64|32)-gcc6/,    anyType,     gte(16) ],    // 14.x: gcc6 builds stop
-  [ /^centos7-(arm)?(64)-gcc8/,       anyType,     gte(18) ], // 18.x: centos7 builds stop
+  [ /^centos7-(arm)?64-gcc48/,        anyType,     gte(16) ],
+  [ /^centos7-(arm)?64-gcc6/,         anyType,     gte(16) ],    // 14.x: gcc6 builds stop
+  [ /^centos7-(arm)?64-gcc8/,         anyType,     gte(18) ], // 18.x: centos7 builds stop
   [ /^centos7-64/,                    anyType,     gte(18) ],
-  [ /debian8-x86/,                    anyType,     gte(16) ], // 32-bit linux for <10 only
   [ /debian8/,                        anyType,     gte(16) ],
   [ /debian9/,                        anyType,     gte(16) ],
   [ /rhel7/,                          anyType,     gte(18) ],
@@ -36,7 +35,6 @@ def buildExclusions = [
   [ /^centos7-ppcle/,                 anyType,     gte(18) ],
 
   // ARM  --------------------------------------------------
-  [ /^debian8-docker-armv7$/,                        anyType, gte(16) ],
   [ /^debian10-armv7l$/,                             anyType, gte(20) ], // gcc 10 requires newer libstdc++
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-4.9/,   anyType, gte(16) ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,     anyType, gte(16) ],
@@ -45,40 +43,25 @@ def buildExclusions = [
   [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, lt(18)  ],
   [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, gte(20) ],
   [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/, anyType, lt(20)  ],
-  [ /^ubuntu1604-arm64/,                             anyType, gte(16) ],
 
   // Windows -----------------------------------------------
   // https://github.com/nodejs/build/blob/main/doc/windows-visualstudio-supported-versions.md
   // Release Builders - should only match one VS version per Node.js version
-  [ /vs2013/,                         releaseType, gte(16)       ],
   [ /vs2015/,                         releaseType, gte(16)       ],
   [ /vs2017/,                         releaseType, gte(16)       ],
   [ /vs2019-arm64/,                   releaseType, lt(20)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
-  [ /vs2013(-\w+)?$/,                 testType,    gte(16)       ],
   [ /vs2015(-\w+)?$/,                 testType,    gte(16)       ],
-  [ /vcbt2015(-\w+)?$/,               testType,    gte(16)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(16)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(20)        ], // Temporarily compile Node v20+ on both VS2019 and VS2022
-  [ /vs2015-x86$/,                    testType,    gte(16)       ], // compile arm64/x86 only once
-  [ /vs2017-x86$/,                    testType,    gte(16)       ],
   [ /vs2022-x86$/,                    testType,    lt(20)        ], // Temporarily compile Node v20+ arm64 and x86 on both VS2019 and VS2022
   [ /vs2022-arm64$/,                  testType,    lt(20)        ],
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
-  [ /vs2013-COMPILED_BY/,             testType,    gte(16)       ],
   [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],
-  [ /vcbt2015-COMPILED_BY/,           testType,    gte(20)       ],
-  // Exclude some redundant configurations
-  // https://github.com/nodejs/build/blob/main/doc/node-test-commit-matrix.md
-  [ /win10.*COMPILED_BY-vs2017/,      testType,    gte(16)       ], // vs2019 runs on win10 for >=13
 
   // SmartOS -----------------------------------------------
-  [ /^smartos18/,                     releaseType, gte(16) ],
   [ /^smartos18/,                     anyType,     gte(16) ],
-
-  // AIX PPC64 ---------------------------------------------
-  [ /aix71/,                          anyType,     gte(16) ],
 
   // Shared libs docker containers -------------------------
   [ /sharedlibs_debug_x64/,           anyType,     gte(18) ],
@@ -90,9 +73,6 @@ def buildExclusions = [
   [ /osx11-x64-release-tar/,          releaseType, lt(20)  ],
   [ /osx1015-release-pkg/,            releaseType, gte(16) ],
   [ /osx1015-release-tar/,            releaseType, gte(20) ],
-
-  // FreeBSD -----------------------------------------------
-  [ /^freebsd10/,                     anyType,     gte(16) ],
 
   // Source / headers / docs -------------------------------
   [ /^centos7-release-sources$/,      releaseType, gte(18) ],


### PR DESCRIPTION
I got the list of existing labels from the configuration matrix sections in https://ci.nodejs.org/job/node-test-commit-linux/configure and https://ci-release.nodejs.org/job/iojs+release/configure