### PR TITLE
jenkins,doc: update supported Visual Studio for v21

### DIFF
--- a/doc/windows-visualstudio-supported-versions.md
+++ b/doc/windows-visualstudio-supported-versions.md
@@ -10,10 +10,9 @@ Supported versions for running the Node.js installer and executable as released.
 
 | Node.js Version | Windows Version            |
 |-----------------|----------------------------|
-| v16             | 10  / 2012 R2              |
 | v18             | 10 / 2016                  |
-| v19             | 10 / 2016                  |
 | v20             | 10 / 2016                  |
+| v21             | 10 / 2016                  |
 
 ## For building Node.js Core
 
@@ -21,10 +20,9 @@ Supported versions for building Node.js from source.
 
 | Node.js Version | Visual Studio Version               |
 |-----------------|-------------------------------------|
-| v16             | 2019 <sup>[1]</sup>                 |
 | v18             | 2019                                |
-| v19             | 2019                                |
 | v20             | 2019                                |
+| v21             | 2022                                |
 
 ## For building Node.js Addons
 
@@ -32,10 +30,9 @@ Supported versions for building Node.js addons. End-users should have one of the
 
 | Node.js Version | Visual Studio Version                     |
 |-----------------|-------------------------------------------|
-| v16             | 2015, VCBT2015, 2017, 2019                |
 | v18             | 2015, VCBT2015, 2017, 2019                |
-| v19             | 2017, 2019 <sup>[2]</sup>                 |
-| v20             | 2017, 2019 <sup>[2]</sup>                 |
+| v20             | 2017, 2019 <sup>[1]</sup>                 |
+| v21             | 2017, 2019, 2022 <sup>[1]</sup>           |
 
 ## Official Releases
 
@@ -43,14 +40,11 @@ These versions are used to build the official releases.
 
 | Node.js Version | Windows Version | Visual Studio Version |
 |-----------------|-----------------|-----------------------|
-| v16             | 2012 R2         | 2019                  |
 | v18             | 2012 R2         | 2019                  |
-| v19             | 2012 R2         | 2019                  |
 | v20             | 2012 R2         | 2019                  |
+| v21             | 2022            | 2022                  |
 
 ## References
 
-1. Support for Visual Studio 2017 was removed in v15.0.0.
-   - Pull Request: https://github.com/nodejs/node/pull/33694
-2. Support for building addons with Visual Studio 2015 was removed in v19.0.0.
+1. Support for building addons with Visual Studio 2015 was removed in v19.0.0.
    - Pull Request: https://github.com/nodejs/node-gyp/pull/2746

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -51,6 +51,7 @@ def buildExclusions = [
   [ /vs2017/,                         releaseType, gte(16)       ],
   [ /vs2019-arm64/,                   releaseType, lt(20)        ],
   [ /vs2019/,                         releaseType, gte(21)       ],
+  [ /vs2022/,                         releaseType, lt(21)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2015(-\w+)?$/,                 testType,    gte(16)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(16)       ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -50,9 +50,11 @@ def buildExclusions = [
   [ /vs2015/,                         releaseType, gte(16)       ],
   [ /vs2017/,                         releaseType, gte(16)       ],
   [ /vs2019-arm64/,                   releaseType, lt(20)        ],
+  [ /vs2019/,                         releaseType, gte(21)       ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2015(-\w+)?$/,                 testType,    gte(16)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(16)       ],
+  [ /vs2019/,                         testType,    gte(21)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(20)        ], // Temporarily compile Node v20+ on both VS2019 and VS2022
   [ /vs2022-x86$/,                    testType,    lt(20)        ], // Temporarily compile Node v20+ arm64 and x86 on both VS2019 and VS2022
   [ /vs2022-arm64$/,                  testType,    lt(20)        ],


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/49051

/cc @StefanStojanovic I think the test CI is ready for this, but the release CI isn't. Can you help with that?