### PR TITLE
ansible,jenkins: rm centos7-release-sources host

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -35,7 +35,6 @@ hosts:
   - release:
 
     - digitalocean:
-        centos7-x64-1: {ip: 138.68.12.105}
         rhel8-x64-1: {ip: 159.203.115.217}
 
     - ibm:

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -76,7 +76,6 @@ def buildExclusions = [
   [ /osx1015-release-tar/,            releaseType, gte(20) ],
 
   // Source / headers / docs -------------------------------
-  [ /^centos7-release-sources$/,      releaseType, gte(18) ],
   [ /^rhel8-release-sources$/,        releaseType, lt(18)  ],
 
   // -------------------------------------------------------

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -186,16 +186,6 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       . /opt/rh/devtoolset-6/enable
       echo "Compiler set to devtoolset-6"
       ;;
-    centos7-release-sources )
-      if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
-        . /opt/rh/devtoolset-8/enable
-      else
-        . /opt/rh/devtoolset-6/enable
-      fi
-      export CC="ccache gcc"
-      export CXX="ccache g++"
-      echo "Compiler set to GCC" `$CXX -dumpversion`
-      ;;
     *ubuntu1804*64|*ubuntu1604-*64|benchmark )
       if [ "$NODEJS_MAJOR_VERSION" -gt "15" ]; then
         export CC="ccache gcc-8"


### PR DESCRIPTION
Since v16 went EoL, RHEL8 is used for all release lines.

TODO:
- Remove from secrets repo
- Delete DO droplet
