### PR TITLE
jenkins: fix arm64 debug build compiler selection

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -239,7 +239,7 @@ elif [ "$SELECT_ARCH" = "ARM64" ]; then
       fi
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;
-    *ubuntu2004_sharedlibs* )
+    *ubuntu2004* )
       if [ "$NODEJS_MAJOR_VERSION" -gt "19" ]; then
         export CC="ccache gcc-10"
         export CXX="ccache g++-10"


### PR DESCRIPTION
Debug builds are not suffixed with `_sharedlibs` so were not matching the intended case selection.

Refs: https://github.com/nodejs/build/pull/3485#issuecomment-1728060439

cc @targos 