### PR TITLE
ansible: install gcc-10 in remaining Ubuntu 20.04 containers

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     ccache \
     g++-8 \
     gcc-8 \
+    g++-10 \
+    gcc-10 \
     git \
     openjdk-17-jre-headless \
     curl \

--- a/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
@@ -16,6 +16,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
       g++-8 \
       gcc-8 \
+      g++-10 \
+      gcc-10 \
       git \
       openjdk-17-jre-headless \
       pkg-config \


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/pull/3493#discussion_r1331916486
Refs: https://github.com/nodejs/build/pull/3485#discussion_r1324718608

---

Deployed to:
- [x] test-equinix-ubuntu2004-docker-arm64-1
- [x] test-equinix-ubuntu2004-docker-arm64-3
- [x] test-osuosl-ubuntu2004-docker-arm64-1