### PR TITLE
ansible: install aws cli on release builders

### DIFF
--- a/ansible/playbooks/jenkins/worker/create.yml
+++ b/ansible/playbooks/jenkins/worker/create.yml
@@ -8,6 +8,7 @@
   - test
   - release
   - "!*-win*"
+  gather_facts: yes
 
   roles:
     - bootstrap

--- a/ansible/roles/release-builder/tasks/main.yml
+++ b/ansible/roles/release-builder/tasks/main.yml
@@ -36,3 +36,25 @@
     state: present
   become: yes
   become_user: "{{ server_user }}"
+
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+- name: Download awscliv2 installer
+  unarchive:
+    src: "https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip"
+    dest: "/tmp"
+    remote_src: true
+    creates: '/tmp/aws'
+    mode: 0755
+
+- name: Run awscliv2 installer
+  command:
+  args:
+    cmd: "/tmp/aws/install"
+    creates: /usr/local/bin/aws
+  become: true
+  register: aws_install
+
+- name: "Show awscliv2 installer output"
+  debug:
+    var: aws_install
+    verbosity: 2


### PR DESCRIPTION
refs: https://github.com/nodejs/build/issues/3461
refs: https://github.com/nodejs/build/pull/3501

using https://galaxy.ansible.com/deekayen/awscli2
the intent is to add an `aws cp` command in all places that upload artifacts, i.e.:
https://github.com/nodejs/node/blob/fef7927cc3a7a3fb81c355301aada4a679c5661c/Makefile#L1143-L1147
https://github.com/nodejs/node/blob/fef7927cc3a7a3fb81c355301aada4a679c5661c/vcbuild.bat#L520-L538