### PR TITLE
release: copy cloudflare assets when promoting

### DIFF
--- a/ansible/www-standalone/ansible-playbook.yaml
+++ b/ansible/www-standalone/ansible-playbook.yaml
@@ -32,3 +32,6 @@
 
     - include: tasks/metrics.yaml
       tags: metrics
+
+    - include: tasks/cloudflare.yaml
+      tags: cloudflare

--- a/ansible/www-standalone/tasks/cloufdflare.yaml
+++ b/ansible/www-standalone/tasks/cloufdflare.yaml
@@ -1,0 +1,45 @@
+---
+
+- name: create .aws directory
+  ansible.builtin.file:
+    dest: "dist/.aws"
+    owner: dist
+    group: dist
+    state: directory
+
+- name: copy credentials to deploy release artifacts
+  ansible.builtin.copy:
+    content: "{{ secrets.worker_credentials }}"
+    dest: "dist/.aws/credentials"
+    owner: dist
+    group: dist
+
+- name: write worker_config
+  ansible.builtin.copy:
+    dest: "dist/.aws/config"
+    src: "{{ role_path }}/files/worker_config"
+    owner: dist
+    group: dist
+
+
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+- name: Download awscliv2 installer
+  unarchive:
+    src: "https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip"
+    dest: "/tmp"
+    remote_src: true
+    creates: '/tmp/aws'
+    mode: 0755
+
+- name: Run awscliv2 installer
+  command:
+  args:
+    cmd: "/tmp/aws/install"
+    creates: /usr/local/bin/aws
+  become: true
+  register: aws_install
+
+- name: "Show awscliv2 installer output"
+  debug:
+    var: aws_install
+    verbosity: 2

--- a/ansible/www-standalone/tools/promote/_promote.sh
+++ b/ansible/www-standalone/tools/promote/_promote.sh
@@ -51,9 +51,8 @@ for subdir in $(cd $srcdir && ls); do
 
     if [ "X${version}" == "X" ] && [ "$resha" == "yes" ]; then
       ${__dirname}/_resha.sh $site $dstdir $subdir
-    fi
-
     . ${__dirname}/upload_to_cloudflare.sh $site $subdir
+    fi
 
   fi
 

--- a/ansible/www-standalone/tools/promote/_promote.sh
+++ b/ansible/www-standalone/tools/promote/_promote.sh
@@ -46,13 +46,14 @@ for subdir in $(cd $srcdir && ls); do
       fi
 
       rm -f "${srcdir}/${subdir}/${donefile}"
-      . ${__dirname}/upload_to_cloudflare.sh $site $subdir
 
     done
 
     if [ "X${version}" == "X" ] && [ "$resha" == "yes" ]; then
       ${__dirname}/_resha.sh $site $dstdir $subdir
     fi
+
+    . ${__dirname}/upload_to_cloudflare.sh $site $subdir
 
   fi
 

--- a/ansible/www-standalone/tools/promote/_promote.sh
+++ b/ansible/www-standalone/tools/promote/_promote.sh
@@ -46,6 +46,7 @@ for subdir in $(cd $srcdir && ls); do
       fi
 
       rm -f "${srcdir}/${subdir}/${donefile}"
+      . ${__dirname}/upload_to_cloudflare.sh $site $subdir
 
     done
 

--- a/ansible/www-standalone/tools/promote/promote_release.sh
+++ b/ansible/www-standalone/tools/promote/promote_release.sh
@@ -37,6 +37,8 @@ while true; do
   if [ "X${yorn}" == "Xy" ]; then
       . ${__dirname}/_promote.sh $site $2
       nodejs-latest-linker /home/dist/${site}/release/ /home/dist/${site}/docs/
+      dstdir=/home/dist/${site}/docs
+      . ${__dirname}/upload_to_cloudflare.sh $site $2
     break
   fi
 done

--- a/ansible/www-standalone/tools/promote/promote_release.sh
+++ b/ansible/www-standalone/tools/promote/promote_release.sh
@@ -37,8 +37,6 @@ while true; do
   if [ "X${yorn}" == "Xy" ]; then
       . ${__dirname}/_promote.sh $site $2
       nodejs-latest-linker /home/dist/${site}/release/ /home/dist/${site}/docs/
-      dstdir=/home/dist/${site}/docs
-      . ${__dirname}/upload_to_cloudflare.sh $site $2
     break
   fi
 done

--- a/ansible/www-standalone/tools/promote/resha_release.sh
+++ b/ansible/www-standalone/tools/promote/resha_release.sh
@@ -25,4 +25,6 @@ fi
 
 ${__dirname}/_resha.sh $site $dstdir $2
 
+. ${__dirname}/upload_to_cloudflare.sh $site $2
+
 /home/nodejs/queue-cdn-purge.sh $site resha_release

--- a/ansible/www-standalone/tools/promote/settings
+++ b/ansible/www-standalone/tools/promote/settings
@@ -36,3 +36,7 @@ chakracore_rc_dirmatch=.*
 chakracore_release_srcdir=${staging_rootdir}chakracore-release
 chakracore_release_dstdir=${dist_rootdir}chakracore-release
 chakracore_release_dirmatch=.*
+
+cloudflare_endpoint=https://07be8d2fbc940503ca1be344714cb0d1.r2.cloudflarestorage.com
+cloudflare_profile=worker
+destination_bucket=s3://dist-prod

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -39,3 +39,5 @@ relativedir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
 aws s3 cp $dstdir/$tmpversion/ $destination_bucket/$relativedir/$tmpversion/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
+aws s3 cp $dstdir/index.json $destination_bucket/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
+aws s3 cp $dstdir/index.tab $destination_bucket/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -36,6 +36,6 @@ if [ -z ${cloudflare_profile+x} ]; then
 fi
 
 relativedir=${dstdir/$dist_rootdir/"$site/"}
-version=$2
+tmpversion=$2
 
-aws s3 cp $dstdir/$version/ $destination_bucket/$relativedir/$version/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
+aws s3 cp $dstdir/$tmpversion/ $destination_bucket/$relativedir/$tmpversion/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -14,6 +14,27 @@ if [ "X$2" == "X" ]; then
   exit 1
 fi
 
+if [ -z ${dstdir+x} ]; then
+  echo "\$dstdir is not set"
+  exit 1
+fi
+if [ -z ${dist_rootdir+x} ]; then
+  echo "\$dist_rootdir is not set"
+  exit 1
+fi
+if [ -z ${destination_bucket+x} ]; then
+  echo "\$destination_bucket is not set"
+  exit 1
+fi
+if [ -z ${cloudflare_endpoint+x} ]; then
+  echo "\$cloudflare_endpoint is not set"
+  exit 1
+fi
+if [ -z ${cloudflare_profile+x} ]; then
+  echo "\$cloudflare_profile is not set"
+  exit 1
+fi
+
 relativedir=${dstdir/$dist_rootdir/"$site/"}
 version=$2
 

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+site=$1
+
+if [ "X$site" != "Xiojs" ] && [ "X$site" != "Xnodejs" ]; then
+  echo "Usage: upload_to_cloudflare.sh < iojs | nodejs > <version>"
+  exit 1
+fi
+
+if [ "X$2" == "X" ]; then
+  echo "Usage: upload_to_cloudflare.sh < iojs | nodejs > <version>"
+  exit 1
+fi
+
+relativedir=${dstdir/$dist_rootdir/"$site/"}
+version=$2
+
+aws s3 cp $dstdir/$version/ $destination_bucket/$relativedir/$version/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -39,5 +39,5 @@ relativedir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
 aws s3 cp $dstdir/$tmpversion/ $destination_bucket/$relativedir/$tmpversion/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
-aws s3 cp $dstdir/index.json $destination_bucket/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
-aws s3 cp $dstdir/index.tab $destination_bucket/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
+aws s3 cp $dstdir/index.json $destination_bucket/$relativedir/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile
+aws s3 cp $dstdir/index.tab $destination_bucket/$relativedir/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile


### PR DESCRIPTION
While I believe assets can be copied directly from Jenkins in many cases, I think it is better to start with this approach where everything is promoted from within the www server.

this still doesn't handle the latest soft links. see discussion https://github.com/nodejs/release-cloudflare-worker/issues/33