### PR TITLE
ansible: create group on ibm i

### DIFF
--- a/ansible/roles/user-create/tasks/main.yml
+++ b/ansible/roles/user-create/tasks/main.yml
@@ -15,9 +15,15 @@
     group: "{{ server_user }}"
     shell: "{{ bash_path[os|stripversion]|default('/bin/bash') }}"
 
+- name: create group for ibmi
+  when: os|startswith("ibmi")
+  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF(GRP) GID(*GEN)'"
+  args:
+    creates: "/QSYS.LIB/GRP.USRPRF"
+
 - name: create user for ibmi
   when: os|startswith("ibmi")
-  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) PASSWORD(*none)'"
+  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) GRPPRF(nobody) PASSWORD(*none)'"
   args:
     creates: "/QSYS.LIB/IOJS.USRPRF"
 

--- a/ansible/roles/user-create/tasks/main.yml
+++ b/ansible/roles/user-create/tasks/main.yml
@@ -23,9 +23,13 @@
 
 - name: create user for ibmi
   when: os|startswith("ibmi")
-  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) GRPPRF(GRP) PASSWORD(*none)'"
+  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) PASSWORD(*none)'"
   args:
     creates: "/QSYS.LIB/IOJS.USRPRF"
+
+- name: add user to the group
+  when: os|startswith("ibmi")
+  command: "/QOpenSys/usr/bin/system 'CHGUSRPRF USRPRF({{ server_user }}) GRPPRF(GRP)'"
 
 - name: setup user home directory for ibmi
   when: os|startswith("ibmi")

--- a/ansible/roles/user-create/tasks/main.yml
+++ b/ansible/roles/user-create/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: create user for ibmi
   when: os|startswith("ibmi")
-  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) GRPPRF(nobody) PASSWORD(*none)'"
+  command: "/QOpenSys/usr/bin/system 'CRTUSRPRF USRPRF({{ server_user }}) GRPPRF(GRP) PASSWORD(*none)'"
   args:
     creates: "/QSYS.LIB/IOJS.USRPRF"
 


### PR DESCRIPTION
On IBM i group profiles are a subset of user profiles therefore
user profiles and group profiles can't have the same name

In this case I created group named grp and added the server_user to the group

This change was made to help with test failures that expect the test runner user profile to be part of a group.

Ref: https://github.com/libuv/libuv/issues/4143


CC 
@nodejs/platform-ibmi 
@richardlau 