### PR TITLE
ansible: add swap for release-osuosl-rhel8-arm64-1 

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -87,7 +87,11 @@ hosts:
             server_jobs: 6
         centos7-arm64-1: {ip: 140.211.169.7, server_jobs: 2, user: centos}
         centos7-ppc64_le-1: {ip: 140.211.168.61, user: centos}
-        rhel8-arm64-1: {ip: 140.211.169.58, server_jobs: 2, user: cloud-user}
+        rhel8-arm64-1:
+            ip: 140.211.169.58
+            server_jobs: 2
+            user: cloud-user
+            swap_file_size_mb: 4096
         rhel8-ppc64_le-1: {ip: 140.211.168.185, user: cloud-user}
 
     - orka:

--- a/ansible/roles/bootstrap/tasks/partials/linux-swap.yml
+++ b/ansible/roles/bootstrap/tasks/partials/linux-swap.yml
@@ -1,0 +1,40 @@
+---
+
+#
+# Creates a swap file on Linux.
+# Assumes swap_file_size_mb has been set.
+#
+
+- name: create swapfile
+  ansible.builtin.command:
+    cmd: dd if=/dev/zero of=/{{ swap_file }} bs=1M count={{ swap_file_size_mb }}
+    creates: "{{ swap_file }}"
+  become: yes
+  become_user: root
+  register: swap_create
+
+- name: set swapfile permissions
+  ansible.builtin.file:
+    group: root
+    mode: 0600
+    owner: root
+    path: "{{ swap_file }}"
+
+- name: set up swap area
+  ansible.builtin.command:
+    cmd: mkswap {{ swap_file }}
+  when: swap_create.changed
+
+- name: enable swap
+  ansible.builtin.command:
+    cmd: swapon {{ swap_file }}
+  when: swap_create.changed
+
+- name: add swap to fstab
+  ansible.posix.mount:
+    fstype: swap
+    opts: defaults
+    path: swap
+    src: "{{ swap_file }}"
+    state: present
+  when: swap_create.changed

--- a/ansible/roles/bootstrap/tasks/partials/rhel8.yml
+++ b/ansible/roles/bootstrap/tasks/partials/rhel8.yml
@@ -15,3 +15,7 @@
     activationkey: "{{ secrets.rh_activationkey }}"
     org_id: "{{ secrets.rh_org }}"
     state: present
+
+- name: set up swap on Linux
+  include_tasks: linux-swap.yml
+  when: swap_file_size_mb is defined

--- a/ansible/roles/bootstrap/vars/main.yml
+++ b/ansible/roles/bootstrap/vars/main.yml
@@ -1,1 +1,2 @@
 autologon_regpath: 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon'
+swap_file: /swapfile


### PR DESCRIPTION
Add task to the bootstrap role for creating and enabling a file based
swap area.

Adds 4Gb of swap to release-osuosl-rhel8-arm64-1.

Fixes: https://github.com/nodejs/build/issues/3520 