### PR TITLE
docs: add ssh setup to the onboarding process tasks

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -17,7 +17,8 @@ onboarding session.
     [`GOVERNANCE.md`](./GOVERNANCE.md) and have any questions ready
 - [ ] Schedule a meeting with the member to:
     - [ ] Walk them through the infrastructure and what other members do
-    - [ ] Explain how to decrypt nodejs/secrets 
+    - [ ] Explain how to decrypt nodejs/secrets
+    - [ ] Practice SSH access to the organization's machines. See [`ssh.md`](./doc/ssh.md).
     - [ ] Practice running the `jenkins/worker/create.yml` playbook on one of the machines in the test CI cluster
     - [ ] Answer any questions they may have
 - [ ] PR changes to [README.md](./README.md#build-wg-members) to add the member to build-test


### PR DESCRIPTION
I think is important to include this point on the onboarding meeting. It is a great way to ensure that ansible is working and also the SSH related stuff ☕️