### PR TITLE
jenkins: remove macOS 10.x release machines

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -72,10 +72,6 @@ def buildExclusions = [
   [ /sharedlibs_openssl102/,          anyType,     gte(16) ],
   [ /sharedlibs_fips20/,              anyType,     gte(16) ],
 
-  // OSX ---------------------------------------------------
-  [ /osx11-x64-release-tar/,          releaseType, gte(18) ],
-  [ /osx11-x64-release-pkg/,          releaseType, gte(18) ],
-
   // Source / headers / docs -------------------------------
   [ /^centos7-release-sources$/,      releaseType, gte(18) ],
   [ /^rhel8-release-sources$/,        releaseType, lt(18)  ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -73,8 +73,8 @@ def buildExclusions = [
   [ /sharedlibs_fips20/,              anyType,     gte(16) ],
 
   // OSX ---------------------------------------------------
-  [ /osx1015/,                        anyType,     gte(21) ],
-  [ /osx11-x64-release-tar/,          releaseType, lt(20)  ],
+  [ /osx11-x64-release-tar/,          releaseType, gte(18) ],
+  [ /osx11-x64-release-pkg/,          releaseType, gte(18) ],
 
   // Source / headers / docs -------------------------------
   [ /^centos7-release-sources$/,      releaseType, gte(18) ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -75,8 +75,6 @@ def buildExclusions = [
   // OSX ---------------------------------------------------
   [ /osx1015/,                        anyType,     gte(21) ],
   [ /osx11-x64-release-tar/,          releaseType, lt(20)  ],
-  [ /osx1015-release-pkg/,            releaseType, gte(16) ],
-  [ /osx1015-release-tar/,            releaseType, gte(20) ],
 
   // Source / headers / docs -------------------------------
   [ /^centos7-release-sources$/,      releaseType, gte(18) ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -72,6 +72,9 @@ def buildExclusions = [
   [ /sharedlibs_openssl102/,          anyType,     gte(16) ],
   [ /sharedlibs_fips20/,              anyType,     gte(16) ],
 
+  // OSX ---------------------------------------------------
+  [ /osx1015/,                        anyType,     gte(21) ],
+
   // Source / headers / docs -------------------------------
   [ /^centos7-release-sources$/,      releaseType, gte(18) ],
   [ /^rhel8-release-sources$/,        releaseType, lt(18)  ],


### PR DESCRIPTION
### Main changes

This will remove macOS 10.x release machines in Jenkins pipelines.

### Context

On November 1, 2023 macOS 10.x won't be able to notarize the binaries.

Related: https://github.com/nodejs/build/issues/3385#issuecomment-1729281269
Related: https://github.com/nodejs/node/pull/50291 