### PR TITLE
Remove macOS 10.x release machines from inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -70,10 +70,6 @@ hosts:
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
 
     - nearform:
-        macos10.15-x64-1:
-            ip: 83.147.191.69
-            user: administrator
-            ansible_python_interpreter: /usr/bin/python3
         macos11.0-arm64-1:
             ansible_python_interpreter: /usr/bin/python3
             ip: 83.147.191.76

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -95,11 +95,6 @@ hosts:
         rhel8-ppc64_le-1: {ip: 140.211.168.185, user: cloud-user}
 
     - orka:
-        macos10.15-x64-1:
-            ansible_python_interpreter: /usr/bin/python3
-            ip: 199.7.167.101
-            port: 8825
-            user: administrator
         macos11-x64-1:
             ansible_python_interpreter: /usr/bin/python3
             ip: 199.7.167.100


### PR DESCRIPTION
### Main changes

This will remove macOS 10.x release machines from the inventory

### Blockers

- [x] https://github.com/nodejs/build/pull/3531
- [x] Remove the tag before merging in Jenkins. see: https://github.com/nodejs/build/pull/3531#issuecomment-1779565236

### Context

On November 1, 2023 macOS 10.x won't be able to notarize the binaries.

Related: https://github.com/nodejs/build/issues/3385#issuecomment-1729281269
Related: https://github.com/nodejs/node/pull/50291 