### PR TITLE
ansible: don't copy symlinks to R2 buckets

### DIFF
--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -38,6 +38,6 @@ fi
 relativedir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
-aws s3 cp $dstdir/$tmpversion/ $destination_bucket/$relativedir/$tmpversion/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive
+aws s3 cp $dstdir/$tmpversion/ $destination_bucket/$relativedir/$tmpversion/ --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile --recursive --no-follow-symlinks
 aws s3 cp $dstdir/index.json $destination_bucket/$relativedir/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile
 aws s3 cp $dstdir/index.tab $destination_bucket/$relativedir/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile


### PR DESCRIPTION
As of now, symlinks are currently being copied into R2 as two completely separate directories. The release worker handles the symlinks manually though as of nodejs/release-cloudflare-worker#39. This means we can just ignore any symlinks when syncing with R2 since they should never be read from (e.g. the worker should never be trying to read nodejs/release/latest/ from the bucket, instead nodejs/release/v21.0.0).

cc @MoLow 