### PR TITLE
docs: removed old reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ Build and test orchestration is performed by [Jenkins][21].
 - A summary of build and test jobs can be found at: <https://ci.nodejs.org>
 - A listing of connected servers for testing, building and benchmarking
   can be found at: <https://ci.nodejs.org/computer/>
-- A summary of the general health of the last 100 jobs can be found at: <https://ci-health.nodejs.org/#/job-summary>
 - Monitoring with Grafana: <https://grafana.nodejs.org/>
 
 The Build WG will keep build configuration required for a release line for 6


### PR DESCRIPTION
Seems like https://ci-health.nodejs.org/#/job-summary is not working anymore. This remove the reference in the `README.md`