### PR TITLE
ansible,doc,win: manual steps document update

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -599,7 +599,7 @@ The preparation script needs to be run in PowerShell (run as Administrator):
 
 ```powershell
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Invoke-WebRequest "https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1" -OutFile "ConfigureRemotingForAnsible.ps1"
+Invoke-WebRequest "https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1" -OutFile "ConfigureRemotingForAnsible.ps1"
 .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert true -CertValidityDays 3650
 ```
 


### PR DESCRIPTION
Updated the ConfigureRemotingForAnsible.ps1 download URL.

While creating new machines for the Windows CI I noticed that the URL we had in the docs is no longer valid. This PR replaces it with a valid one.