### PR TITLE
docs: add manual step for OSX Keychain profile

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -121,6 +121,33 @@ As root:
 * `sudo xcodebuild -license` - accept license
 * `git` - check that git is working (confirming license has been accepted)
 
+#### OSX Keychain Profile
+
+Create a keychain profile (`NODE_RELEASE_PROFILE`) for the release machine: 
+
+```bash
+sudo xcrun notarytool store-credentials NODE_RELEASE_PROFILE \
+  --apple-id XXXX \
+  --team-id XXXX \
+  --password XXXX \
+  --keychain /Library/Keychains/System.keychain  
+```
+
+Note: `XXXX` values are found in `secrets/build/release/apple.md`
+
+Note2: (`security unlock-keychain -u /Library/Keychains/System.keychain` _may_ be required prior to running this command).
+
+The expected output is:
+
+```
+This process stores your credentials securely in the Keychain. You reference these credentials later using a profile name.
+
+Validating your credentials...
+Success. Credentials validated.
+Credentials saved to Keychain.
+To use them, specify `--keychain-profile "NODE_RELEASE_PROFILE" --keychain /Library/Keychains/System.keychain`
+```
+
 #### Signing certificates
 
 * Go to the `build/release` folder in the secrets repo.


### PR DESCRIPTION
### Main Changes
This will be the first step for https://github.com/nodejs/build/issues/3545. This step creates the kaychain profile `NODE_RELEASE_PROFILE` that later on will be used while notarizing the binaries. [Code reference](https://github.com/nodejs/node/blob/main/tools/osx-notarize.sh#L38).

This PR change is only for documentation. The updated machines were tested in a separate PR (https://github.com/nodejs/node/pull/50715) in the Node repo while updating the `xcrun notarytool submit` command in `/tools/osx-notarize.sh`

The following machines have been updated manually:
- [x] release-orka-macos11-x64-1
- [x] release-nearform-macos11.0-arm64-1
- [x] release-macstadium-macos11.0-arm64-1

### Context
- Related: https://github.com/nodejs/build/issues/3545
- Secrets update: https://github.com/nodejs-private/secrets/pull/295

