### PR TITLE
jenkins: skip debian10 for Node.js >=21

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -24,8 +24,8 @@ def buildExclusions = [
   [ /^centos7-(arm)?64-gcc6/,         anyType,     gte(16) ],    // 14.x: gcc6 builds stop
   [ /^centos7-(arm)?64-gcc8/,         anyType,     gte(18) ], // 18.x: centos7 builds stop
   [ /^centos7-64/,                    anyType,     gte(18) ],
-  [ /debian8/,                        anyType,     gte(16) ],
   [ /debian9/,                        anyType,     gte(16) ],
+  [ /debian10/,                       anyType,     gte(21) ],
   [ /rhel7/,                          anyType,     gte(18) ],
   [ /rhel8/,                          releaseType, lt(18)  ],
   [ /^ubuntu1604-32/,                 anyType,     gte(16) ], // 32-bit linux for <10 only


### PR DESCRIPTION
Remove debian8 as all machines were replaced.

Refs: https://github.com/nodejs/build/issues/3499
