### PR TITLE
ansible: replace DO Ubuntu 18.04 sharedlibs container (1) with 22.04

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -129,7 +129,7 @@ hosts:
         freebsd12-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd12-x64-2: {ip: 107.170.28.213, user: freebsd}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes}
-        ubuntu1804_docker-x64-1: {ip: 134.209.55.216}
+        ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
         ubuntu2204-x64-1: {ip: 138.197.4.1}


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/2933

Compared to the previous one, which had 12 containers, this only has 9 (can be changed later). I removed:
- test-digitalocean-ubuntu1604_container-x64-1
- test-digitalocean-ubuntu1804_container-x64-1
- test-digitalocean-ubuntu1804_arm_cross_container-x64-1

I'm running the playbook now.