### PR TITLE
jenkins: skip ubuntu1804-arm64 on Node.js >=21

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -35,6 +35,7 @@ def buildExclusions = [
   [ /^centos7-ppcle/,                 anyType,     gte(18) ],
 
   // ARM  --------------------------------------------------
+  [ /^ubuntu1804-arm64/,                             anyType, gte(21) ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-4.9/,   anyType, gte(16) ],
   [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,     anyType, gte(16) ],
   [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,        anyType, gte(16) ],


### PR DESCRIPTION
We already have coverage for Ubuntu 20.04.

Refs: https://github.com/nodejs/build/issues/3317
