### PR TITLE
jenkins: enable `select-compiler.sh` on UBI8

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -34,7 +34,7 @@ fi
 
 # Linux distros should be arch agnostic
 case $NODE_NAME in
-  *rhel8*)
+  *rhel8*|*ubi8*)
     case "$CONFIG_FLAGS" in
       *--enable-lto*)
         echo "Setting compiler for Node.js $NODEJS_MAJOR_VERSION (LTO) on" `cat /etc/redhat-release`


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/3317#issuecomment-1848998715

---

This needs a corresponding change in [node-test-commit-linux-containered](https://ci.nodejs.org/job/node-test-commit-linux-containered/) to call `select-compiler.sh` on the [ubi81_sharedlibs_openssl111fips_x64](https://ci.nodejs.org/job/node-test-commit-linux-containered/nodes=ubi81_sharedlibs_openssl111fips_x64/) configuration.

e.g. Insert the following at the top of the script:
```console
export CCACHE_BASEDIR=$PWD
curl -sLO https://raw.githubusercontent.com/nodejs/build/main/jenkins/scripts/select-compiler.sh
. ./select-compiler.sh
```

Test build using `select-compiler.sh` from `main` (still defaults to gcc 8 as it falls through all conditionals): 
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/23/nodes=ubi81_sharedlibs_openssl111fips_x64/consoleFull

Test build showing GCC 10 is picked (using the modified `select-compiler.sh` from this PR): 
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/24/nodes=ubi81_sharedlibs_openssl111fips_x64/consoleFull

Test build for https://github.com/targos/node/tree/c%2B%2B20: 
- https://ci.nodejs.org/job/richardlau-node-test-commit-linux-containered/25/nodes=ubi81_sharedlibs_openssl111fips_x64/consoleFull

cc @targos 