### PR TITLE
ansible: add gcc-toolset-10-binutils

### DIFF
--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -28,7 +28,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
-      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.{{ ansible_architecture }}.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-11.el8.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -28,6 +28,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
+      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -32,6 +32,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.i686.rpm \

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -32,7 +32,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
-      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.x86_64.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-binutils-2.35-11.el8.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.x86_64.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.i686.rpm \

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -28,7 +28,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
-      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.{{ ansible_architecture }}.rpm \
+      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-11.el8.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -28,6 +28,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
+      http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-8.el8_5.6.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://mirror.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-libstdc++-devel-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \


### PR DESCRIPTION
Add the `gcc-toolset-10` version of `binutils` to all RHEL 8 based containers.

Refs: https://github.com/nodejs/build/issues/3595#issuecomment-1861284497

---

Untested.