### PR TITLE
ansible,win: fix temurin17 update breaking jenkins

### DIFF
--- a/ansible/roles/jenkins-worker-windows/templates/jenkins.bat
+++ b/ansible/roles/jenkins-worker-windows/templates/jenkins.bat
@@ -1,3 +1,8 @@
+:: Temurin17 can only be safely upgraded outside of the running Jenkin loop.
+:: windows-update-reboot job will make sure machine is rebooted when needed.
+choco upgrade Temurin17 -y
+call refreshenv
+
 C:
 cd \
 :start


### PR DESCRIPTION
This PR addresses issues with updating Temurin17 on Windows machines in the CI. The changes proposed here ensure that the Temurin17 upgrade is tried every time the machine is rebooted. This is the only time when this can safely be done because once the machine is connected to Jenkins, upgrading will break the connection and leave the machine hanging until someone manually restarts Jenkins or reboots the machine.

The second part of this fix is in `windows-update-reboot` job (to be done after this lands, but there is a test job used for working on the change [mefi-windows-update-reboot](https://ci.nodejs.org/view/housekeeping/job/mefi-windows-update-reboot/)). This job will no longer upgrade the Temurin17 chocolatey package but will detect if it is outdated and force a reboot in that case. After the reboot, the changes from `jenkins.bat` kick in and upgrade the package before connecting to Jenkis.

Fixes: https://github.com/nodejs/build/issues/3548