### PR TITLE
jenkins: fix vs2019 exclusion for native suites job

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -55,7 +55,7 @@ def buildExclusions = [
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2015(-\w+)?$/,                 testType,    gte(16)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(16)       ],
-  [ /vs2019/,                         testType,    gte(21)       ],
+  [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(20)        ], // Temporarily compile Node v20+ on both VS2019 and VS2022
   [ /vs2022-x86$/,                    testType,    lt(20)        ], // Temporarily compile Node v20+ arm64 and x86 on both VS2019 and VS2022
   [ /vs2022-arm64$/,                  testType,    lt(20)        ],


### PR DESCRIPTION
While working on adding new Windows 10 and 11 machines to the CI I noticed that some configurations were getting excluded in the native add-on tests when they should be included. After some investigation, I narrowed it down to VS2019 machines. This change fixes that behavior as seen from tests done in this [temporary copied job](https://ci.nodejs.org/view/All/job/mefi-node-test-binary-windows-native-suites/).