### PR TITLE
jenkins,doc: remove support for building addons with VS2017

### DIFF
--- a/doc/windows-visualstudio-supported-versions.md
+++ b/doc/windows-visualstudio-supported-versions.md
@@ -13,6 +13,7 @@ Supported versions for running the Node.js installer and executable as released.
 | v18             | 10 / 2016                  |
 | v20             | 10 / 2016                  |
 | v21             | 10 / 2016                  |
+| v22             | 10 / 2016                  |
 
 ## For building Node.js Core
 
@@ -23,6 +24,7 @@ Supported versions for building Node.js from source.
 | v18             | 2019                                |
 | v20             | 2019                                |
 | v21             | 2022                                |
+| v22             | 2022                                |
 
 ## For building Node.js Addons
 
@@ -33,6 +35,7 @@ Supported versions for building Node.js addons. End-users should have one of the
 | v18             | 2015, VCBT2015, 2017, 2019                |
 | v20             | 2017, 2019 <sup>[1]</sup>                 |
 | v21             | 2017, 2019, 2022 <sup>[1]</sup>           |
+| v22             | 2019, 2022 <sup>[2]</sup>                 |
 
 ## Official Releases
 
@@ -43,8 +46,10 @@ These versions are used to build the official releases.
 | v18             | 2012 R2         | 2019                  |
 | v20             | 2012 R2         | 2019                  |
 | v21             | 2022            | 2022                  |
+| v22             | 2022            | 2022                  |
 
 ## References
 
 1. Support for building addons with Visual Studio 2015 was removed in v19.0.0.
    - Pull Request: https://github.com/nodejs/node-gyp/pull/2746
+2. Support for building addons with Visual Studio 2017 was removed in v22.0.0.

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -62,6 +62,7 @@ def buildExclusions = [
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
   [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],
+  [ /vs2017-COMPILED_BY/,             testType,    gte(22)       ],
 
   // SmartOS -----------------------------------------------
   [ /^smartos18/,                     anyType,     gte(16) ],


### PR DESCRIPTION
This is necessary for C++20 compat.

Refs: https://github.com/nodejs/node/pull/45427
