### PR TITLE
ansible: update unofficial-builds scripts to run again, install newer node

### DIFF
--- a/ansible/roles/docker/tasks/partials/repo/ubuntu1804.yml
+++ b/ansible/roles/docker/tasks/partials/repo/ubuntu1804.yml
@@ -5,10 +5,13 @@
 #
 
 - name: "repo : add Ubuntu Docker repo key"
-  raw: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  ansible.builtin.apt_key:
+    state: present
+    url: https://download.docker.com/linux/ubuntu/gpg
 
 - name: "repo : add Ubuntu Docker repo"
-  raw: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
   register: has_updated_package_repo
 
 - name: "repo : update apt cache"

--- a/ansible/roles/unofficial-builds/tasks/main.yml
+++ b/ansible/roles/unofficial-builds/tasks/main.yml
@@ -8,33 +8,47 @@
     loop_var: package
   with_items: "{{ base_packages }}"
 
-- name: Bootstrap | Add nodesource signing key
-  apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: present
+- name: Bootstrap | Ensure keyrings directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Bootstrap | Download nodesource signing key
+  ansible.builtin.get_url:
+    url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+    dest: /tmp/nodesource-repo.gpg.key
+    mode: '0644'
+
+- name: Bootstrap | De-armoring GPG key
+  ansible.builtin.shell:
+    cmd: gpg --dearmor < /tmp/nodesource-repo.gpg.key > /etc/apt/keyrings/nodesource.gpg
+    creates: /etc/apt/keyrings/nodesource.gpg
 
 - name: Bootstrap | Add nodesource repo
-  apt_repository:
-    repo: deb https://deb.nodesource.com/node_10.x jessie main
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main"
     state: present
 
-- name: letsencrypt | Add certbot ppa
-  apt_repository:
-    repo: 'ppa:certbot/certbot'
-    state: present
+- name: letsencrypt | Add certbot snap
+  community.general.snap:
+    name: certbot
 
-- name: Bootstrap | APT Update and upgrade
-  apt:
+    classic: true
+- name: Bootstrap | APT update and upgrade
+  ansible.builtin.apt:
     update_cache: yes
     upgrade: full
 
-- name: Bootstrap | Install packages
-  package:
-    name: "{{ package }}"
-    state: present
+- name: Bootstrap | Install and upgrade packages
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: latest
+  loop: "{{ packages }}"
   loop_control:
-    loop_var: package
-  with_items: "{{ packages }}"
+    loop_var: item
 
 - name: Bootstrap | Enable time syncing
   service:
@@ -73,9 +87,10 @@
 - name: Init | Clone unofficial-builds repo
   become: yes
   become_user: "nodejs"
-  git:
+  ansible.builtin.git:
     repo: https://github.com/nodejs/unofficial-builds
     dest: "/home/nodejs/unofficial-builds"
+    version: "main"
 
 - name: Deploy Webhook | Install github-webhook
   npm:

--- a/ansible/roles/unofficial-builds/vars/main.yml
+++ b/ansible/roles/unofficial-builds/vars/main.yml
@@ -4,4 +4,6 @@ base_packages:
   - python-apt
 
 packages:
-  - nodejs,git,nginx,logrotate,certbot,python-certbot-nginx
+  - nodejs
+  - git
+  - logrotate


### PR DESCRIPTION
Ref: https://github.com/nodejs/unofficial-builds/issues/119

This is going to have to be a good-enough-for-now solution. The box is an 18.04 and the latest Node.js I could get on it using this method is 16.x. But that works with dist-indexer and with the newer `npm exec` method, so the original thing is fixed. I didn't have time to experiment with running Node from a snap, which might have been a better solution here. But ultimately this thing needs to be upgraded from 18.04 and then other options open up. Probably just a `do-release-upgrade` in place I think. :shrug: works for now, will think about it later or next time it breaks.