### PR TITLE
ansible: add gcc-toolsets 12 and 13 to RHEL 8

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -104,7 +104,7 @@ packages: {
   ],
 
   rhel8: [
-    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,git,make,python3',
+    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-13,git,make,python3',
   ],
 
   smartos: [


### PR DESCRIPTION
Add gcc 12 and 13 to our RHEL 8 machines.

---

Semi-related to https://github.com/nodejs/build/issues/3630, this PR will add gcc-toolset-12 and gcc-toolset-13 to our RHEL 8 machines, which gives us the ability to do test builds with gcc 12 and/or gcc 13. It does not switch the compiler selection to build Node.js -- that will be done in a follow up PR.