### PR TITLE
ansible: use non-deprecated way to connect Jenkins agents

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -243,7 +243,7 @@ Unsorted stuff of things we need to do/think about
       hosts (or set up a new jump host)
 - [x] copy release (staging) keys to release machines
 - [ ] backup host: generate config, install rsnapshot
-- [ ] switch to slaveLog for all jenkins instances lacking stdout redirection
+- [ ] switch to agentLog for all jenkins instances lacking stdout redirection
       (note: this depends on init type!)
 - [ ] add iptables-save-persistent to cron on ci hosts
 - [ ] [unencrypted host](https://gist.github.com/jbergstroem/5c308089c26e7ae7529a0ef2df92a7f9)

--- a/ansible/aix61-standalone/ansible-playbook.yaml
+++ b/ansible/aix61-standalone/ansible-playbook.yaml
@@ -17,7 +17,7 @@
       tags: user
 
     - name: Jenkins | Download Jenkins agent.jar
-      get_url: url=https://ci.nodejs.org/jnlpJars/agent.jar dest=/home/{{ server_user }}/slave.jar validate_certs=no
+      get_url: url=https://ci.nodejs.org/jnlpJars/agent.jar dest=/home/{{ server_user }}/agent.jar validate_certs=no
       tags: jenkins
 
     - name: Jenkins | Copy S20jenkins

--- a/ansible/aix61-standalone/resources/S20jenkins
+++ b/ansible/aix61-standalone/resources/S20jenkins
@@ -20,7 +20,7 @@ start )
               export SSL_CERT_FILE="$HOME/ca-bundle.crt"; \
         java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/agent.jar" \
           -secret {{secret}} \
-          -jnlpUrl https://ci.nodejs.org/computer/{{id}}/jenkins-agent.jnlp >$jenkins_log_file 2>&1 &'
+          -url https://ci.nodejs.org -name {{id}} >$jenkins_log_file 2>&1 &'
         ;;
 stop )
         ;;

--- a/ansible/aix61-standalone/resources/S20jenkins
+++ b/ansible/aix61-standalone/resources/S20jenkins
@@ -18,7 +18,7 @@ start )
               export JOBS=4; \
               export GIT_SSL_CAINFO="$HOME/ca-bundle.crt"; \
               export SSL_CERT_FILE="$HOME/ca-bundle.crt"; \
-        java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
+        java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/agent.jar" \
           -secret {{secret}} \
           -jnlpUrl https://ci.nodejs.org/computer/{{id}}/jenkins-agent.jnlp >$jenkins_log_file 2>&1 &'
         ;;

--- a/ansible/playbooks/jenkins/worker/upgrade-jar.yml
+++ b/ansible/playbooks/jenkins/worker/upgrade-jar.yml
@@ -12,7 +12,7 @@
     - name: download agent.jar
       get_url:
         url: "{{ jenkins_agent_jar }}"
-        dest: '{{ home }}/{{ server_user }}/slave.jar'
+        dest: '{{ home }}/{{ server_user }}/agent.jar'
         mode: 0644
         force: yes
 

--- a/ansible/roles/docker/templates/alpine315.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine315.Dockerfile.j2
@@ -58,5 +58,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/alpine318.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine318.Dockerfile.j2
@@ -58,5 +58,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/centos7.Dockerfile.j2
+++ b/ansible/roles/docker/templates/centos7.Dockerfile.j2
@@ -53,5 +53,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/debian11_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/debian11_armv7l.Dockerfile.j2
@@ -45,5 +45,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -58,5 +58,6 @@ CMD cd /home/{{ server_user }} \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -69,5 +69,6 @@ CMD cd /home/{{ server_user }} \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -54,5 +54,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604.Dockerfile.j2
@@ -39,5 +39,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1604_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1604_arm_cross.Dockerfile.j2
@@ -56,5 +56,6 @@ CMD cd /home/{{ server_user }} \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804.Dockerfile.j2
@@ -51,5 +51,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2
@@ -65,5 +65,6 @@ CMD cd /home/{{ server_user }} \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu1804_sharedlibs.Dockerfile.j2
@@ -111,5 +111,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004.Dockerfile.j2
@@ -45,5 +45,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_armv7l.Dockerfile.j2
@@ -42,5 +42,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2004_sharedlibs.Dockerfile.j2
@@ -106,5 +106,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -133,5 +133,6 @@ CMD cd /home/iojs \
   && curl https://ci.nodejs.org/jnlpJars/agent.jar -O \
   && java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ item.name }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ item.name }} \
           -secret {{ item.secret }}

--- a/ansible/roles/jenkins-worker-windows/templates/jenkins.bat
+++ b/ansible/roles/jenkins-worker-windows/templates/jenkins.bat
@@ -7,6 +7,6 @@ C:
 cd \
 :start
 curl -L {{ jenkins_agent_jar }} -o {{ agent_path }}
-java -Dhudson.remoting.Launcher.pingIntervalSec=10 -jar {{ agent_path }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp -secret {{ secret }}
+java -Dhudson.remoting.Launcher.pingIntervalSec=10 -jar {{ agent_path }} -url {{ jenkins_url }} -name {{ inventory_hostname }} -secret {{ secret }}
 echo Restarting Jenkins...
 goto start

--- a/ansible/roles/jenkins-worker/files/alpine.monitrc
+++ b/ansible/roles/jenkins-worker/files/alpine.monitrc
@@ -2,6 +2,6 @@ set logfile syslog
 set daemon 30
 
 check process jenkins
-  matching slave.jar
+  matching agent.jar
   start program = "/sbin/rc-service -q jenkins zap && /sbin/rc-service -q jenkins start"
   stop program  = "/sbin/rc-service -q jenkins stop"

--- a/ansible/roles/jenkins-worker/tasks/main.yml
+++ b/ansible/roles/jenkins-worker/tasks/main.yml
@@ -63,7 +63,7 @@
 - name: download agent.jar
   get_url:
     url: "{{ jenkins_agent_jar }}"
-    dest: '{{ home }}/{{ server_user }}/slave.jar'
+    dest: '{{ home }}/{{ server_user }}/agent.jar'
     mode: 0644
     timeout: 60
     force: yes

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -20,7 +20,7 @@ start )
               export PATH="/opt/freeware/bin:/usr/opt/python3/bin/:$PATH"; \
               export OSTYPE=AIX72; \
               export JOBS={{ jobs_env }}; \
-        /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/slave.jar" \
+        /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/agent.jar" \
           -secret {{secret}} \
           -jnlpUrl {{jenkins_url}}/computer/{{inventory_hostname}}/jenkins-agent.jnlp >$jenkins_log_file 2>&1 &'
         ;;

--- a/ansible/roles/jenkins-worker/templates/aix.rc2.j2
+++ b/ansible/roles/jenkins-worker/templates/aix.rc2.j2
@@ -22,7 +22,7 @@ start )
               export JOBS={{ jobs_env }}; \
         /usr/bin/java -Xmx128m -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=30 -jar "$HOME/agent.jar" \
           -secret {{secret}} \
-          -jnlpUrl {{jenkins_url}}/computer/{{inventory_hostname}}/jenkins-agent.jnlp >$jenkins_log_file 2>&1 &'
+          -url {{jenkins_url}} -name {{inventory_hostname}} >$jenkins_log_file 2>&1 &'
         ;;
 stop )
         ;;

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -31,7 +31,7 @@ jenkins_env=" \
   CC=cc \
   CXX=c++"
 
-jenkins_jar="/home/{{ server_user }}/slave.jar"
+jenkins_jar="/home/{{ server_user }}/agent.jar"
 jenkins_log_file="/home/{{ server_user }}/${name}_console.log"
 jenkins_args="-Xmx{{ server_ram|default('128m') }} -jar ${jenkins_jar} \
   -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp \

--- a/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
+++ b/ansible/roles/jenkins-worker/templates/freebsd.initd.j2
@@ -34,7 +34,7 @@ jenkins_env=" \
 jenkins_jar="/home/{{ server_user }}/agent.jar"
 jenkins_log_file="/home/{{ server_user }}/${name}_console.log"
 jenkins_args="-Xmx{{ server_ram|default('128m') }} -jar ${jenkins_jar} \
-  -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp \
+  -url {{ jenkins_url }} -name {{ inventory_hostname }} \
   -secret {{ secret }}"
 jenkins_user="{{ server_user }}"
 jenkins_group="{{ server_user }}"

--- a/ansible/roles/jenkins-worker/templates/ibmi_start.j2
+++ b/ansible/roles/jenkins-worker/templates/ibmi_start.j2
@@ -40,6 +40,6 @@ echo "done"
 
 ########################### Now start our agent
 
-export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -Djava.net.preferIPv4Stack=true -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
+export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -Djava.net.preferIPv4Stack=true -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
 echo $START_CMD
 exec /QOpenSys/usr/bin/system -v -kpiveO "SBMJOB CMD(QSH CMD('echo starting Jenkins agent && cd $HOME && env && touch $HOME/jenkins.log && setccsid 1208 $HOME/jenkins.log && exec $START_CMD')) CPYENVVAR(*YES) PRTDEV(*USRPRF) ALWMLTTHD(*YES) $SBMJOB_OPTS"

--- a/ansible/roles/jenkins-worker/templates/ibmi_start.j2
+++ b/ansible/roles/jenkins-worker/templates/ibmi_start.j2
@@ -40,6 +40,6 @@ echo "done"
 
 ########################### Now start our agent
 
-export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -Djava.net.preferIPv4Stack=true -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
+export START_CMD="{{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} -Dos400.stdio.convert=N -Djava.net.preferIPv4Stack=true -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} -url {{ jenkins_url }} -name {{ inventory_hostname }} >{{ home }}/{{ server_user }}/jenkins.log 2>&1 "
 echo $START_CMD
 exec /QOpenSys/usr/bin/system -v -kpiveO "SBMJOB CMD(QSH CMD('echo starting Jenkins agent && cd $HOME && env && touch $HOME/jenkins.log && setccsid 1208 $HOME/jenkins.log && exec $START_CMD')) CPYENVVAR(*YES) PRTDEV(*USRPRF) ALWMLTTHD(*YES) $SBMJOB_OPTS"

--- a/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
+++ b/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
@@ -28,7 +28,7 @@
 
       <exec_method type='method'
                    name='start'
-                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/slave.jar -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp -secret {{ secret }}'
+                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/agent.jar -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp -secret {{ secret }}'
                    timeout_seconds='30' />
 
       <exec_method type="method"

--- a/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
+++ b/ansible/roles/jenkins-worker/templates/jenkins_manifest.xml.j2
@@ -28,7 +28,7 @@
 
       <exec_method type='method'
                    name='start'
-                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/agent.jar -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp -secret {{ secret }}'
+                   exec='{{ java_path[os] }} -Dsun.security.pkcs11.enable-solaris=false -Xmx{{ server_ram|default('128m') }} -jar /home/{{ server_user }}/agent.jar -url {{ jenkins_url }} -name {{ inventory_hostname }} -secret {{ secret }}'
                    timeout_seconds='30' />
 
       <exec_method type="method"

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -11,4 +11,4 @@ export PATH="/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current
 export PATH="$(brew --prefix)/opt/ccache/libexec:$PATH"
 {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} \
-    -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp
+    -url {{ jenkins_url }} -name {{ inventory_hostname }}

--- a/ansible/roles/jenkins-worker/templates/start.j2
+++ b/ansible/roles/jenkins-worker/templates/start.j2
@@ -10,5 +10,5 @@ export DESTCPU="{{ arch }}"
 export PATH="/usr/local/opt/python3/Frameworks/Python.framework/Versions/Current/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export PATH="$(brew --prefix)/opt/ccache/libexec:$PATH"
 {{ java_path[os] }} -Xmx{{ server_ram|default('128m') }} \
-    -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
+    -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp

--- a/ansible/roles/jenkins-worker/templates/systemd.service.j2
+++ b/ansible/roles/jenkins-worker/templates/systemd.service.j2
@@ -26,6 +26,6 @@ Environment="DESTCPU={{ arch }}"
 Environment="ARCH={{ arch }}"
 
 ExecStart=/usr/bin/java -Xmx{{ server_ram|default('128m') }} \
-          -jar /home/{{ server_user }}/slave.jar \
+          -jar /home/{{ server_user }}/agent.jar \
           -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp \
           -secret {{ secret }}

--- a/ansible/roles/jenkins-worker/templates/systemd.service.j2
+++ b/ansible/roles/jenkins-worker/templates/systemd.service.j2
@@ -27,5 +27,6 @@ Environment="ARCH={{ arch }}"
 
 ExecStart=/usr/bin/java -Xmx{{ server_ram|default('128m') }} \
           -jar /home/{{ server_user }}/agent.jar \
-          -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp \
+          -url {{ jenkins_url }} \
+          -name {{ inventory_hostname }} \
           -secret {{ secret }}

--- a/ansible/roles/jenkins-worker/templates/zos_start.j2
+++ b/ansible/roles/jenkins-worker/templates/zos_start.j2
@@ -25,5 +25,5 @@ export LDFLAGS="-q64"
 
 {{ java_path[os] }} -Dfile.encoding=ISO8859_1 -Xmx{{ server_ram|default('128m') }} \
     -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} \
-    -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1  &
+    -url {{ jenkins_url }} -name {{ inventory_hostname }} >{{ home }}/{{ server_user }}/jenkins.log 2>&1  &
 EOF

--- a/ansible/roles/jenkins-worker/templates/zos_start.j2
+++ b/ansible/roles/jenkins-worker/templates/zos_start.j2
@@ -24,6 +24,6 @@ export CFLAGS="-q64"
 export LDFLAGS="-q64"
 
 {{ java_path[os] }} -Dfile.encoding=ISO8859_1 -Xmx{{ server_ram|default('128m') }} \
-    -jar {{ home }}/{{ server_user }}/slave.jar -secret {{ secret }} \
+    -jar {{ home }}/{{ server_user }}/agent.jar -secret {{ secret }} \
     -jnlpUrl {{ jenkins_url }}/computer/{{ inventory_hostname }}/jenkins-agent.jnlp >{{ home }}/{{ server_user }}/jenkins.log 2>&1  &
 EOF

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -110,7 +110,7 @@ println "Node.js major version: $nodeMajorVersion"
 if (parameters['NODEJS_VERSION'])
   println "Node.js version: ${new String(parameters['NODEJS_VERSION'])}"
 
-// NOTE: this assumes that the default "Slaves"->"Name" in the Configuration
+// NOTE: this assumes that the default "Agents"->"Name" in the Configuration
 // Matrix is left as "nodes", if it's changed then `it.nodes` below won't work
 // and returning a result with a "nodes" property won't work.
 result['nodes'] = []


### PR DESCRIPTION
- **ansible,jenkins: use "agent" naming**
- **ansible: use non-deprecated way to connect Jenkins agents**
