### PR TITLE
jenkins,win: add buildpulse support

### DIFF
--- a/jenkins/scripts/windows/buildpulse.cmd
+++ b/jenkins/scripts/windows/buildpulse.cmd
@@ -1,0 +1,108 @@
+:: CODE TO SEND RESULTS TO BUILDPULSE IF MACHINE IS CONFIGURED
+:: IF ANY REQUIRED CONDITION IS NOT MET IT WILL BE SKIPPED
+echo "Preparing to send data to BuildPulse."
+
+:: 1.Check organization and repository
+echo "Checking organization and repository."
+
+set "REQUIRED_ORGANIZATION=nodejs"
+if not "%GITHUB_ORG%"=="%REQUIRED_ORGANIZATION%" (
+  echo "Organization set to %GITHUB_ORG%, %REQUIRED_ORGANIZATION% required. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "Organization set to %GITHUB_ORG%."
+
+set "REQUIRED_REPOSITORY=node"
+if not "%REPO_NAME%"=="%REQUIRED_REPOSITORY%" (
+  echo "Repository set to %REPO_NAME%, %REQUIRED_REPOSITORY% required. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "Repository set to %REPO_NAME%."
+
+:: 2.Check test results
+echo "Checking test results."
+
+if "%1"=="" (
+  echo "No results provided to send to BuildPulse."
+  exit /b 0
+)
+
+if not exist %1 (
+  echo "No results found in %1 to send to BuildPulse."
+  exit /b 0
+)
+
+echo "Results found in %1."
+
+:: 3.Check required environment variables
+echo "Checking required environment variables."
+
+if not defined BUILDPULSE_ACCESS_KEY_ID (
+  echo "BUILDPULSE_ACCESS_KEY_ID not set. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "BUILDPULSE_ACCESS_KEY_ID is set."
+
+if not defined BUILDPULSE_SECRET_ACCESS_KEY (
+  echo "BUILDPULSE_SECRET_ACCESS_KEY not set. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "BUILDPULSE_SECRET_ACCESS_KEY is set."
+
+if not defined BUILDPULSE_ACCOUNT_ID (
+  echo "BUILDPULSE_ACCOUNT_ID not set. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "BUILDPULSE_ACCOUNT_ID is set."
+
+if not defined BUILDPULSE_REPOSITORY_ID (
+  echo "BUILDPULSE_REPOSITORY_ID not set. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "BUILDPULSE_REPOSITORY_ID is set."
+
+:: 4.Check test-reporter tool
+echo "Checking test-reporter tool."
+
+set "TEST_REPORTER_PATH=C:\test-reporter-windows-amd64.exe"
+if not exist %TEST_REPORTER_PATH% (
+  echo "Cannot find test-reporter tool in %TEST_REPORTER_PATH%. Cannot send results to BuildPulse."
+  exit /b 0
+)
+echo "Test-reporter tool found in %TEST_REPORTER_PATH%."
+
+:: 5.Set test-reporter tool required environment variables
+echo "Setting test-reporter tool required environment variables."
+
+set "GIT_BRANCH=%GIT_REMOTE_REF%"
+:: GIT_COMMIT is already set by Jenkins
+:: BUILD_URL is already set by Jenkins
+set "ORGANIZATION_NAME=%GITHUB_ORG%"
+set "REPOSITORY_NAME=%REPO_NAME%"
+
+echo "GIT_BRANCH set to %GIT_BRANCH%."
+echo "GIT_COMMIT set to %GIT_COMMIT%."
+echo "BUILD_URL set to %BUILD_URL%."
+echo "ORGANIZATION_NAME set to %ORGANIZATION_NAME%."
+echo "REPOSITORY_NAME set to %REPOSITORY_NAME%."
+
+:: GIT_URL is required for the test-reporter tool
+:: We can hardcode it since we enforce nodejs/node
+if "%GIT_URL%"=="" set "GIT_URL=https://github.com/%ORGANIZATION_NAME%/%REPOSITORY_NAME%"
+echo "GIT_URL set to %GIT_URL%."
+
+:: 6.Send results to BuildPulse
+echo "Sending data to BuildPulse."
+
+:: Add available tags for easier navigation in BuildPulse
+set "TAGS=%NODE_NAME% %nodes% v%NODEJS_MAJOR_VERSION%"
+if defined NODEJS_VERSION (
+  set "TAGS=%TAGS% v%NODEJS_VERSION%"
+)
+
+:: Edit BUILD_URL to enable better grouping in BuildPulse
+set "BUILD_URL_BACKUP=%BUILD_URL%"
+for /f "usebackq delims=" %%i in (`powershell -File "%~dp0modify-build-url.ps1" -BUILD_URL "%BUILD_URL%"`) do set "BUILD_URL=%%i"
+%TEST_REPORTER_PATH% submit %1 --account-id %BUILDPULSE_ACCOUNT_ID% --repository-id %BUILDPULSE_REPOSITORY_ID% --tags "%TAGS%"
+set "BUILD_URL=%BUILD_URL_BACKUP%"
+exit /b 0

--- a/jenkins/scripts/windows/modify-build-url.ps1
+++ b/jenkins/scripts/windows/modify-build-url.ps1
@@ -1,0 +1,17 @@
+# USED FOR MODIFYING BUILD_URL SENT TO BUILDPULSE FOR BETTER GROUPING
+param (
+    [string]$BUILD_URL
+)
+
+# If url ends with "/" we have to correct splitting
+$CORRECTION = 0
+if ($BUILD_URL -Match '/$') {
+    $CORRECTION = 1
+}
+
+# We need to remove configuration part from url
+$URL_PARTS = $BUILD_URL -Split '/'
+$URL_PARTS = $URL_PARTS[0..($URL_PARTS.Length - (3 + $CORRECTION))] + $URL_PARTS[-(1 + $CORRECTION)]
+$BUILD_URL = $URL_PARTS -Join '/'
+
+Write-Output $BUILD_URL

--- a/jenkins/scripts/windows/test.cmd
+++ b/jenkins/scripts/windows/test.cmd
@@ -21,9 +21,15 @@ if exist test.tap (
   tap2junit -i test.tap -o js-tests.junit.xml
   if errorlevel 1 exit /b
 )
+if exist js-tests.junit.xml (
+  call %~dp0buildpulse.cmd js-tests.junit.xml
+)
 if exist cctest.tap (
   tap2junit -i cctest.tap -o cctest.junit.xml
   if errorlevel 1 exit /b
+)
+if exist cctest.junit.xml (
+  call %~dp0buildpulse.cmd cctest.junit.xml
 )
 
 :: The JUnit Plugin only marks the job as Unstable when it finds any kind of failure, including flaky tests.


### PR DESCRIPTION
This commit adds initial BuildPulse support by optionally uploading test results there. If the machine is not configured to connect to BuildPulse, or if any condition is not met, the data will not be sent. If the upload fails, the test job will just continue.

For now, this is a PoC and only Windows machines can upload results. If we decide to move forward with it, other platforms will be added.

The current situation in the CI is that only the recently added Windows 10 and Windows 11 machines (8 in total) are configured to send the data. There is also this [copy of node-test-commit-windows-fanned](https://ci.nodejs.org/job/mefi-buildpulse-node-test-commit-windows-fanned/) which I used to test the flow while working on these changes.

Once this lands, we'll start gathering results from all CI runs (PRs and daily builds) and soon, we'll see a part of what BuildPulse can bring to the table. The changes are safe as they enable optional behavior that cannot fail the CI job. The idea is to let this run for some time (BuildPulse keeps data for 14 days) until we can see some meaningful data. The dashboard can be seen [here](https://app.buildpulse.io/@StefanStojanovic/node), and I'm sure @siddhantdange can help with accessing it if someone has an issue with that. After that, it can be further discussed if this will move forward and how. If not, we can even drop this commit to keep the build repo cleaner.

cc @nodejs/build

Refs: https://github.com/nodejs/build/issues/3575