### PR TITLE
ansible: migrate test-softlayer-ubuntu1404-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -174,6 +174,7 @@ hosts:
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
         ubuntu1804-x64-2: {ip: 50.97.245.9}
+        ubuntu2204-x64-1: {ip: 169.60.150.82}
         ubuntu2204_docker-x64-1: {ip: 52.117.26.9}
 
     - equinix_mnx:
@@ -332,4 +333,3 @@ hosts:
         centos7-x64-1: {ip: 50.23.85.250}
         debian10-x64-1: {ip: 169.44.16.126}
         debian12-x64-1: {ip: 169.60.150.88}
-        ubuntu1404-x64-1: {ip: 50.97.245.5}


### PR DESCRIPTION
Remove test-softlayer-ubuntu1404-x64-1 which is in an IBM data center (SJC1) that is closing.

Replace with [test-ibm-ubuntu2204-x64-1](https://ci.nodejs.org/computer/test-ibm-ubuntu2204-x64-1/).

Refs: https://github.com/nodejs/build/issues/3279