### PR TITLE
ansible: migrate test-ibm-ubuntu1804-x64-2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -173,8 +173,8 @@ hosts:
         rhel8-x64-2: {ip: 169.61.75.58, build_test_v8: yes}
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
-        ubuntu1804-x64-2: {ip: 50.97.245.9}
         ubuntu2204-x64-1: {ip: 169.60.150.82}
+        ubuntu2204-x64-2: {ip: 169.44.168.2}
         ubuntu2204_docker-x64-1: {ip: 52.117.26.9}
 
     - equinix_mnx:


### PR DESCRIPTION
Remove test-ibm-ubuntu1804-x64-2 which is in an IBM data center (SJC1) that is closing.

Replace with [test-ibm-ubuntu2204-x64-2](https://ci.nodejs.org/computer/test-ibm-ubuntu2204-x64-2/).

Refs: https://github.com/nodejs/build/issues/3279

---

I'm unable to create new Ubuntu 18.04 servers in IBM Cloud, so I've opted for another Ubuntu 22.04.