### PR TITLE
use gcc 12 on rhel8-s390x for Node.js 22

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -104,7 +104,7 @@ packages: {
   ],
 
   rhel8: [
-    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-13,git,make,python3',
+    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,git,make,python3',
   ],
 
   rhel9: [

--- a/ansible/roles/build-test-v8/files/gcc-bug-113960.patch
+++ b/ansible/roles/build-test-v8/files/gcc-bug-113960.patch
@@ -1,0 +1,57 @@
+--- a/usr/include/c++/12/bits/stl_algobase.h
++++ b/usr/include/c++/12/bits/stl_algobase.h
+@@ -1778,11 +1778,14 @@
+     }
+
+ #if __cpp_lib_three_way_comparison
+-  // Iter points to a contiguous range of unsigned narrow character type
+-  // or std::byte, suitable for comparison by memcmp.
+-  template<typename _Iter>
+-    concept __is_byte_iter = contiguous_iterator<_Iter>
+-      && __is_memcmp_ordered<iter_value_t<_Iter>>::__value;
++  // Both iterators refer to contiguous ranges of unsigned narrow characters,
++  // or std::byte, or big-endian unsigned integers, suitable for comparison
++  // using memcmp.
++  template<typename _Iter1, typename _Iter2>
++    concept __memcmp_ordered_with
++      = (__is_memcmp_ordered_with<iter_value_t<_Iter1>,
++                                 iter_value_t<_Iter2>>::__value)
++         && contiguous_iterator<_Iter1> && contiguous_iterator<_Iter2>;
+
+   // Return a struct with two members, initialized to the smaller of x and y
+   // (or x if they compare equal) and the result of the comparison x <=> y.
+@@ -1832,20 +1835,20 @@
+       if (!std::__is_constant_evaluated())
+        if constexpr (same_as<_Comp, __detail::_Synth3way>
+                      || same_as<_Comp, compare_three_way>)
+-         if constexpr (__is_byte_iter<_InputIter1>)
+-           if constexpr (__is_byte_iter<_InputIter2>)
+-             {
+-               const auto [__len, __lencmp] = _GLIBCXX_STD_A::
+-                 __min_cmp(__last1 - __first1, __last2 - __first2);
+-               if (__len)
+-                 {
+-                   const auto __c
+-                     = __builtin_memcmp(&*__first1, &*__first2, __len) <=> 0;
+-                   if (__c != 0)
+-                     return __c;
+-                 }
+-               return __lencmp;
+-             }
++         if constexpr (__memcmp_ordered_with<_InputIter1, _InputIter2>)
++           {
++             const auto [__len, __lencmp] = _GLIBCXX_STD_A::
++               __min_cmp(__last1 - __first1, __last2 - __first2);
++             if (__len)
++               {
++                 const auto __blen = __len * sizeof(*__first1);
++                 const auto __c
++                   = __builtin_memcmp(&*__first1, &*__first2, __blen) <=> 0;
++                 if (__c != 0)
++                   return __c;
++               }
++             return __lencmp;
++           }
+
+       while (__first1 != __last1)
+        {

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
@@ -8,7 +8,7 @@
 # Newer V8 builds require Python 3.8, or later.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['GConf2-devel', 'python2', 'python2-pip', 'python39']
+    name: ['GConf2-devel', 'python2', 'python2-pip', 'python39', 'patch']
     state: present
   notify: package updated
 
@@ -35,3 +35,11 @@
     executable: pip-3
     name: ['httplib2', 'six']
     state: present
+
+- name: temporary patch for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=113960
+  ansible.posix.patch:
+    basedir: /opt/rh/gcc-toolset-12/root/
+    ignore_whitespace: true
+    src: gcc-bug-113960.patch
+    strip: 1
+  become: true

--- a/ansible/roles/gn/vars/main.yml
+++ b/ansible/roles/gn/vars/main.yml
@@ -7,6 +7,4 @@ compiler: {
 }
 
 gn_select_compiler: "{{ compiler[os]|default(compiler[os|stripversion])|default('true') }}"
-# Pin gn for now so we can still build older versions of V8 in Node.js 14.
-# Refs: https://github.com/nodejs/node/pull/40689#issuecomment-956303875
-gn_version: 69ec4fc
+gn_version: 88e8054

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -47,6 +47,16 @@ case $NODE_NAME in
         ;;
       *)
         echo "Setting compiler for Node.js $NODEJS_MAJOR_VERSION on" `cat /etc/redhat-release`
+        if [ "$NODEJS_MAJOR_VERSION" -gt "21" ]; then
+          # s390x, use later toolset to avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106355
+          if [ "$SELECT_ARCH" = "S390X" ]; then
+            . /opt/rh/gcc-toolset-12/enable
+            export CC="ccache gcc"
+            export CXX="ccache g++"
+            echo "Selected compiler:" `${CXX} -dumpversion`
+            return
+          fi
+        fi
         if [ "$NODEJS_MAJOR_VERSION" -gt "19" ]; then
           . /opt/rh/gcc-toolset-10/enable
           export CC="ccache gcc"


### PR DESCRIPTION
- ansible: add libatomic-devel to gcc toolsets
- ansible: build newer version of gn
- jenkins: use gcc 12 on rhel8-s390x for Node.js 22

Refs: https://github.com/nodejs/build/issues/3630
Fixes: https://github.com/nodejs/build/issues/3335