### PR TITLE
ansible: migrate release-ibm-rhel8-x64-2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -47,7 +47,7 @@ hosts:
         rhel7-s390x-1: {ip: 148.100.84.166, user: linux1}
         rhel8-s390x-1: {ip: 148.100.84.45, user: linux1}
         rhel8-x64-1: {ip: 169.62.77.228}
-        rhel8-x64-2: {ip: 50.97.245.10}
+        rhel8-x64-2: {ip: 52.117.26.5}
 
     - iinthecloud:
         ibmi73-ppc64_be-1: {ip: 65.183.160.62, user: nodejs}


### PR DESCRIPTION
Replace the [release-ibm-rhel8-x64-2](https://ci-release.nodejs.org/computer/release%2Dibm%2Drhel8%2Dx64%2D2/) hosted in SJC1 to a new server (hosted at DAL13).

Refs: https://github.com/nodejs/build/issues/3279