### PR TITLE
ansible: add test-ibm-rhel9-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -172,6 +172,7 @@ hosts:
         rhel8-x64-1: {ip: 169.61.75.51, build_test_v8: yes}
         rhel8-x64-2: {ip: 169.61.75.58, build_test_v8: yes}
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
+        rhel9-x64-1: {ip: 169.60.150.92}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
         ubuntu2204-x64-1: {ip: 169.60.150.82}
         ubuntu2204-x64-2: {ip: 169.44.168.2}
@@ -330,6 +331,5 @@ hosts:
         win2022_vs2022-x64-6: {}
 
     - softlayer:
-        centos7-x64-1: {ip: 50.23.85.250}
         debian10-x64-1: {ip: 169.44.16.126}
         debian12-x64-1: {ip: 169.60.150.88}

--- a/ansible/roles/baselayout/tasks/partials/repo/rhel9.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/rhel9.yml
@@ -1,0 +1,14 @@
+---
+
+# Red Hat Enterprise Linux 9
+
+- name: install GPG key for EPEL 9
+  become: yes
+  ansible.builtin.rpm_key:
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+    state: present
+
+- name: install EPEL 8
+  ansible.builtin.dnf:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state: present

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -107,6 +107,10 @@ packages: {
     'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-13,git,make,python3',
   ],
 
+  rhel9: [
+    'ccache,cmake,gcc-c++,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,git,make,python3',
+  ],
+
   smartos: [
     'gccmakedep',
     'git',

--- a/ansible/roles/bootstrap/tasks/partials/rhel9.yml
+++ b/ansible/roles/bootstrap/tasks/partials/rhel9.yml
@@ -1,0 +1,21 @@
+---
+
+# Red Hat Enterprise Linux 9
+
+# Set the hostname as it will be used by subscription manager.
+- name: gather facts
+  setup:
+
+- name: set hostname
+  ansible.builtin.hostname:
+    name: "{{ inventory_hostname | regex_replace('_', '--') }}"
+
+- name: register Red Hat subscription
+  community.general.redhat_subscription:
+    activationkey: "{{ secrets.rh_activationkey }}"
+    org_id: "{{ secrets.rh_org }}"
+    state: present
+
+- name: set up swap on Linux
+  include_tasks: linux-swap.yml
+  when: swap_file_size_mb is defined

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -17,6 +17,7 @@ packages: {
   'macos': 'temurin17',
   'rhel7': 'java-11-openjdk',
   'rhel8': 'java-17-openjdk',
+  'rhel9': 'java-17-openjdk',
   'smartos': 'openjdk11',
   'ubuntu': 'openjdk-17-jre-headless',
   'ubuntu1604': 'openjdk-8-jre-headless',

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel9.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel9.yml
@@ -1,0 +1,16 @@
+---
+
+#
+# install tap2junit from pip
+#
+
+- name: install pip
+  ansible.builtin.dnf: 
+    name: python3-pip
+    state: present
+
+- name: install tap2junit
+  ansible.builtin.pip:
+    executable: /usr/bin/pip3
+    name: tap2junit=={{ tap2junit_version }}
+    state: present

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -9,7 +9,7 @@ init: {
   freebsd: 'freebsd',
   ibmi: 'ibmi73',
   macos: 'macos',
-  systemd: ['centos7', 'debian', 'fedora', 'rhel7', 'rhel8', 'ubuntu1604', 'ubuntu1804','ubuntu2204'],
+  systemd: ['centos7', 'debian', 'fedora', 'rhel7', 'rhel8', 'rhel9', 'ubuntu1604', 'ubuntu1804','ubuntu2204'],
   svc: 'smartos',
   zos_start: 'zos'
   }

--- a/ansible/roles/package-upgrade/handlers/partials/rhel9.yml
+++ b/ansible/roles/package-upgrade/handlers/partials/rhel9.yml
@@ -1,0 +1,19 @@
+---
+
+# Red Hat Enterpise Linux 9 bootstrap handlers
+
+# If packages are updated, force a check-in with Subscription Manager to
+# reflect the current state.
+- name: clear rhsm cache
+  ansible.builtin.file:
+    name: /var/lib/rhsm/cache/profile.json
+    state: absent
+
+- name: stop rhsmcertd
+  ansible.builtin.systemd:
+    name: rhsmcertd
+    state: stopped
+
+- name: run rhsmcertd
+  ansible.builtin.command:
+    cmd: rhsmcertd --now

--- a/ansible/roles/package-upgrade/vars/main.yml
+++ b/ansible/roles/package-upgrade/vars/main.yml
@@ -7,7 +7,7 @@
   pm: {
     'yum': ['centos', 'rhel7', 'aix72', 'ibmi'],
     'apt': ['debian', 'ubuntu'],
-    'dnf': ['aix73', 'fedora', 'rhel8'],
+    'dnf': ['aix73', 'fedora', 'rhel8', 'rhel9'],
     'pkgng': 'freebsd',
     'pkgin': 'smartos',
     'chocolatey': 'win',


### PR DESCRIPTION
Replace test-centos7-x64-1 which was hosted on IBM Cloud at SJC1 (which is closing) with a new IBM Cloud hosted server running RHEL 9.

Refs: https://github.com/nodejs/build/issues/3279