### PR TITLE
ansible: add swap to DigitalOcean rhel8-x64 VMs

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -35,7 +35,7 @@ hosts:
   - release:
 
     - digitalocean:
-        rhel8-x64-1: {ip: 159.203.115.217}
+        rhel8-x64-1: {ip: 159.203.115.217, swap_file_size_mb: 2048}
 
     - ibm:
         aix72-ppc64_be-1:
@@ -127,7 +127,7 @@ hosts:
         fedora39-x64-1: {ip: 159.203.117.50}
         freebsd12-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd12-x64-2: {ip: 107.170.28.213, user: freebsd}
-        rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes}
+        rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}


### PR DESCRIPTION
Add swap memory to DigitalOcean hosted rhel8-x64 droplets so that they are similar to the IBM Cloud hosted ones.

Refs: https://github.com/nodejs/build/issues/3669