### PR TITLE
ansible: add test-digitalocean-rhel9-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -128,6 +128,7 @@ hosts:
         freebsd12-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd12-x64-2: {ip: 107.170.28.213, user: freebsd}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}
+        rhel9-x64-1: {ip: 134.122.12.240}
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -128,7 +128,7 @@ hosts:
         freebsd12-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd12-x64-2: {ip: 107.170.28.213, user: freebsd}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel9-x64-1: {ip: 134.122.12.240}
+        rhel9-x64-1: {ip: 134.122.12.240, swap_file_size_mb: 2048}
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
@@ -172,7 +172,7 @@ hosts:
         rhel8-x64-1: {ip: 169.61.75.51, build_test_v8: yes}
         rhel8-x64-2: {ip: 169.61.75.58, build_test_v8: yes}
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
-        rhel9-x64-1: {ip: 169.60.150.92}
+        rhel9-x64-1: {ip: 169.60.150.92, swap_file_size_mb: 2048}
         ubuntu1804-x64-1: {ip: 52.117.26.14, alias: jenkins-workspace-6}
         ubuntu2204-x64-1: {ip: 169.60.150.82}
         ubuntu2204-x64-2: {ip: 169.44.168.2}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -16,7 +16,7 @@ sshd_service_map: {
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
 
 ntp_service: {
-  chrony: ['rhel8', 'debian11'],
+  chrony: ['rhel8', 'rhel9', 'debian11'],
   systemd: ['debian8', 'debian10', 'debian12', 'ubuntu']
 }
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/pull/3663

---

Created with custom image `rhel-9.3-x86_64-kvm.qcow2` uploaded to DigitalOcean from https://access.redhat.com/downloads/content/rhel.