### PR TITLE
ansible: upgrade test-digitalocean-ubuntu1804_docker-x64-2 to Ubuntu 22.04

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -130,7 +130,7 @@ hosts:
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}
         rhel9-x64-1: {ip: 134.122.12.240, swap_file_size_mb: 2048}
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
-        ubuntu1804_docker-x64-2: {ip: 159.89.183.200}
+        ubuntu2204_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
         ubuntu2204-x64-1: {ip: 138.197.4.1}
         ubuntu2204-x64-2: {ip: 167.99.124.188}


### PR DESCRIPTION
Closes: https://github.com/nodejs/build/issues/3681
