### PR TITLE
ansible: add 2GB swap to debian x64 hosts

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -111,8 +111,8 @@ hosts:
         msft-win2016_vs2017-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
 
     - digitalocean:
-        debian11-x64-1: {ip: 174.138.79.159}
-        debian12-x64-1: {ip: 159.203.105.159}
+        debian11-x64-1: {ip: 174.138.79.159, swap_file_size_mb: 2048}
+        debian12-x64-1: {ip: 159.203.105.159, swap_file_size_mb: 2048}
         fedora37-x64-1: {ip: 159.65.248.149}
         fedora38-x64-1: {ip: 162.243.187.89}
         fedora38-x64-2: {ip: 134.209.172.40}
@@ -306,4 +306,4 @@ hosts:
 
     - softlayer:
         debian10-x64-1: {ip: 169.44.16.126}
-        debian12-x64-1: {ip: 169.60.150.88}
+        debian12-x64-1: {ip: 169.60.150.88, swap_file_size_mb: 2048}

--- a/ansible/roles/bootstrap/tasks/partials/debian12.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian12.yml
@@ -1,0 +1,9 @@
+---
+
+#
+# debian 12
+#
+
+- name: set up swap on Linux
+  include_tasks: linux-swap.yml
+  when: swap_file_size_mb is defined


### PR DESCRIPTION
Adds 2GB swap to
- test-digitalocean-debian11-x64-1
- test-digitalocean-debian12-x64-1
- test-softlayer-debian12-x64-1

in an attempt to stabilize the CI after recent V8 updates.