### PR TITLE
jenkins: skip Alpine 3.18 on Node.js >=22

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -25,7 +25,7 @@ def buildExclusions = [
   [ /^centos7-(arm)?64-gcc8/,         anyType,     gte(18) ], // 18.x: centos7 builds stop
   [ /^centos7-64/,                    anyType,     gte(18) ],
   [ /debian10/,                       anyType,     gte(21) ],
-  [ /alpine-last-latest/,             anyType,     gte(23) ], // Alpine 3.18. Bug in GCC 12.2.
+  [ /alpine-last-latest/,             anyType,     gte(22) ], // Alpine 3.18. Bug in GCC 12.2.
   [ /rhel7/,                          anyType,     gte(18) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(18) ], // 32-bit linux for <10 only
   [ /^ubuntu1604-64/,                 anyType,     gte(18) ],


### PR DESCRIPTION
Required if we want to backport C++20 support on Node.js 22.

Refs: https://github.com/nodejs/node/pull/52838