### PR TITLE
jenkins: always select gcc-11 on Debian 12

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -212,11 +212,9 @@ elif [ "$SELECT_ARCH" = "X64" ]; then
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;
     debian12-x64 )
-      if [ "$NODEJS_MAJOR_VERSION" -gt "22" ]; then
-        export CC="ccache gcc-11"
-        export CXX="ccache g++-11"
-        export LINK="g++-11"
-      fi
+      export CC="ccache gcc-11"
+      export CXX="ccache g++-11"
+      export LINK="g++-11"
       echo "Compiler set to GCC" `$CXX -dumpversion`
       ;;
   esac


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/52838

I think it makes sense as this is a lower version than the default one.