### PR TITLE
ansible: fix adoptopenjdk metadata fetch

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -57,6 +57,7 @@
   check_mode: no
   register: adoptopenjdk_metadata
   uri:
+    body: ""
     body_format: json
     return_content: yes
     status_code: 200

--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -57,8 +57,6 @@
   check_mode: no
   register: adoptopenjdk_metadata
   uri:
-    body: ""
-    body_format: json
     return_content: yes
     status_code: 200
     url: "https://api.adoptopenjdk.net/v3/assets/feature_releases/{{ adoptopenjdk_version }}/ga?architecture={{ adoptopenjdk_arch }}&image_type=jre&jvm_impl=openj9&os={{ adoptopenjdk_os }}&project=jdk&heap_size=normal&page_size=1&sort_method=DEFAULT&sort_order=DESC&vendor=adoptopenjdk"


### PR DESCRIPTION
Pass an empty `body` when fetching AdoptOpenJDK metadata to prevent getting a 403 error from CloudFlare.

Fixes: https://github.com/nodejs/build/issues/3710