### PR TITLE
ansible: pin 7-zip to 22.01

### DIFF
--- a/ansible/roles/baselayout-windows/tasks/main.yml
+++ b/ansible/roles/baselayout-windows/tasks/main.yml
@@ -56,8 +56,18 @@
     when: gyp_stat.stat.exists
 
 # Necessary for compressing the Node package
+# Pinned to v22.01 because later (v23.01) has issues when extracting ARM64 node.exe
 - name: install 7Zip
-  win_chocolatey: name=7zip
+  win_chocolatey:
+    name: 7zip
+    pinned: yes
+    version: "22.1.0"
+
+- name: install 7Zip
+  win_chocolatey:
+    name: 7zip.install
+    pinned: yes
+    version: "22.1.0"
 
 # Utilities
 - block:


### PR DESCRIPTION
Windows ARM64 cross-compiled node.exe cannot be extracted from `.7z` file on Windows 11 because of the way the latest version of 7-zip (v23.01) packs it. This pins the `7zip` and `7zip.install` Chocolatey packages to the version that works.

This change is already applied to all machines that do compilation in both release and test CI (VS2019 and VS2022 machines in Rackspace)

Fixes: https://github.com/nodejs/build/issues/3695