### PR TITLE
ansible: add ClangCL to VS2022

### DIFF
--- a/ansible/roles/visual-studio/tasks/partials/vs2022.yml
+++ b/ansible/roles/visual-studio/tasks/partials/vs2022.yml
@@ -9,10 +9,11 @@
   win_chocolatey: name=visualstudio2022community
 
 # Note: The .NET SDK was added as a prerequisite for WiX4 - https://github.com/nodejs/node/pull/45943
+# Note: Clang components were aded as a prerequisite for v23 - https://github.com/nodejs/node/pull/52870
 - name: install Visual Studio Community 2022 Native Desktop Workload
   win_chocolatey:
       name: visualstudio2022-workload-nativedesktop
-      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK'
+      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK --add Microsoft.VisualStudio.Component.VC.Llvm.Clang'
 
 - name: install WiX Toolset
   import_tasks: 'wixtoolset.yml'


### PR DESCRIPTION
This is a part of an effort to enable compilation with Clang on Windows. This commit enables building with ClangCL in the CI.

This change is already applied to all VS2022 machines in the test and release CI. Note, that changing `params` for the `win_chocolatey` doesn't trigger installing a new component, so I installed these components manually on the existing machines.

After everything is ready in the main repo, I'll rework Jenkins jobs and make changes needed to this repo to enable compiling and testing Clang compiled Node.js.

Fixes: https://github.com/nodejs/build/issues/3709