### PR TITLE
meta: add Stefan Stojanovic to infra admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Above list is manually synced with the [gpg member list](https://github.com/node
 * [@MoLow](https://github.com/MoLow) - Moshe Atlow
 * [@richardlau](https://github.com/richardlau) - Richard Lau
 * [@rvagg](https://github.com/rvagg) - Rod Vagg
+* [@StefanStojanovic](https://github.com/StefanStojanovic) - Stefan Stojanovic
 * [@sxa](https://github.com/sxa) - Stewart X Addison
 * [@targos](https://github.com/targos) - Michaël Zasso
 * [@UlisesGascon](https://github.com/UlisesGascon) - Ulises Gascón


### PR DESCRIPTION
I would like to include Stefan Stojanovic (@StefanStojanovic) in the infra admin team.

Stefan has fully ramped up and taken all of my tasks related to Node.js. I believe he is fully prepared and his help will be valuable in maintaining the Windows infrastructure. With full access to infra, Stefan can create and delete Windows machines himself, debug Jenkins issues, and generally be proactive in maintaining the Windows machines.

I can remain on the team as a backup for a while longer, but given my level of involvement, I will eventually move to emeritus.

Stefan will need to be added to the @nodejs/build-infra team by someone with permission if this is approved. I can add him to the secrets repo folder and will check if I can create a Rackspace account for him.

cc @nodejs/build 
