### PR TITLE
jenkins: pack embedtest.exe for Windows builds

### DIFF
--- a/jenkins/scripts/windows/ci-cleanup.cmd
+++ b/jenkins/scripts/windows/ci-cleanup.cmd
@@ -1,6 +1,7 @@
 :: Processes that can and have interfered with CI in the past
 taskkill /t /f /fi "IMAGENAME eq node.exe"
 taskkill /t /f /fi "IMAGENAME eq cctest.exe"
+taskkill /t /f /fi "IMAGENAME eq embedtest.exe"
 taskkill /t /f /fi "IMAGENAME eq run-tests.exe"
 taskkill /t /f /fi "IMAGENAME eq msbuild.exe"
 taskkill /t /f /fi "IMAGENAME eq mspdbsrv.exe"

--- a/jenkins/scripts/windows/node-compile-windows.cmd
+++ b/jenkins/scripts/windows/node-compile-windows.cmd
@@ -15,7 +15,7 @@ call %~dp0compile.cmd
 if errorlevel 1 exit /b
 
 :: Select files to pack
-set "BINARY_FILES=config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/node.pdb"
+set "BINARY_FILES=config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/embedtest.exe Release/node.pdb"
 if exist Release\node_test_engine.dll set "BINARY_FILES=%BINARY_FILES% Release/node_test_engine.dll"
 if exist Release\overlapped-checker.exe set "BINARY_FILES=%BINARY_FILES% Release/overlapped-checker.exe"
 

--- a/jenkins/scripts/windows/node-compile-windows.cmd
+++ b/jenkins/scripts/windows/node-compile-windows.cmd
@@ -15,7 +15,8 @@ call %~dp0compile.cmd
 if errorlevel 1 exit /b
 
 :: Select files to pack
-set "BINARY_FILES=config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/embedtest.exe Release/node.pdb"
+set "BINARY_FILES=config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/node.pdb"
+if exist Release\embedtest.exe set "BINARY_FILES=%BINARY_FILES% Release/embedtest.exe"
 if exist Release\node_test_engine.dll set "BINARY_FILES=%BINARY_FILES% Release/node_test_engine.dll"
 if exist Release\overlapped-checker.exe set "BINARY_FILES=%BINARY_FILES% Release/overlapped-checker.exe"
 

--- a/jenkins/scripts/windows/test.cmd
+++ b/jenkins/scripts/windows/test.cmd
@@ -6,7 +6,8 @@ md5sum binary/binary.tar.gz
 tar xzvf binary/binary.tar.gz
 if errorlevel 1 exit /b
 if exist out\Release\node.exe ln -s out/Release Release
-md5sum config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/embedtest.exe Release/node.pdb
+md5sum config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe
+if exist Release\embedtest.exe md5sum Release/embedtest.exe
 
 :: Run the tests
 call :diagnostics Before

--- a/jenkins/scripts/windows/test.cmd
+++ b/jenkins/scripts/windows/test.cmd
@@ -6,7 +6,7 @@ md5sum binary/binary.tar.gz
 tar xzvf binary/binary.tar.gz
 if errorlevel 1 exit /b
 if exist out\Release\node.exe ln -s out/Release Release
-md5sum config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe
+md5sum config.gypi icu_config.gypi Release/node.exe Release/node.lib Release/openssl-cli.exe Release/cctest.exe Release/embedtest.exe Release/node.pdb
 
 :: Run the tests
 call :diagnostics Before

--- a/jenkins/xml/citgm-smoker.xml
+++ b/jenkins/xml/citgm-smoker.xml
@@ -362,6 +362,7 @@ $CITGM_COMMAND --nodedir=$npm_config_nodedir -v $CITGM_LOGLEVEL -x $PWD/report.x
         <hudson.tasks.BatchFile>
           <command>TASKKILL /F /IM node.exe /T || TRUE&#xd;
 TASKKILL /F /IM cctest.exe /T || TRUE&#xd;
+TASKKILL /F /IM embedtest.exe /T || TRUE&#xd;
 TASKKILL /F /IM run-tests.exe /T || TRUE&#xd;
 &#xd;
 :: smoker dir is only for the report, Release is used to run because there&apos;s no make install&#xd;
@@ -432,6 +433,7 @@ echo on&#xd;
 &#xd;
 TASKKILL /F /IM node.exe /T || TRUE&#xd;
 TASKKILL /F /IM cctest.exe /T || TRUE&#xd;
+TASKKILL /F /IM embedtest.exe /T || TRUE&#xd;
 TASKKILL /F /IM run-tests.exe /T || TRUE&#xd;
 </command>
         </hudson.tasks.BatchFile>


### PR DESCRIPTION
CI runs for PR https://github.com/nodejs/node/pull/52646 fail because the `embedtest.exe` is not packaged along with other binary files and it cannot be found by the test being enabled.

This PR changes Jenkins Windows scripts to treat `embedtest.exe` the same way as `cctest.exe`.
The only difference is that we check that `embedtest.exe` file exists.
It must unblock the PR https://github.com/nodejs/node/pull/52646.
