### PR TITLE
Ansible: updates to support smartos21/23 test hosts.

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -226,6 +226,11 @@ hosts:
                 PATH: /rsusr/rocket/python-2017-04-12-py27/python27/bin:/bin:/rsusr/rocket/bin
                 SSL_CERT_FILE: "{{ home }}/{{ server_user }}/ca-bundle.crt"
             server_jobs: 4
+    - mnx:
+        smartos21-x64-1: {ip: 8.225.232.135}
+        smartos21-x64-2: {ip: 8.225.232.137}
+        smartos23-x64-1: {ip: 8.225.232.134}
+        smartos23-x64-2: {ip: 8.225.232.141}
 
     - osuosl:
         # secret for -1 was compromised, do not use -1 name

--- a/ansible/plugins/inventory/nodejs_yaml.py
+++ b/ansible/plugins/inventory/nodejs_yaml.py
@@ -47,7 +47,7 @@ valid = {
 
     # providers - validated for consistency
     'provider': ('azure', 'digitalocean', 'equinix', 'ibm', 'iinthecloud', 'joyent',
-                 'linuxonecc', 'hetzner', 'macstadium', 'marist', 'mininodes', 'msft',
+                 'linuxonecc', 'hetzner', 'macstadium', 'marist', 'mininodes', 'mnx', 'msft',
                  'orka', 'osuosl', 'rackspace',
                  'rzkh', 'scaleway', 'softlayer', 'voxer')
 }

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -10,7 +10,8 @@ git_version: 2.10.2
 ssh_config: /etc/ssh/sshd_config
 
 sshd_service_map: {
-  'smartos18': 'ssh',
+  'smartos21': 'ssh',
+  'smartos23': 'ssh',
 }
 
 sshd_service_name: "{{ sshd_service_map[os]|default(sshd_service_map[os|stripversion])|default('sshd') }}"
@@ -119,18 +120,17 @@ packages: {
     'sudo',
   ],
 
-  smartos18: [
-    'gcc7',
-    'ccache',
-    'python37',
-    'py37-pip'
-  ],
-
-  smartos20: [
+  smartos21: [
     'gcc10',
     'ccache',
-    'python38',
-    'py38-pip'
+    'py310-pip'
+  ],
+
+  smartos23: [
+    'gcc13',
+    'ccache',
+    'python310',
+    'py310-pip'
   ],
 
   ubuntu: [

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/smartos.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/smartos.yml
@@ -1,16 +1,5 @@
 ---
 
-#
-# smartos
-#
-
-- name: smartos | update pip3 symlink
-  when: os == "smartos18"
-  file:
-    dest: "/opt/local/bin/pip3"
-    state: link
-    src: "/opt/local/bin/pip3.7"
-
 - name: install tap2junit
   pip:
     executable: /opt/local/bin/pip3

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -65,8 +65,8 @@ java_path: {
   'macos10.15': 'java',
   'macos11': 'java',
   'macos11.0': 'java',
-  'smartos18': '/opt/local/java/openjdk11/bin/java',
-  'smartos20': '/opt/local/java/openjdk11/bin/java',
+  'smartos21': '/opt/local/java/openjdk11/bin/java',
+  'smartos23': '/opt/local/java/openjdk11/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 


### PR DESCRIPTION
The four hosts are provisioned that will replace the smartos18/20 testing hosts.

I still need access to the test jenkins to get secrets to complete making these available to jenkins.