### PR TITLE
jenkins: stop building on 32-bit Windows for Node.js 23

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -49,6 +49,7 @@ def buildExclusions = [
   [ /vs2017/,                         releaseType, gte(18)       ],
   [ /vs2019-arm64/,                   releaseType, lt(20)        ],
   [ /vs2019/,                         releaseType, gte(21)       ],
+  [ /vs2022-x86/,                     releaseType, gte(23)       ],
   [ /vs2022/,                         releaseType, lt(21)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2015(-\w+)?$/,                 testType,    gte(18)       ],
@@ -56,6 +57,7 @@ def buildExclusions = [
   [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(20)        ], // Temporarily compile Node v20+ on both VS2019 and VS2022
   [ /vs2022-x86$/,                    testType,    lt(20)        ], // Temporarily compile Node v20+ arm64 and x86 on both VS2019 and VS2022
+  [ /vs2022-x86$/,                    testType,    gte(23)       ],
   [ /vs2022-arm64$/,                  testType,    lt(20)        ],
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/53184
