### PR TITLE
ansible: ensure iptables-persistent is installed on jenkins hosts

### DIFF
--- a/ansible/playbooks/jenkins/host/iptables.yml
+++ b/ansible/playbooks/jenkins/host/iptables.yml
@@ -18,6 +18,15 @@
       }
 
   tasks:
+  - name: Update the apt cache
+    apt:
+      update_cache: yes
+
+  - name: Ensure iptables-persistent is installed
+    apt:
+      name: iptables-persistent
+      state: present
+
   - name: add hosts to firewall
     when:
       - not 'ansible_ssh_common_args' in hostvars[host]


### PR DESCRIPTION
ci-release had no iptables defined (but they were preserved in /etc/iptables/rules.v4)

This ensures that on reboot those rules get reloaded.