### PR TITLE
ansible: update sharedlibs containers

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -35,8 +35,7 @@ RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 
 RUN adduser --gid {{ server_user_gid.stdout_lines[0] }} --uid {{ server_user_uid.stdout_lines[0] }} --disabled-password --gecos {{ server_user }} {{ server_user }}
 
-ENV ICU68DIR=/opt/icu-68.1 \
-    ICU69DIR=/opt/icu-69.1 \
+ENV ICU69DIR=/opt/icu-69.1 \
     ICU71DIR=/opt/icu-71.1 \
     ICU73DIR=/opt/icu-73.2
 

--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -111,6 +111,17 @@ RUN mkdir -p /tmp/openssl-$OPENSSL31VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL31VER
 
+ENV OPENSSL32VER 3.2.2
+ENV OPENSSL32DIR /opt/openssl-$OPENSSL32VER
+
+RUN mkdir -p /tmp/openssl-$OPENSSL32VER && \
+    cd /tmp/openssl-$OPENSSL32VER && \
+    curl -sL https://www.openssl.org/source/openssl-$OPENSSL32VER.tar.gz | tar zxv --strip=1 && \
+    ./config --prefix=$OPENSSL32DIR && \
+    make -j $JOBS && \
+    make install && \
+    rm -rf /tmp/openssl-$OPENSSL32VER
+
 ENV ZLIBVER 1.2.13
 ENV ZLIB12DIR /opt/zlib_$ZLIBVER
 


### PR DESCRIPTION
- [ansible: remove ICU 68 from sharedlibs containers](https://github.com/nodejs/build/commit/d5ee0b3221b68879aed6cd151f8cead92d2f964b) 
The earliest supported Node.js version we still build in the CI is 18.x.
For Node.js 18.x, the minimum supported version of ICU is 69.
- [ansible: add OpenSSL 3.2 to sharedlibs containers](https://github.com/nodejs/build/commit/719daecd26ab07f3bec7e50e6ab8b074ac165dd4)