### PR TITLE
metrics: log line with length if parsing fails in process cloudflare

### DIFF
--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -164,7 +164,10 @@ function createPipeline (bucket, filename, processedFile, callback) {
           const jsonparse = JSON.parse(line)
           const printout = logTransform2(jsonparse)
           if (printout !== undefined) { results = results.concat(printout) }
-        } catch (err) { console.log(err) }
+        } catch (err) {
+          console.log('ERROR PARSING: "' + line + '" of length ' + line.length)
+          console.log(err)
+        }
       }
 
       writeBucket.file(processedFile).save(results, function (err) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/3697#issuecomment-2177237274

```console
$> node
Welcome to Node.js v20.14.0.
> line = ''
''
> console.log('ERROR PARSING: "' + line + '" of length ' + line.length)
ERROR PARSING: "" of length 0
```