### PR TITLE
ansible: update nodejs to 20 in Dockerfile

### DIFF
--- a/ansible/roles/metrics/files/index-generator/Dockerfile
+++ b/ansible/roles/metrics/files/index-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:20-slim
 
 WORKDIR /usr/src/app
 

--- a/ansible/roles/metrics/files/process-cloudflare/Dockerfile
+++ b/ansible/roles/metrics/files/process-cloudflare/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15-slim
+FROM node:20-slim
 
 WORKDIR /usr/src/app
 

--- a/ansible/roles/metrics/files/summaries/Dockerfile
+++ b/ansible/roles/metrics/files/summaries/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:20-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/3697#issuecomment-2137861247

I went through the JavaScript source code run in these Dockerfiles, and verified that there are no Node.js APIs being used which were deprecated between Node.js 14.x and 20.x

cc @richardlau 