### PR TITLE
metrics: replace moment with JavaScript Date API

### DIFF
--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -16,7 +16,6 @@
     "@google-cloud/storage": "^5.0.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "moment": "^2.29.1",
     "split2": "~3.1.1",
     "strftime": "~0.10.0"
   },

--- a/ansible/roles/metrics/files/summaries/package.json
+++ b/ansible/roles/metrics/files/summaries/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@google-cloud/storage": "^5.0.0",
     "body-parser": "^1.19.0",
-    "express": "^4.17.1",
-    "moment": "^2.29.1"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "eslint": "^7.8.1"


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/3782

Verified that `moment` and `Date` return same output if you're in GMT.

```js
import moment from 'moment' // v2.30.1

const today = new Date()
const momentDate = moment(today)
console.log(`date from moment: ${moment(momentDate, 'YYYYMMDD').subtract(1, 'days').format('YYYYMMDD')}`)

const yesterday = new Date().getTime() - (24 * 60 * 60 * 1000)
console.log(`date from Date: ${new Date(yesterday).toISOString().slice(0, 10).replace(/-/g, '')}`)
```

```console
date from moment: 20240624
date from Date: 20240624
```

The only difference I noticed is Node.js returns the Date in GMT, and moment returns the date in locale string.
It shouldn't be an issue, since the script is run at 12 PM GMT or 6 AM Central.
