### PR TITLE
ansible: add ClangCL to VS2022 fix

### DIFF
--- a/ansible/roles/visual-studio/tasks/partials/vs2022.yml
+++ b/ansible/roles/visual-studio/tasks/partials/vs2022.yml
@@ -13,7 +13,7 @@
 - name: install Visual Studio Community 2022 Native Desktop Workload
   win_chocolatey:
       name: visualstudio2022-workload-nativedesktop
-      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK --add Microsoft.VisualStudio.Component.VC.Llvm.Clang'
+      params: '--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset'
 
 - name: install WiX Toolset
   import_tasks: 'wixtoolset.yml'


### PR DESCRIPTION
This is a part of an effort to enable compilation with Clang on Windows. This commit allows for building with ClangCL in the CI.

This change is already applied to all VS2022 machines in the test and release CI. Note, that changing params for the win_chocolatey doesn't trigger installing a new component, so I installed these components manually on the existing machines.

Since the installation was done manually, the component I added in this PR was missing in Ansible. but was installed on the CI machines (previously I installed 2 components and only added 1 in Ansible).

Refs: https://github.com/nodejs/build/pull/3714
Refs: https://github.com/nodejs/build/issues/3709