### PR TITLE
metrics: bump @google-cloud/storage to 7.x

### DIFF
--- a/ansible/roles/metrics/files/index-generator/package.json
+++ b/ansible/roles/metrics/files/index-generator/package.json
@@ -10,7 +10,7 @@
   "author": "Ash <email@ashleycripps.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/storage": "^5.0.0",
+    "@google-cloud/storage": "^7.11.2",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/storage": "^5.0.0",
+    "@google-cloud/storage": "^7.11.2",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/ansible/roles/metrics/files/summaries/package.json
+++ b/ansible/roles/metrics/files/summaries/package.json
@@ -10,7 +10,7 @@
   "author": "Ash <email@ashleycripps.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@google-cloud/storage": "^5.0.0",
+    "@google-cloud/storage": "^7.11.2",
     "express": "^4.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Verified that we don't use any APIs which are broken

---

Breaking changes:
* 6.x https://github.com/googleapis/nodejs-storage/blob/main/CHANGELOG.md#600-2022-05-24
* 7.x https://github.com/googleapis/nodejs-storage/blob/main/CHANGELOG.md#700-2023-08-03