### PR TITLE
ansible: update NodeSource repository setup

### DIFF
--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -110,11 +110,6 @@
     value: 0
 
 # Remove old NodeSource repository setup
-- name: Remove old nodesource signing key
-  apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: absent
-
 - name: Get Ubuntu codename
   ansible.builtin.command: "lsb_release -s -c"
   changed_when: no
@@ -129,6 +124,11 @@
 - name: Remove nodesource 16 repo
   apt_repository:
     repo: deb https://deb.nodesource.com/node_16.x {{ release_codename.stdout }} main
+    state: absent
+
+- name: Remove old nodesource signing key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     state: absent
 
 # NodeSource distribution

--- a/ansible/roles/jenkins-workspace/tasks/main.yml
+++ b/ansible/roles/jenkins-workspace/tasks/main.yml
@@ -109,10 +109,11 @@
     scope: file
     value: 0
 
-- name: Add nodesource signing key
+# Remove old NodeSource repository setup
+- name: Remove old nodesource signing key
   apt_key:
     url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: present
+    state: absent
 
 - name: Get Ubuntu codename
   ansible.builtin.command: "lsb_release -s -c"
@@ -120,15 +121,26 @@
   check_mode: no
   register: release_codename
 
-- name: Add nodesource 20 repo
+- name: Remove nodesource 20 repo
   apt_repository:
     repo: deb https://deb.nodesource.com/node_20.x {{ release_codename.stdout }} main
-    state: present
+    state: absent
  
 - name: Remove nodesource 16 repo
   apt_repository:
     repo: deb https://deb.nodesource.com/node_16.x {{ release_codename.stdout }} main
     state: absent
+
+# NodeSource distribution
+- name: Add nodesource signing key
+  ansible.builtin.get_url:
+    dest: /etc/apt/keyrings/nodesource-repo.gpg.asc
+    url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+
+- name: Add nodesource 20 repo
+  apt_repository:
+    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/nodesource-repo.gpg.asc] https://deb.nodesource.com/node_20.x nodistro main
+    state: present
 
 - name: Install node
   package:


### PR DESCRIPTION
The old NodeSource repository stopped updating and the version of Node.js installed from there is old (20.5.1). Update to use the new repository, which will install Node.js 20.15.0 at the time of this change.

Refs: https://github.com/nodesource/distributions/issues/1715

---

I spotted this while working on https://github.com/nodejs/build/pull/3803 (and made a similar update there for the github-bot role).

I've not deployed this yet -- we're planning on [replacing the Equinix machines](https://github.com/nodejs/build/issues/3597) which includes two of the three [`jenkins-workspace`](https://ci.nodejs.org/label/jenkins-workspace/) machines. (I can see there are entries in Jenkins for the replacements, but I don't know the IP addresses so can't Ansible them.)