### PR TITLE
metrics: return failure for date route if it's not 8 digits

### DIFF
--- a/ansible/roles/metrics/files/summaries/summaries.js
+++ b/ansible/roles/metrics/files/summaries/summaries.js
@@ -106,7 +106,7 @@ app.post('/', async (req, res) => {
 app.post('/date/:date', async (req, res) => {
   const date = req.params.date
 
-  if (/^\d{8}$/.test(req.params.date)) {
+  if (!/^\d{8}$/.test(req.params.date)) {
     res.status(400).send('Invalid date. Must be in YYYYMMDD format.')
     return
   }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/3808

---

To avoid any further bugs due to absence of unit tests, I deployed and verified that this fix works

```console
$ curl -X POST "https://produce-summaries-kdtacnjogq-uc.a.run.app/date/20240405" -H "Authorization: Bearer $(gcloud auth print-identity-token)"
```

The summary is created at https://storage.googleapis.com/access-logs-summaries-nodejs/nodejs.org-access.log.20240405.json