### PR TITLE
Updates backup scripts

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -51,9 +51,9 @@ Note: You will likely want ~1Tb storage available on /backup.
 4. Create the folder `/backup` (or edit configs to use another path)
 5. Add scripts to cron:
    ```
-   50 23 * * * /opt/local/bin/rsnapshot -c /opt/local/etc/rsnapshot.conf daily
-   40 23 * * 6 /opt/local/bin/rsnapshot -c /opt/local/etc/rsnapshot.conf weekly && /root/backup_scripts/remove_old.sh ci-release.nodejs.org && /root/backup_scripts/remove_old.sh    ci.nodejs.org
-   30 23 1 * * /opt/local/bin/rsnapshot -c /opt/local/etc/rsnapshot.conf monthly
+   50 23 * * * /usr/bin/rsnapshot -c /usr/local/etc/rsnapshot.conf daily
+   40 23 * * 6 /usr/bin/rsnapshot -c /usr/local/etc/rsnapshot.conf weekly && /root/backup_scripts/remove_old.sh ci-release.nodejs.org && /root/backup_scripts/remove_old.sh    ci.nodejs.org
+   30 23 1 * * /usr/bin/rsnapshot -c /usr/local/etc/rsnapshot.conf monthly
    ```
 6. Edit your ssh config as needed (likely the benchmark host)
 7. Place the backup key retrieved from the secrets repo in

--- a/backup/backup_scripts/dist.sh
+++ b/backup/backup_scripts/dist.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ROOTDIR=/backup/static
+ROOTDIR=/data/backup/static
 
 rsync -az -e "ssh -i /root/.ssh/nodejs_build_backup" root@nodejs-www:/home/dist/nodejs/ $ROOTDIR/dist/nodejs/
 rsync -az -e "ssh -i /root/.ssh/nodejs_build_backup" root@nodejs-www:/home/dist/iojs/ $ROOTDIR/dist/iojs/

--- a/backup/rsnapshot.conf
+++ b/backup/rsnapshot.conf
@@ -1,8 +1,8 @@
 config_version	1.2
-snapshot_root	/backup/periodic/
+snapshot_root	/data/backup/periodic/
 no_create_root	1
 cmd_rm		/usr/bin/rm
-cmd_rsync	/opt/local/bin/rsync
+cmd_rsync	/usr/bin/rsync
 cmd_ssh	/usr/bin/ssh
 cmd_logger	/usr/bin/logger
 


### PR DESCRIPTION
The new backup server is a ubuntu2204 server, and the old server was a smartos15 server.

This updates the scripts to use the proper paths.

Additionally the new server's data is mounted on /data so the root folder has changed. 