### PR TITLE
ansible: fix write-ssh-config modules

### DIFF
--- a/ansible/plugins/library/remmina_config.py
+++ b/ansible/plugins/library/remmina_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright Node.js contributors. All rights reserved.

--- a/ansible/plugins/library/ssh_config.py
+++ b/ansible/plugins/library/ssh_config.py
@@ -64,11 +64,14 @@ def multi_replace(content, to_replace):
         content = content.replace(key, val)
     return content
 
+
 def get_template_section(config):
     return match.search(config).group(1)
 
+
 def is_templatable(config):
     return bool(match.search(config))
+
 
 def render_template(hosts):
     render = Environment()
@@ -103,7 +106,7 @@ def main():
 
     if not is_templatable(contents):
         module.fail_json(msg='Your ssh config lacks template stubs. Check README.md for instructions.')
-    
+
     before_value = get_template_section(contents)
     after_value = render_template(module.params['hostinfo'])
 


### PR DESCRIPTION
- Use `/usr/bin/python` in the shebang to allow `ansible_python_interpreter` to work.
- Compare the template section before and after the change to avoid unnecessary
  changes and to have a correct report in the playbook output.

Closes: https://github.com/nodejs/build/issues/3821
