### PR TITLE
metrics: convert from CommonJS to ES Modules

### DIFF
--- a/ansible/roles/metrics/files/index-generator/index-generator.js
+++ b/ansible/roles/metrics/files/index-generator/index-generator.js
@@ -1,8 +1,9 @@
-const { Storage } = require('@google-cloud/storage')
+import { Storage } from '@google-cloud/storage';
+import express, { json } from 'express';
+
 const storage = new Storage();
-const express = require('express')
 const app = express()
-app.use(express.json())
+app.use(json())
 
 async function getFileList() {
 
@@ -53,4 +54,4 @@ app.post('/', async (req, res) => {
     console.log('Listening on port: ', port)
   })
 
-  module.exports = app
+  export default app

--- a/ansible/roles/metrics/files/index-generator/package.json
+++ b/ansible/roles/metrics/files/index-generator/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index-generator.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "index-generator": "node --trace-warnings index-generator.js"

--- a/ansible/roles/metrics/files/process-cloudflare/package.json
+++ b/ansible/roles/metrics/files/process-cloudflare/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "process-cloudflare.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "processLogs": "node --trace-warnings process-cloudflare.js"

--- a/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
+++ b/ansible/roles/metrics/files/process-cloudflare/process-cloudflare.js
@@ -2,11 +2,11 @@
 
 'use strict'
 
-const { Storage } = require('@google-cloud/storage')
-const express = require('express')
-const app = express()
+import { Storage } from '@google-cloud/storage'
+import express, { json } from 'express'
 
-app.use(express.json())
+const app = express()
+app.use(json())
 
 const extensionRe = /\.(tar\.gz|tar\.xz|pkg|msi|exe|zip|7z)$/
 const uriRe = /(\/+(dist|download\/+release)\/+(node-latest\.tar\.gz|([^/]+)\/+((win-x64|win-x86|win-arm64|x64)?\/+?node\.exe|(x64\/)?node-+(v[0-9.]+)[.-]([^? ]+))))/
@@ -230,4 +230,4 @@ app.listen(port, () => {
   console.log('Listening on port: ', port)
 })
 
-module.exports = app
+export default app

--- a/ansible/roles/metrics/files/summaries/package.json
+++ b/ansible/roles/metrics/files/summaries/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "summaries.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "produceSummaries": "node --trace-warnings summaries.js"

--- a/ansible/roles/metrics/files/summaries/summaries.js
+++ b/ansible/roles/metrics/files/summaries/summaries.js
@@ -4,11 +4,11 @@
 // 2019-10-31,US,,/dist/v13.0.1/node-v13.0.1-linux-x64.tar.xz,v13.0.1,linux,x64,20102340
 //
 
-const { Storage } = require('@google-cloud/storage')
-const express = require('express')
-const app = express()
+import { Storage } from '@google-cloud/storage'
+import express, { json } from 'express'
 
-app.use(express.json())
+const app = express()
+app.use(json())
 
 function csvStream (chunk) {
   try {
@@ -138,4 +138,4 @@ app.listen(port, () => {
   console.log('Listening on port: ', port)
 })
 
-module.exports = app
+export default app


### PR DESCRIPTION
Converts the scripts in metrics from CommonJS to ES Modules
Part of modernizing metrics scripts as a follow-up to https://github.com/nodejs/build/issues/3697

### Testing

The ESM setup was deployed on processlogs, and verified that logs are being processed

#### Before

```console
2024-07-14 09:26:39.929 PDT EVENT TYPE:  OBJECT_FINALIZE
2024-07-14 09:26:39.929 PDT Node version is: v20.15.0
2024-07-14 09:26:39.929 PDT BUCKET cloudflare-logs-nodejs
2024-07-14 09:26:39.929 PDT FILENAME 20240714/20240714T162556Z_20240714T162556Z_7d9dc7c0.log.gz
2024-07-14 09:26:39.929 PDT PROCESSEDFILENAME 20240714/20240714T162556Z_20240714T162556Z
2024-07-14 09:26:39.930 PDT INSIDE CREATE PIPELINE
2024-07-14 09:26:40.275 PDT String length: 33351
2024-07-14 09:26:40.275 PDT Array Length: 73
2024-07-14 09:26:40.580 PDT Upload complete: 20240714/20240714T162556Z_20240714T162556Z
```

#### After

```console
2024-07-14 09:27:28.041 PDT EVENT TYPE:  OBJECT_FINALIZE
2024-07-14 09:27:28.041 PDT Node version is: v20.15.1
2024-07-14 09:27:28.041 PDT BUCKET cloudflare-logs-nodejs
2024-07-14 09:27:28.041 PDT FILENAME 20240714/20240714T162608Z_20240714T162715Z_91d12f82.log.gz
2024-07-14 09:27:28.041 PDT PROCESSEDFILENAME 20240714/20240714T162608Z_20240714T162715Z
2024-07-14 09:27:28.042 PDT INSIDE CREATE PIPELINE
2024-07-14 09:27:28.706 PDT String length: 6535414
2024-07-14 09:27:28.709 PDT Array Length: 13500
2024-07-14 09:27:29.149 PDT Upload complete: 20240714/20240714T162608Z_20240714T162715Z
```