### PR TITLE
ansible: replace test-digitalocean-fedora38-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -114,10 +114,10 @@ hosts:
     - digitalocean:
         debian11-x64-1: {ip: 174.138.79.159, swap_file_size_mb: 2048}
         debian12-x64-1: {ip: 159.203.105.159, swap_file_size_mb: 2048}
-        fedora38-x64-1: {ip: 162.243.187.89}
         fedora39-x64-1: {ip: 159.203.117.50}
         fedora39-x64-2: {ip: 134.209.172.40}
         fedora40-x64-1: {ip: 159.65.248.149}
+        fedora40-x64-2: {ip: 162.243.187.89}
         freebsd12-x64-1: {ip: 45.55.90.237, user: freebsd}
         freebsd12-x64-2: {ip: 107.170.28.213, user: freebsd}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}

--- a/ansible/roles/bootstrap/files/fedora40-resolv.conf
+++ b/ansible/roles/bootstrap/files/fedora40-resolv.conf
@@ -1,0 +1,4 @@
+[Resolve]
+DNS=1.1.1.1#1dot1dot1dot1.cloudflare-dns.com 1.0.0.1#1dot1dot1dot1.cloudflare-dns.com 2606:4700:4700::1111#1dot1dot1dot1.cloudflare-dns.com 2606:4700:4700::1001#1dot1dot1dot1.cloudflare-dns.com
+DNSSEC=yes
+DNSOverTLS=yes

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -3,6 +3,16 @@
 #
 # bootstrap packages required for ansible to work
 #
+  - name: run provider-specific bootstrap
+    include_tasks: "{{ bootstrap_include }}"
+    loop_control:
+      loop_var: bootstrap_include
+    with_first_found:
+      - files:
+        - "{{ role_path }}/tasks/partials/{{ provider }}/{{ os }}-{{ arch }}.yml"
+        - "{{ role_path }}/tasks/partials/{{ provider }}/{{ os }}.yml"
+        - "{{ role_path }}/tasks/partials/{{ provider }}/{{ os|stripversion }}.yml"
+        skip: true
 
   - name: run os-specific bootstrap
     include_tasks: "{{ bootstrap_include }}"

--- a/ansible/roles/bootstrap/tasks/partials/digitalocean/fedora40.yml
+++ b/ansible/roles/bootstrap/tasks/partials/digitalocean/fedora40.yml
@@ -1,0 +1,24 @@
+---
+
+# DigitalOcean Fedora 40
+
+- name: "{{ provider }} : create systemd-resolved configuration directory"
+  ansible.builtin.file:
+    state: directory
+    path: /etc/systemd/resolved.conf.d
+
+- name: "{{ provider }} : create DNS settings file"
+  ansible.builtin.copy:
+    dest: /etc/systemd/resolved.conf.d/cloudflare.conf
+    src: "{{ os }}-resolv.conf"
+  register: resolved
+
+- name: "{{ provider }} : restart systemd-resolved"
+  ansible.builtin.service:
+    name: systemd-resolved
+    state: restarted
+  when: resolved.changed
+
+- name: "{{ provider }} : reboot machine"
+  ansible.builtin.reboot:
+  when: resolved.changed


### PR DESCRIPTION
Replace test-digitalocean-fedora38-x64-1 with Fedora 40.

Update the Ansible scripts to fix the DNS settings on DigitalOcean-hosted Fedora 40 machines.

Refs: https://github.com/nodejs/build/issues/3350
Refs: https://github.com/nodejs/build/pull/3829#issuecomment-2227283376