### PR TITLE
ansible: mirror _resha.sh changes

### DIFF
--- a/ansible/www-standalone/tools/promote/_resha.sh
+++ b/ansible/www-standalone/tools/promote/_resha.sh
@@ -54,6 +54,6 @@ find "${dstdir}/${version}" -type f -exec chmod 644 '{}' \;
 find "${dstdir}/${version}" -type d -exec chmod 755 '{}' \;
 
 relativedir=${dstdir/$dist_rootdir/"$site/"}
-aws s3 cp ${dstdir}/index.json $staging_bucket/$relativedir/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile
-aws s3 cp ${dstdir}/index.tab $staging_bucket/$relativedir/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile
-aws s3 cp ${dstdir}/${version}/SHASUMS256.txt $staging_bucket/$relativedir/${version}/SHASUM256.txt --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile
+aws s3 cp ${dstdir}/index.json $staging_bucket/$relativedir/index.json --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile > /dev/null
+aws s3 cp ${dstdir}/index.tab $staging_bucket/$relativedir/index.tab --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile > /dev/null
+aws s3 cp ${dstdir}/${version}/SHASUMS256.txt $staging_bucket/$relativedir/${version}/SHASUMS256.txt --endpoint-url=$cloudflare_endpoint --profile $cloudflare_profile > /dev/null


### PR DESCRIPTION
The extra output from the `aws` commands is causing issues with the `release.sh` script from nodejs/node (which expects the only output to be the path to the `SHASUMS256.txt` file).

---

This is just a mirror of the current `_resha.sh` that is on the server after @targos @RafaelGSS and I live debugged this while trying to release Node.js 22.5.0.

The current [`tools/release.sh`](https://github.com/nodejs/node/blob/589b67aa1748974b24df4b4b7281e0cce4e915c7/tools/release.sh#L110-L120) is capturing the output of the sign command (`dist-sign`->`resha_release.sh`->`_resha.sh`) and was getting confused by the extra output from the `aws` commands.

Redirecting to `/dev/null` is going to make debugging issues with the r2 upload tricky, but for now this PR is keeping the repository in sync with what is live on the server.