### PR TITLE
jenkins: skip debian11 for Node.js >=23

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -25,6 +25,7 @@ def buildExclusions = [
   [ /^centos7-(arm)?64-gcc8/,         anyType,     gte(18) ], // 18.x: centos7 builds stop
   [ /^centos7-64/,                    anyType,     gte(18) ],
   [ /debian10/,                       anyType,     gte(21) ],
+  [ /debian11/,                       anyType,     gte(23) ],
   [ /alpine-last-latest/,             anyType,     gte(22) ], // Alpine 3.18. Bug in GCC 12.2.
   [ /rhel7/,                          anyType,     gte(18) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(18) ], // 32-bit linux for <10 only


### PR DESCRIPTION
`gcc-12` is not available for this version.

Refs: https://github.com/nodejs/build/issues/3806
