### PR TITLE
Add initial support for Packer in Orka

### DIFF
--- a/.github/workflows/orka-templates.yml
+++ b/.github/workflows/orka-templates.yml
@@ -1,0 +1,38 @@
+name: Check ORKA Packer Templates
+
+on:
+  push:
+    paths:
+      - 'orka/**/*.pkr.hcl'
+  pull_request:
+    paths:
+      - 'orka/**/*.pkr.hcl'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+
+    - name: Set up Packer
+      uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 #v3.1.0
+
+    - name: Initialize Packer
+      run: packer init .
+
+    - name: Validate Packer templates
+      env:
+        ORKA_ENDPOINT: 'https://mock-orka-endpoint'
+        ORKA_AUTH_TOKEN: 'mock-orka-auth-token'
+        SSH_USERNAME: 'mock-ssh-username'
+        SSH_PASSWORD: 'mock-ssh-password'
+      run: |
+        packer validate -var "orka_endpoint=$ORKA_ENDPOINT" \
+                        -var "orka_auth_token=$ORKA_AUTH_TOKEN" \
+                        -var "ssh_username=$SSH_USERNAME" \
+                        -var "ssh_password=$SSH_PASSWORD" .

--- a/.github/workflows/orka-templates.yml
+++ b/.github/workflows/orka-templates.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Initialize Packer
       run: packer init .
+      working-directory: orka/templates
 
     - name: Validate Packer templates
       env:
@@ -36,3 +37,4 @@ jobs:
                         -var "orka_auth_token=$ORKA_AUTH_TOKEN" \
                         -var "ssh_username=$SSH_USERNAME" \
                         -var "ssh_password=$SSH_PASSWORD" .
+      working-directory: orka/templates

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ ansible/host_vars/*
 !ansible/host_vars/*-template
 .venv
 Pipfile.lock
+
+# Orka secrets files including naming mutations
+orka/*/.env*

--- a/orka/templates/README.md
+++ b/orka/templates/README.md
@@ -1,0 +1,77 @@
+# Using Packer with Orka
+
+## Pre-requisites
+
+You need to install Packer in your local machine. You can find the installation instructions [here](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli).
+
+Once installed, you can verify the installation by running the following command:
+
+```shell
+packer --version
+```
+
+While writing this document, the latest version of Packer is `1.11.2`.
+
+## Install dependencies
+
+You need to run the following command to install the dependencies:
+
+```shell
+packer init .
+```
+
+## Access the Orka environment
+
+You need to connect to the Orka VPN. You can find the instructions in the secrets repository. 
+
+## Load the environment variables
+
+You need to load the environment variables:
+
+1. Get the `.env` file from the secrets repository. You will find the instructions in the repository.
+2. Copy the `.env` file to this directory.
+3. Run the following command:
+    ```shell
+    source .env
+    ```
+4. Verify that the environment variables are loaded by running the following command:
+    ```shell
+    echo $ORKA_ENDPOINT
+    echo $ORKA_AUTH_TOKEN
+    echo $SSH_USERNAME
+    echo $SSH_PASSWORD
+    ```
+
+## Validate the template
+
+You can validate all the templates by running the following command:
+
+```shell
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+```
+
+You can validate a specific template by running the following command:
+
+```shell
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+```
+
+## Build the image
+
+You can build all the templates by running the following command:
+
+```shell
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+```
+
+You can build a specific template by running the following command:
+
+```shell
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+```
+
+## Continuous Integration
+
+The templates are initialized and validated in the CI pipeline using GitHub Actions. The pipeline runs on every push to the repository that modifies the templates. You can find the pipeline in the `.github/workflows/orka-templates.yml` directory.
+
+We don't plan to build the images in the CI pipeline. The images are built manually by the team once the PRs are merged or just before merged. 

--- a/orka/templates/macos-11-arm-test.pkr.hcl
+++ b/orka/templates/macos-11-arm-test.pkr.hcl
@@ -1,0 +1,51 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_password" {
+  type    = string
+  default = ""
+}
+
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+source "macstadium-orka" "macos11-arm-test-image" {
+  source_image      = "90gbigsurssh.img"
+  image_name        = "macos11-arm-test-latest.img"
+  image_description = "The MacOS 11 ARM test image"
+  orka_endpoint     = var.orka_endpoint
+  orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_username
+  ssh_password      = var.ssh_password
+}
+
+build {
+  sources = [
+    "macstadium-orka.macos11-arm-test-image"
+  ]
+  provisioner "shell" {
+    inline = [
+      "echo we are running on the remote host",
+      "hostname",
+      "touch .we-ran-packer-successfully"
+    ]
+  }
+}

--- a/orka/templates/macos-11-intel-test.pkr.hcl
+++ b/orka/templates/macos-11-intel-test.pkr.hcl
@@ -27,19 +27,17 @@ packer {
   }
 }
 
-source "macstadium-orka" "macos11-arm-test-image" {
+source "macstadium-orka" "macos11-intel-test-image" {
   source_image      = "90gbigsurssh.img"
-  image_name        = "macos11-arm-test-latest.img"
-  image_description = "The MacOS 11 ARM test image"
+  image_name        = "macos11-intel-test-latest.img"
+  image_description = "The MacOS 11 Intel test image"
   orka_endpoint     = var.orka_endpoint
   orka_auth_token   = var.orka_auth_token
-  ssh_username      = var.ssh_username
-  ssh_password      = var.ssh_password
 }
 
 build {
   sources = [
-    "macstadium-orka.macos11-arm-test-image"
+    "macstadium-orka.macos11-intel-test-image"
   ]
   provisioner "shell" {
     inline = [


### PR DESCRIPTION
### Main Changes

The main goal is to add support for Packer in Orka and validate the templates in future PRs. 

**Details**
- Add git rules to ignore `.env` files in `orka/` folder and subfolders
- Add the first Packer template to validate the workfow
- Add a GH pipeline to validate any change done in the templates (exclusively)
- Add basic documentation for using Packer with Orka

### Screenshots

The template is working good enough for what is expected in this PR (communication, creation and CI validation)

![Screenshot from 2024-08-25 15-37-46](https://github.com/user-attachments/assets/02f10d6e-342d-4a07-b3d9-fa0c426cc7c6)

 
![Screenshot from 2024-08-25 16-09-40](https://github.com/user-attachments/assets/44faed68-5207-4b2c-8866-176520dac8ce)


### Context


This PR is part of the Orka plan described in https://github.com/nodejs/build/issues/3686#issuecomment-2278119351

### Notes

The CI passed including the new pipeline [execution details](https://github.com/nodejs/build/actions/runs/10547529762/job/29220336802?pr=3872)

The CI won't handle the image publication, just the validation when we do changes in the templates. All the deployment will remain manually done by the infra admins (as usual).

