### PR TITLE
Orka: packer macos11 intel test

### DIFF
--- a/orka/templates/README.md
+++ b/orka/templates/README.md
@@ -40,6 +40,8 @@ You need to load the environment variables:
     echo $ORKA_AUTH_TOKEN
     echo $SSH_USERNAME
     echo $SSH_PASSWORD
+    echo $SSH_DEFAULT_USERNAME
+    echo $SSH_DEFAULT_PASSWORD
     ```
 
 ## Validate the template
@@ -47,13 +49,13 @@ You need to load the environment variables:
 You can validate all the templates by running the following command:
 
 ```shell
-packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" .
 ```
 
 You can validate a specific template by running the following command:
 
 ```shell
-packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" <template_name>
 ```
 
 ## Build the image
@@ -61,13 +63,13 @@ packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_
 You can build all the templates by running the following command:
 
 ```shell
-packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" .
 ```
 
 You can build a specific template by running the following command:
 
 ```shell
-packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" <template_name>
 ```
 
 ## Continuous Integration

--- a/orka/templates/macos-11-intel-test.pkr.hcl
+++ b/orka/templates/macos-11-intel-test.pkr.hcl
@@ -38,7 +38,7 @@ packer {
 }
 
 source "macstadium-orka" "macos11-intel-test-image" {
-  source_image      = "90gbigsurssh.img"
+  source_image      = "macos11-intel-base.img"
   image_name        = "macos11-intel-test-latest.img"
   image_description = "The MacOS 11 Intel test image"
   orka_endpoint     = var.orka_endpoint

--- a/orka/templates/macos-11-intel-test.pkr.hcl
+++ b/orka/templates/macos-11-intel-test.pkr.hcl
@@ -53,9 +53,27 @@ build {
   ]
   provisioner "shell" {
     inline = [
-      "echo we are running on the remote host",
-      "hostname",
-      "touch .we-ran-packer-successfully"
+      "echo 'Installing Homebrew...'",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "echo 'eval \"$(/usr/local/bin/brew shellenv)\"' >> /Users/${var.ssh_default_username}/.zprofile",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "source /Users/${var.ssh_default_username}/.zprofile"
+    ]
+  }
+  // Check Homebrew. Ignore errors as macos 11 is deprecated
+  provisioner "shell" {
+    inline = [
+      "echo 'Checking Homebrew...'",
+      "source /Users/${var.ssh_default_username}/.zprofile",
+      "brew doctor || true"
+    ]
+  }
+  // Install dependencies using Homebrew. This can take hours to complete as all has to be compiled from source
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing packages using Homebrew...'",
+      "source /Users/${var.ssh_default_username}/.zprofile",
+      "brew install git automake bash libtool cmake python ccache"
     ]
   }
 }

--- a/orka/templates/macos-11-intel-test.pkr.hcl
+++ b/orka/templates/macos-11-intel-test.pkr.hcl
@@ -8,6 +8,16 @@ variable "orka_auth_token" {
   default = ""
 }
 
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
 variable "ssh_username" {
   type    = string
   default = ""
@@ -33,6 +43,8 @@ source "macstadium-orka" "macos11-intel-test-image" {
   image_description = "The MacOS 11 Intel test image"
   orka_endpoint     = var.orka_endpoint
   orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_default_username
+  ssh_password      = var.ssh_default_password
 }
 
 build {


### PR DESCRIPTION
### Main Changes

- Add support for SSH Connection using the default credentials.
- Use a custom base image developed by us.
- Add steps for installing Homebrew and basic dependencies.

### Related

- https://github.com/nodejs/build/issues/3686#issuecomment-2278119351