### PR TITLE
ansible: add swap to DigitalOcean Ubuntu 22.04

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -127,8 +127,8 @@ hosts:
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu2204_docker-x64-2: {ip: 159.89.183.200}
         ubuntu1804-x64-1: {ip: 178.128.181.213}
-        ubuntu2204-x64-1: {ip: 138.197.4.1}
-        ubuntu2204-x64-2: {ip: 167.99.124.188}
+        ubuntu2204-x64-1: {ip: 138.197.4.1, swap_file_size_mb: 2048}
+        ubuntu2204-x64-2: {ip: 167.99.124.188, swap_file_size_mb: 2048}
 
     - equinix:
         ubuntu2004_docker-arm64-1: {ip: 145.40.81.219}

--- a/ansible/roles/bootstrap/tasks/partials/ubuntu2204.yml
+++ b/ansible/roles/bootstrap/tasks/partials/ubuntu2204.yml
@@ -1,0 +1,9 @@
+---
+
+#
+# Ubuntu 22.04
+#
+
+- name: set up swap on Linux
+  include_tasks: linux-swap.yml
+  when: swap_file_size_mb is defined


### PR DESCRIPTION
Builds on 
- [test-digitalocean-ubuntu2204-x64-1](https://ci.nodejs.org/computer/test-digitalocean-ubuntu2204-x64-1/)
- [test-digitalocean-ubuntu2204-x64-2](https://ci.nodejs.org/computer/test-digitalocean-ubuntu2204-x64-2/)

have been failing, with the Jenkins agent being killed by the OOM killer. These machines have 4 GB RAM. Builds on the IBM hosted Ubuntu 22.04 x64 machines have been succeeding -- those also have 4 GB RAM but IBM provision those with 2 GB of swap. The DigitalOcean hosted machines have no swap -- this PR adds 2 GB of swap to bring them in line with the IBM hosted machines.