### PR TITLE
Add Packer support for MacOS 13 test images in Orka

### DIFF
--- a/.github/workflows/orka-templates.yml
+++ b/.github/workflows/orka-templates.yml
@@ -30,11 +30,15 @@ jobs:
       env:
         ORKA_ENDPOINT: 'https://mock-orka-endpoint'
         ORKA_AUTH_TOKEN: 'mock-orka-auth-token'
-        SSH_USERNAME: 'mock-ssh-username'
-        SSH_PASSWORD: 'mock-ssh-password'
+        SSH_DEFAULT_USERNAME: 'mock-ssh-default-username'
+        SSH_DEFAULT_PASSWORD: 'mock-ssh-default-password'
+        SSH_TEST_PASSWORD: 'mock-ssh-test-password'
+        SSH_TEST_PUBLIC_KEY: 'mock-ssh-test-public-key'
       run: |
         packer validate -var "orka_endpoint=$ORKA_ENDPOINT" \
                         -var "orka_auth_token=$ORKA_AUTH_TOKEN" \
-                        -var "ssh_username=$SSH_USERNAME" \
-                        -var "ssh_password=$SSH_PASSWORD" .
+                        -var "ssh_default_username=$SSH_DEFAULT_USERNAME" \
+                        -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" \
+                        -var "ssh_test_public_key=$SSH_TEST_PASSWORD" \
+                        -var "ssh_userssh_test_passwordname=$SSH_TEST_PUBLIC_KEY" .
       working-directory: orka/templates

--- a/orka/templates/README.md
+++ b/orka/templates/README.md
@@ -38,8 +38,10 @@ You need to load the environment variables:
     ```shell
     echo $ORKA_ENDPOINT
     echo $ORKA_AUTH_TOKEN
-    echo $SSH_USERNAME
-    echo $SSH_PASSWORD
+    echo $SSH_DEFAULT_USERNAME
+    echo $SSH_DEFAULT_PASSWORD
+    echo $SSH_TEST_PASSWORD
+    echo $SSH_TEST_PUBLIC_KEY
     ```
 
 ## Validate the template
@@ -47,13 +49,13 @@ You need to load the environment variables:
 You can validate all the templates by running the following command:
 
 ```shell
-packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" .
 ```
 
 You can validate a specific template by running the following command:
 
 ```shell
-packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" <template_name>
 ```
 
 ## Build the image
@@ -61,13 +63,13 @@ packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_
 You can build all the templates by running the following command:
 
 ```shell
-packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" .
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" .
 ```
 
 You can build a specific template by running the following command:
 
 ```shell
-packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_username=$SSH_USERNAME" -var "ssh_password=$SSH_PASSWORD" <template_name>
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" <template_name>
 ```
 
 ## Continuous Integration

--- a/orka/templates/macos-13-arm-test.pkr.hcl
+++ b/orka/templates/macos-13-arm-test.pkr.hcl
@@ -1,33 +1,3 @@
-variable "orka_endpoint" {
-  type    = string
-  default = ""
-}
-
-variable "orka_auth_token" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_default_username" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_default_password" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_test_public_key" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_test_password" {
-  type    = string
-  default = ""
-}
-
 packer {
   required_plugins {
     macstadium-orka = {

--- a/orka/templates/macos-13-arm-test.pkr.hcl
+++ b/orka/templates/macos-13-arm-test.pkr.hcl
@@ -1,0 +1,123 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_public_key" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_password" {
+  type    = string
+  default = ""
+}
+
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+source "macstadium-orka" "macos13-arm-test-image" {
+  source_image      = "macos13-arm-base.orkasi"
+  image_name        = "macos13-arm-test-latest.orkasi"
+  image_description = "The MacOS 13 ARM test image"
+  orka_endpoint     = var.orka_endpoint
+  orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_default_username
+  ssh_password      = var.ssh_default_password
+}
+
+build {
+  sources = [
+    "macstadium-orka.macos13-arm-test-image"
+  ]
+  // Change the password of the default user.
+  provisioner "shell" {
+    inline = [
+      "echo 'Changing default user password...'",
+      "sudo sysadminctl -adminUser ${var.ssh_default_username} -adminPassword ${var.ssh_default_password} -resetPasswordFor ${var.ssh_default_username} -newPassword ${var.ssh_test_password}"
+    ]
+  }
+  // Add SSH key access.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding SSH key access...'",
+      "mkdir -p /Users/${var.ssh_default_username}/.ssh",
+      "echo '${var.ssh_test_public_key}' >> /Users/${var.ssh_default_username}/.ssh/authorized_keys",
+      "chown -R ${var.ssh_default_username}:staff /Users/${var.ssh_default_username}/.ssh",
+      "chmod 700 /Users/${var.ssh_default_username}/.ssh",
+      "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
+    ]
+  } 
+
+  // Disable SSH password authentication.
+  // @TODO: Review fallback to password authentication.
+  provisioner "shell" {
+    inline = [
+      "echo 'Disabling SSH password authentication...'",
+      "sudo sed -i '' 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo systemsetup -f -setremotelogin on",
+      "sudo launchctl unload /System/Library/LaunchDaemons/ssh.plist",
+      "sudo launchctl load /System/Library/LaunchDaemons/ssh.plist",
+    ]
+  }
+
+  // Install Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing Homebrew...'",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "(echo; echo 'eval \"$($(brew --prefix)/bin/brew shellenv)\"') >> /Users/admin/.zprofile",
+      "eval \"$($(brew --prefix)/bin/brew shellenv)\""
+    ]
+  }
+  // Check Homebrew. Ignore errors because we are not using the last version of Xcode.
+  provisioner "shell" {
+    inline = [
+      "echo 'Checking Homebrew...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew doctor || true"
+    ]
+  }
+  // Install dependencies using Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing packages using Homebrew...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew install git automake bash libtool cmake python ccache"
+    ]
+  }
+
+  // Print the version of the installed packages.
+  provisioner "shell" {
+    inline = [
+      "echo 'Printing the version of the installed packages...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew list --versions"
+    ]
+  }
+}

--- a/orka/templates/macos-13-arm-test.pkr.hcl
+++ b/orka/templates/macos-13-arm-test.pkr.hcl
@@ -1,12 +1,3 @@
-packer {
-  required_plugins {
-    macstadium-orka = {
-      version = "~> 3.0"
-      source  = "github.com/macstadium/macstadium-orka"
-    }
-  }
-}
-
 source "macstadium-orka" "macos13-arm-test-image" {
   source_image      = "macos13-arm-base.orkasi"
   image_name        = "macos13-arm-test-latest.orkasi"

--- a/orka/templates/macos-13-intel-test.pkr.hcl
+++ b/orka/templates/macos-13-intel-test.pkr.hcl
@@ -1,33 +1,3 @@
-variable "orka_endpoint" {
-  type    = string
-  default = ""
-}
-
-variable "orka_auth_token" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_default_username" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_default_password" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_test_public_key" {
-  type    = string
-  default = ""
-}
-
-variable "ssh_test_password" {
-  type    = string
-  default = ""
-}
-
 packer {
   required_plugins {
     macstadium-orka = {

--- a/orka/templates/macos-13-intel-test.pkr.hcl
+++ b/orka/templates/macos-13-intel-test.pkr.hcl
@@ -1,12 +1,3 @@
-packer {
-  required_plugins {
-    macstadium-orka = {
-      version = "~> 3.0"
-      source  = "github.com/macstadium/macstadium-orka"
-    }
-  }
-}
-
 source "macstadium-orka" "macos13-intel-test-image" {
   source_image      = "macos13-intel-base.img"
   image_name        = "macos13-intel-test-latest.img"

--- a/orka/templates/macos-13-intel-test.pkr.hcl
+++ b/orka/templates/macos-13-intel-test.pkr.hcl
@@ -1,0 +1,121 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_public_key" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_password" {
+  type    = string
+  default = ""
+}
+
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+source "macstadium-orka" "macos13-intel-test-image" {
+  source_image      = "macos13-intel-base.img"
+  image_name        = "macos13-intel-test-latest.img"
+  image_description = "The MacOS 13 Intel test image"
+  orka_endpoint     = var.orka_endpoint
+  orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_default_username
+  ssh_password      = var.ssh_default_password
+}
+
+build {
+  sources = [
+    "macstadium-orka.macos13-intel-test-image"
+  ]
+  // Change the password of the default user.
+  provisioner "shell" {
+    inline = [
+      "echo 'Changing default user password...'",
+      "sudo sysadminctl -adminUser ${var.ssh_default_username} -adminPassword ${var.ssh_default_password} -resetPasswordFor ${var.ssh_default_username} -newPassword ${var.ssh_test_password}"
+    ]
+  }
+  // Add SSH key access.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding SSH key access...'",
+      "mkdir -p /Users/${var.ssh_default_username}/.ssh",
+      "echo '${var.ssh_test_public_key}' >> /Users/${var.ssh_default_username}/.ssh/authorized_keys",
+      "chown -R ${var.ssh_default_username}:staff /Users/${var.ssh_default_username}/.ssh",
+      "chmod 700 /Users/${var.ssh_default_username}/.ssh",
+      "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
+    ]
+  } 
+
+  // Disable SSH password authentication.
+  // @TODO: Review fallback to password authentication.
+  provisioner "shell" {
+    inline = [
+      "echo 'Disabling SSH password authentication...'",
+      "sudo sed -i '' 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo systemsetup -f -setremotelogin on",
+      "sudo launchctl unload /System/Library/LaunchDaemons/ssh.plist",
+      "sudo launchctl load /System/Library/LaunchDaemons/ssh.plist",
+    ]
+  }
+  // Install Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing Homebrew...'",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "(echo; echo 'eval \"$($(brew --prefix)/bin/brew shellenv)\"') >> /Users/admin/.zprofile",
+      "eval \"$($(brew --prefix)/bin/brew shellenv)\""
+    ]
+  }
+  // Check Homebrew. Ignore errors because we are not using the last version of Xcode.
+  provisioner "shell" {
+    inline = [
+      "echo 'Checking Homebrew...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew doctor || true"
+    ]
+  }
+  // Install dependencies using Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing packages using Homebrew...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew install git automake bash libtool cmake python ccache"
+    ]
+  }
+  // Print the version of the installed packages.
+  provisioner "shell" {
+    inline = [
+      "echo 'Printing the version of the installed packages...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew list --versions"
+    ]
+  }
+}

--- a/orka/templates/plugins.pkr.hcl
+++ b/orka/templates/plugins.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}

--- a/orka/templates/variables.pkr.hcl
+++ b/orka/templates/variables.pkr.hcl
@@ -1,0 +1,29 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_public_key" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_test_password" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
### Main Changes

- Updated documentation with the new environmental variables
- Added Packer template for Orka MacOS 13 ARM test
- Added Packer template for Orka MacOS 13 Intel test
- Updated CI to use all the expected environmental variables

### Context

- Related: https://github.com/nodejs/build/issues/3686


### VMs current capabilities

Currently the images do the following:
- Change the password of the default user
- Add SSH key access
- Disable SSH password authentication.
- Install Homebrew.
- Check Homebrew (Ignore errors because we are not using the last version of Xcode).
- Install dependencies using Homebrew. (git, automake, bash, libtool, cmake, python, and ccache)

**Dependencies installed**
- `autoconf 2.72`
- `automake 1.17`
- `bash 5.2.32`
- `blake3 1.5.4`
- `ca-certificates 2024-07-02`
- `ccache 4.10.2_1`
- `cmake 3.30.3`
- `fmt 11.0.2`
- `gettext 0.22.5`
- `git 2.46.0`
- `hiredis 1.2.0`
- `libtool 2.4.7`
- `lz4 1.10.0`
- `m4 1.4.19`
- `mpdecimal 4.0.0`
- `openssl@3 3.3.1`
- `pcre2 10.44`
- `python@3.12 3.12.5`
- `readline 8.2.13`
- `sqlite 3.46.1`
- `xxhash 0.8.2`
- `xz 5.6.2`
- `zstd 1.5.6`

**Test performed**

The VMs are capable of build and test node from the source code

```
git clone https://github.com/nodejs/node
cd node
./configure
make -j4
make -j4 test
```


