### PR TITLE
Add Packer support for MacOS 13 release images in Orka

### DIFF
--- a/.github/workflows/orka-templates.yml
+++ b/.github/workflows/orka-templates.yml
@@ -37,7 +37,9 @@ jobs:
         SSH_DEFAULT_USERNAME: 'mock-ssh-default-username'
         SSH_DEFAULT_PASSWORD: 'mock-ssh-default-password'
         SSH_TEST_PASSWORD: 'mock-ssh-test-password'
+        SSH_RELEASE_PASSWORD: 'mock-ssh-release-password'
         SSH_TEST_PUBLIC_KEY: 'mock-ssh-test-public-key'
+        SSH_RELEASE_PUBLIC_KEY: 'mock-ssh-release-public-key'
       run: |
         for file in $(find . -name '*.pkr.hcl'); do
           echo "Validating $file"
@@ -46,6 +48,9 @@ jobs:
                           -var "ssh_default_username=$SSH_DEFAULT_USERNAME" \
                           -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" \
                           -var "ssh_test_public_key=$SSH_TEST_PUBLIC_KEY" \
-                          -var "ssh_test_password=$SSH_TEST_PASSWORD" $file || exit 1
+                          -var "ssh_test_password=$SSH_TEST_PASSWORD" \
+                          -var "ssh_release_password=$SSH_RELEASE_PASSWORD" \
+                          -var "ssh_release_public_key=$SSH_RELEASE_PUBLIC_KEY" \
+                          $file || exit 1
         done
       working-directory: orka/templates

--- a/.github/workflows/orka-templates.yml
+++ b/.github/workflows/orka-templates.yml
@@ -43,14 +43,14 @@ jobs:
       run: |
         for file in $(find . -name '*.pkr.hcl'); do
           echo "Validating $file"
-          packer validate -var "orka_endpoint=$ORKA_ENDPOINT" \
-                          -var "orka_auth_token=$ORKA_AUTH_TOKEN" \
-                          -var "ssh_default_username=$SSH_DEFAULT_USERNAME" \
-                          -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" \
-                          -var "ssh_test_public_key=$SSH_TEST_PUBLIC_KEY" \
-                          -var "ssh_test_password=$SSH_TEST_PASSWORD" \
-                          -var "ssh_release_password=$SSH_RELEASE_PASSWORD" \
-                          -var "ssh_release_public_key=$SSH_RELEASE_PUBLIC_KEY" \
-                          $file || exit 1
+          vars="-var orka_endpoint=$ORKA_ENDPOINT -var orka_auth_token=$ORKA_AUTH_TOKEN -var ssh_default_username=$SSH_DEFAULT_USERNAME"
+          
+          if echo "$file" | grep -q "release"; then
+            vars="$vars -var ssh_release_password=$SSH_RELEASE_PASSWORD -var ssh_release_public_key=$SSH_RELEASE_PUBLIC_KEY"
+          elif echo "$file" | grep -q "test"; then
+            vars="$vars -var ssh_test_password=$SSH_TEST_PASSWORD -var ssh_test_public_key=$SSH_TEST_PUBLIC_KEY -var ssh_default_password=$SSH_DEFAULT_PASSWORD"
+          fi
+
+          packer validate $vars $file || exit 1
         done
       working-directory: orka/templates

--- a/orka/templates/README.md
+++ b/orka/templates/README.md
@@ -49,7 +49,7 @@ You need to load the environment variables:
 You can validate a specific template by running the following command:
 
 ```shell
-packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" <template_name>
+packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_release_password=$SSH_RELEASE_PASSWORD" -var "ssh_release_public_key=$SSH_RELEASE_PUBLIC_KEY" -var "ssh_test_public_key=$SSH_TEST_PUBLIC_KEY" <template_name>
 ```
 
 ## Build the image
@@ -57,7 +57,7 @@ packer validate -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_
 You can build a specific template by running the following command:
 
 ```shell
-packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_test_puclic_key=$SSH_TEST_PUBLIC_KEY" <template_name>
+packer build -var "orka_endpoint=$ORKA_ENDPOINT" -var "orka_auth_token=$ORKA_AUTH_TOKEN" -var "ssh_default_username=$SSH_DEFAULT_USERNAME" -var "ssh_default_password=$SSH_DEFAULT_PASSWORD" -var "ssh_test_password=$SSH_TEST_PASSWORD" -var "ssh_release_password=$SSH_RELEASE_PASSWORD" -var "ssh_release_public_key=$SSH_RELEASE_PUBLIC_KEY" -var "ssh_test_public_key=$SSH_TEST_PUBLIC_KEY" <template_name>
 ```
 
 ## Continuous Integration

--- a/orka/templates/macos-13-arm-release.pkr.hcl
+++ b/orka/templates/macos-13-arm-release.pkr.hcl
@@ -1,0 +1,125 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_release_public_key" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_release_password" {
+  type    = string
+  default = ""
+}
+
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+source "macstadium-orka" "macos13-arm-release-image" {
+  source_image      = "macos13-arm-release-base.orkasi"
+  image_name        = "macos13-arm-release-latest.orkasi"
+  image_description = "The MacOS 13 ARM release image"
+  orka_endpoint     = var.orka_endpoint
+  orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_default_username
+  ssh_password      = var.ssh_release_password
+}
+
+build {
+  sources = [
+    "macstadium-orka.macos13-arm-release-image"
+  ]
+
+  // Add SSH key access.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding SSH key access...'",
+      "mkdir -p /Users/${var.ssh_default_username}/.ssh",
+      "echo '${var.ssh_release_public_key}' >> /Users/${var.ssh_default_username}/.ssh/authorized_keys",
+      "chown -R ${var.ssh_default_username}:staff /Users/${var.ssh_default_username}/.ssh",
+      "chmod 700 /Users/${var.ssh_default_username}/.ssh",
+      "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
+    ]
+  } 
+
+  // Disable SSH password authentication.
+  // @TODO: Review fallback to password authentication.
+  provisioner "shell" {
+    inline = [
+      "echo 'Disabling SSH password authentication...'",
+      "sudo sed -i '' 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo systemsetup -f -setremotelogin on",
+      "sudo launchctl unload /System/Library/LaunchDaemons/ssh.plist",
+      "sudo launchctl load /System/Library/LaunchDaemons/ssh.plist",
+    ]
+  }
+
+  // Install Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing Homebrew...'",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "(echo; echo 'eval \"$($(brew --prefix)/bin/brew shellenv)\"') >> /Users/admin/.zprofile",
+      "eval \"$($(brew --prefix)/bin/brew shellenv)\""
+    ]
+  }
+  // Check Homebrew. Ignore errors because we are not using the last version of Xcode.
+  provisioner "shell" {
+    inline = [
+      "echo 'Checking Homebrew...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew doctor || true"
+    ]
+  }
+  // Install dependencies for build and release.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing packages using Homebrew...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew install git automake bash libtool cmake python ccache"
+    ]
+  }
+  // Install Java 17 for Jenkins.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing JRE...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew install --cask temurin@17",
+    ]
+  }
+  // Print the version of the installed packages.
+  provisioner "shell" {
+    inline = [
+      "echo 'Printing the version of the installed packages...'",
+      "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
+      "/opt/homebrew/bin/brew list --versions",
+      "java -version"
+    ]
+  }
+}

--- a/orka/templates/macos-13-intel-release.pkr.hcl
+++ b/orka/templates/macos-13-intel-release.pkr.hcl
@@ -1,0 +1,123 @@
+variable "orka_endpoint" {
+  type    = string
+  default = ""
+}
+
+variable "orka_auth_token" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_username" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_default_password" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_release_public_key" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_release_password" {
+  type    = string
+  default = ""
+}
+
+packer {
+  required_plugins {
+    macstadium-orka = {
+      version = "~> 3.0"
+      source  = "github.com/macstadium/macstadium-orka"
+    }
+  }
+}
+
+source "macstadium-orka" "macos13-intel-release-image" {
+  source_image      = "macos13-intel-release-base.img"
+  image_name        = "macos13-intel-release-latest.img"
+  image_description = "The MacOS 13 Intel release image"
+  orka_endpoint     = var.orka_endpoint
+  orka_auth_token   = var.orka_auth_token
+  ssh_username      = var.ssh_default_username
+  ssh_password      = var.ssh_release_password
+}
+
+build {
+  sources = [
+    "macstadium-orka.macos13-intel-release-image"
+  ]
+  // Add SSH key access.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding SSH key access...'",
+      "mkdir -p /Users/${var.ssh_default_username}/.ssh",
+      "echo '${var.ssh_release_public_key}' >> /Users/${var.ssh_default_username}/.ssh/authorized_keys",
+      "chown -R ${var.ssh_default_username}:staff /Users/${var.ssh_default_username}/.ssh",
+      "chmod 700 /Users/${var.ssh_default_username}/.ssh",
+      "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
+    ]
+  } 
+
+  // Disable SSH password authentication.
+  // @TODO: Review fallback to password authentication.
+  provisioner "shell" {
+    inline = [
+      "echo 'Disabling SSH password authentication...'",
+      "sudo sed -i '' 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo sed -i '' 's/^ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config",
+      "sudo systemsetup -f -setremotelogin on",
+      "sudo launchctl unload /System/Library/LaunchDaemons/ssh.plist",
+      "sudo launchctl load /System/Library/LaunchDaemons/ssh.plist",
+    ]
+  }
+  // Install Homebrew.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing Homebrew...'",
+      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "(echo; echo 'eval \"$($(brew --prefix)/bin/brew shellenv)\"') >> /Users/admin/.zprofile",
+      "eval \"$($(brew --prefix)/bin/brew shellenv)\""
+    ]
+  }
+  // Check Homebrew. Ignore errors because we are not using the last version of Xcode.
+  provisioner "shell" {
+    inline = [
+      "echo 'Checking Homebrew...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew doctor || true"
+    ]
+  }
+  // Install dependencies for build and release.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing packages using Homebrew...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew install git automake bash libtool cmake python ccache"
+    ]
+  }
+  // Install Java 17 for Jenkins.
+  provisioner "shell" {
+    inline = [
+      "echo 'Installing JRE...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew install --cask temurin@17",
+    ]
+  }
+  // Print the version of the installed packages.
+  provisioner "shell" {
+    inline = [
+      "echo 'Printing the version of the installed packages...'",
+      "eval \"$(/usr/local/bin/brew shellenv)\"",
+      "/usr/local/bin/brew list --versions",
+      "java -version"
+    ]
+  }
+}


### PR DESCRIPTION
### Main Changes
- Added new Orka templated for release images. They are very similar to the tests machines (see: https://github.com/nodejs/build/pull/3882)
- New environmental variables added (included ci and documentation)
- CI is now selective on what variables are passed based on the image name, to avoid validation errors.

### Context

- Related to https://github.com/nodejs/build/issues/3686#issuecomment-2278119351 and https://github.com/nodejs/build/pull/3891.
- Continuation of https://github.com/nodejs/build/pull/3882



