### PR TITLE
Add GitHub host key to known hosts

### DIFF
--- a/orka/templates/macos-13-arm-release.pkr.hcl
+++ b/orka/templates/macos-13-arm-release.pkr.hcl
@@ -63,7 +63,13 @@ build {
       "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
     ]
   } 
-
+  // Add GitHub host key to known hosts.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding GitHub host key to known hosts...'",
+      "ssh-keyscan github.com >> /Users/${var.ssh_default_username}/.ssh/known_hosts"
+    ]
+  }
   // Disable SSH password authentication.
   // @TODO: Review fallback to password authentication.
   provisioner "shell" {

--- a/orka/templates/macos-13-arm-test.pkr.hcl
+++ b/orka/templates/macos-13-arm-test.pkr.hcl
@@ -69,7 +69,13 @@ build {
       "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
     ]
   } 
-
+  // Add GitHub host key to known hosts.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding GitHub host key to known hosts...'",
+      "ssh-keyscan github.com >> /Users/${var.ssh_default_username}/.ssh/known_hosts"
+    ]
+  }
   // Disable SSH password authentication.
   // @TODO: Review fallback to password authentication.
   provisioner "shell" {

--- a/orka/templates/macos-13-intel-release.pkr.hcl
+++ b/orka/templates/macos-13-intel-release.pkr.hcl
@@ -62,7 +62,13 @@ build {
       "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
     ]
   } 
-
+  // Add GitHub host key to known hosts.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding GitHub host key to known hosts...'",
+      "ssh-keyscan github.com >> /Users/${var.ssh_default_username}/.ssh/known_hosts"
+    ]
+  }
   // Disable SSH password authentication.
   // @TODO: Review fallback to password authentication.
   provisioner "shell" {

--- a/orka/templates/macos-13-intel-test.pkr.hcl
+++ b/orka/templates/macos-13-intel-test.pkr.hcl
@@ -68,8 +68,14 @@ build {
       "chmod 700 /Users/${var.ssh_default_username}/.ssh",
       "chmod 600 /Users/${var.ssh_default_username}/.ssh/authorized_keys"
     ]
-  } 
-
+  }
+  // Add GitHub host key to known hosts.
+  provisioner "shell" {
+    inline = [
+      "echo 'Adding GitHub host key to known hosts...'",
+      "ssh-keyscan github.com >> /Users/${var.ssh_default_username}/.ssh/known_hosts"
+    ]
+  }
   // Disable SSH password authentication.
   // @TODO: Review fallback to password authentication.
   provisioner "shell" {


### PR DESCRIPTION
### Main Changes

This PR solves:

```
20:16:31 stderr: No ED25519 host key is known for github.com and you have requested strict checking.
20:16:31 Host key verification failed.
20:16:31 fatal: Could not read from remote repository.
```

Related to https://github.com/nodejs/build/issues/3686