### PR TITLE
ansible: update Python on ubi8/rhel8 containers

### DIFF
--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -23,7 +23,8 @@ RUN dnf install --disableplugin=subscription-manager -y \
       git \
       java-17-openjdk-headless \
       make \
-      python3.8 \
+      python3.12 \
+      python3.12-pip \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all

--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -27,7 +27,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
       libstdc++-devel \
       libstdc++-devel.i686 \
       make \
-      python3.8 \
+      python3.12 \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all
@@ -51,8 +51,6 @@ RUN update-crypto-policies --set LEGACY
 VOLUME /home/{{ server_user }}/ /home/{{ server_user }}/.ccache
 
 ENV PYTHON /usr/bin/python3
-
-RUN pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN git clone --depth=1 https://github.com/rvagg/rpi-newer-crosstools.git /opt/raspberrypi/rpi-newer-crosstools
 

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -23,7 +23,8 @@ RUN dnf install --disableplugin=subscription-manager -y \
       git \
       java-17-openjdk-headless \
       make \
-      python3.8 \
+      python3.12 \
+      python3.12-pip \
       openssl-devel \
       procps-ng \
     && dnf --disableplugin=subscription-manager clean all


### PR DESCRIPTION
Update the version of Python used in the UBI 8/RHEL 8 container images from Python 3.8 to 3.12.

Refs: https://github.com/nodejs/node/pull/55239#issuecomment-2401546120

---

According to `dnf`, UBI 8/RHEL 8 have Python 3.9, 3.11 and 3.12 available to install. I've opted for 3.12 to give us the longest time before we have to update again.

Docker hosts to update:
- [x] release-mnx-ubuntu2404_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-2
- [ ] test-equinix-ubuntu2004_docker-arm64-1
- [ ] test-equinix-ubuntu2004_docker-arm64-3
- [x] test-ibm-ubuntu2204_docker-x64-1
- [ ] test-osuosl-ubuntu2004_docker-arm64-1