### PR TITLE
build,win: compile with clang

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -58,10 +58,9 @@ def buildExclusions = [
   [ /vs2015(-\w+)?$/,                 testType,    gte(18)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(18)       ],
   [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
-  [ /vs2022(-\w+)?$/,                 testType,    lt(20)        ], // Temporarily compile Node v20+ on both VS2019 and VS2022
-  [ /vs2022-x86$/,                    testType,    lt(20)        ], // Temporarily compile Node v20+ arm64 and x86 on both VS2019 and VS2022
-  [ /vs2022-x86$/,                    testType,    gte(23)       ],
-  [ /vs2022-arm64$/,                  testType,    lt(20)        ],
+  [ /vs2022(-\w+)?$/,                 testType,    lt(21)        ],
+  [ /vs2022-x86$/,                    testType,    gte(23)       ], // x86 was dropped on Windows in v23
+  [ /vs2022_clang(-\w+)?$/,           testType,    lt(23)        ], // ClangCL support was added in v23
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
   [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],

--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -4,8 +4,12 @@ if %NODEJS_MAJOR_VERSION% leq 12 set "PATH=C:\Python27\;C:\Python27\Scripts;%PAT
 :: Opt-in for a generating binlog (work with code has https://github.com/nodejs/node/pull/26431/files)
 set "msbuild_args=/binaryLogger:node.binlog"
 
+:: Check if compiler is ClangCL
+echo %nodes% | findstr /R "_clang" >nul
+set "not_clang=%errorlevel%"
+
 :: Opt-in for a clcache
-if not defined DISABLE_CLCACHE if exist C:\clcache\dist\clcache_main\clcache_main.exe (
+if %not_clang% equ 1 if not defined DISABLE_CLCACHE if exist C:\clcache\dist\clcache_main\clcache_main.exe (
   set CLCACHE_OBJECT_CACHE_TIMEOUT_MS=60000
   set CLCACHE_BASEDIR="%WORKSPACE%"
   set CLCACHE_HARDLINK=1
@@ -49,6 +53,9 @@ if "%nodes:~-6%" == "-arm64" (
   set "VCBUILD_EXTRA_ARGS=x86 %VCBUILD_EXTRA_ARGS%"
 ) else (
   set "VCBUILD_EXTRA_ARGS=x64 %VCBUILD_EXTRA_ARGS%"
+)
+if %not_clang% equ 0  (
+  set "VCBUILD_EXTRA_ARGS=%VCBUILD_EXTRA_ARGS% clang-cl"
 )
 set DEBUG_HELPER=1
 call vcbuild.bat %VCBUILD_EXTRA_ARGS%


### PR DESCRIPTION
Since https://github.com/nodejs/node/pull/55249 landed, the main branch of the `node` repo supports compilation with ClangCL with PCH. MSVC and ClangCL compilation times are similar now, so we can start compiling (in some time testing, and eventually releasing) with ClangCL.

This PR adds support for compiling with ClangCL from v23. It also stops compiling v20 with VS2022 since it was temporary (we just never removed it before).

The labels we currently use in CI for VS2022 compilation are `win-vs2022` and `win-vs2022-arm64`. The format will stay the same, only `vs2022` will be replaced by `vs2022_clang`. The way I see it, this is the most consistent way of labeling it compared to what we already have in the CI, but if someone thinks differently we can discuss it.

I already added those labels to the CI machines that will be compiling and made a copy of the Windows fanned job in https://ci.nodejs.org/job/mefi-node-test-commit-windows-fanned/, so I can confirm these changes work. Once this PR lands we can edit the original compile jobs to do the same.

The second part of the plan is to make new labels, similar to these for test jobs and once I test it in the CI, open a PR for them as well.

One more notable thing is that clcache doesn't work with ClangCL, so in parallel with all of this, I'll try and see about alternatives eg. ccache for ClangCL compilation.