### PR TITLE
ansible: fix cross compile container for Node.js 18

### DIFF
--- a/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8_arm_cross.Dockerfile.j2
@@ -28,6 +28,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
       libstdc++-devel.i686 \
       make \
       python3.12 \
+      python3.12-setuptools \
       procps-ng \
       xz \
     && dnf --disableplugin=subscription-manager clean all


### PR DESCRIPTION
In https://github.com/nodejs/build/pull/3930 I dropped `python3.12-pip` from the cross compile container because we do not need to install `tap2junit`. Unfortunately that means that `python3.12-setuptools` wasn't installed and that is still required for the version of gyp-next in Node.js 18.

Refs: https://github.com/nodejs/build/pull/3930

---

e.g. https://ci.nodejs.org/job/node-cross-compile/50359/nodes=cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/console
```console
10:03:12 /usr/bin/python3 ./configure --verbose  --dest-cpu=arm
10:03:12 Node.js configure: Found Python 3.12.5...
10:03:12 Traceback (most recent call last):
10:03:12   File "/home/iojs/build/workspace/node-cross-compile/./configure", line 29, in <module>
10:03:12     import configure
10:03:12   File "/home/iojs/build/workspace/node-cross-compile/configure.py", line 17, in <module>
10:03:12     from distutils.version import StrictVersion
10:03:12 ModuleNotFoundError: No module named 'distutils'
```

For reference:
```console
# dnf install python3.12-pip
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:00:09 ago on Fri Oct 11 15:35:55 2024.
Dependencies resolved.
=================================================================================================================================================================================================================
 Package                                                 Architecture                             Version                                           Repository                                              Size
=================================================================================================================================================================================================================
Installing:
 python3.12-pip                                          noarch                                   23.2.1-4.el8                                      ubi-8-appstream-rpms                                   3.2 M
Installing dependencies:
 mpdecimal                                               x86_64                                   2.5.1-3.el8                                       ubi-8-appstream-rpms                                    93 k
 python3.12                                              x86_64                                   3.12.5-2.el8_10                                   ubi-8-appstream-rpms                                    30 k
 python3.12-libs                                         x86_64                                   3.12.5-2.el8_10                                   ubi-8-appstream-rpms                                    10 M
 python3.12-pip-wheel                                    noarch                                   23.2.1-4.el8                                      ubi-8-appstream-rpms                                   1.5 M
Installing weak dependencies:
 python3.12-setuptools                                   noarch                                   68.2.2-4.el8_10                                   ubi-8-appstream-rpms                                   1.7 M

Transaction Summary
=================================================================================================================================================================================================================
Install  6 Packages
```
compared to 
```console
# dnf install python3.12
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Last metadata expiration check: 0:12:37 ago on Fri Oct 11 15:35:55 2024.
Dependencies resolved.
=================================================================================================================================================================================================================
 Package                                                Architecture                             Version                                            Repository                                              Size
=================================================================================================================================================================================================================
Installing:
 python3.12                                             x86_64                                   3.12.5-2.el8_10                                    ubi-8-appstream-rpms                                    30 k
Installing dependencies:
 mpdecimal                                              x86_64                                   2.5.1-3.el8                                        ubi-8-appstream-rpms                                    93 k
 python3.12-libs                                        x86_64                                   3.12.5-2.el8_10                                    ubi-8-appstream-rpms                                    10 M
 python3.12-pip-wheel                                   noarch                                   23.2.1-4.el8                                       ubi-8-appstream-rpms                                   1.5 M

Transaction Summary
=================================================================================================================================================================================================================
Install  4 Packages
```