### PR TITLE
ansible: don't assume the relative paths for staging & dist are the same

### DIFF
--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -31,9 +31,10 @@ if [ -z ${staging_bucket+x} ]; then
   exit 1
 fi
 
-relativedir=${dstdir/$dist_rootdir/"$site/"}
+relative_srcdir=${srcdir/$staging_rootdir/"$site/"}
+relative_dstdir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
-rclone copy $staging_bucket/$relativedir/$tmpversion/ $prod_bucket/$relativedir/$tmpversion/
-rclone copyto $staging_bucket/$relativedir/index.json $prod_bucket/$relativedir/index.json
-rclone copyto $staging_bucket/$relativedir/index.tab $prod_bucket/$relativedir/index.tab
+rclone copy $staging_bucket/$relative_srcdir/$tmpversion/ $prod_bucket/$relative_dstdir/$tmpversion/
+rclone copyto $staging_bucket/$relative_dstdir/index.json $prod_bucket/$relative_dstdir/index.json
+rclone copyto $staging_bucket/$relative_dstdir/index.tab $prod_bucket/$relative_dstdir/index.tab


### PR DESCRIPTION
Some non-mainline releases' src dirs differ from their dst dirs (i.e. v8-canary builds upload to `/home/staging/nodejs/custom` and then are promoted to `/home/dist/nodejs/v8-canary`. This wasn't being accounted for when we promoted files from the `dist-staging` bucket to the
    `dist-prod` bucket.