### PR TITLE
ansible: use --log-file option for rclone

### DIFF
--- a/ansible/www-standalone/tools/promote/_resha.sh
+++ b/ansible/www-standalone/tools/promote/_resha.sh
@@ -34,6 +34,11 @@ if [ -z ${staging_bucket+x} ]; then
   exit 1
 fi
 
+if [ -z ${rclone_log+x} ]; then
+    echo "\$rclone_log is not set"
+    exit 1
+fi
+
 (cd "${dstdir}/${version}" && shasum -a256 $(ls node* openssl* iojs* win-*/* x64/* 2> /dev/null) > SHASUMS256.txt) || exit 1
 if [[ $version =~ ^v[0] ]]; then
   (cd "${dstdir}/${version}" && shasum $(ls node* openssl* x64/* 2> /dev/null) > SHASUMS.txt) || exit 1
@@ -44,6 +49,6 @@ find "${dstdir}/${version}" -type f -exec chmod 644 '{}' \;
 find "${dstdir}/${version}" -type d -exec chmod 755 '{}' \;
 
 relativedir=${dstdir/$dist_rootdir/"$site/"}
-rclone copyto ${dstdir}/index.json $staging_bucket/$relativedir/index.json > /dev/null
-rclone copyto ${dstdir}/index.tab $staging_bucket/$relativedir/index.tab > /dev/null
-rclone copyto ${dstdir}/${version}/SHASUMS256.txt $staging_bucket/$relativedir/${version}/SHASUMS256.txt > /dev/null
+rclone copyto --log-file=${rclone_log} ${dstdir}/index.json $staging_bucket/$relativedir/index.json > /dev/null
+rclone copyto --log-file=${rclone_log} ${dstdir}/index.tab $staging_bucket/$relativedir/index.tab > /dev/null
+rclone copyto --log-file=${rclone_log} ${dstdir}/${version}/SHASUMS256.txt $staging_bucket/$relativedir/${version}/SHASUMS256.txt > /dev/null

--- a/ansible/www-standalone/tools/promote/_resha.sh
+++ b/ansible/www-standalone/tools/promote/_resha.sh
@@ -39,6 +39,10 @@ if [ -z ${rclone_log+x} ]; then
     exit 1
 fi
 
+if [ -z ${rclone_log_level+x} ]; then
+  rclone_log_level=INFO
+fi
+
 (cd "${dstdir}/${version}" && shasum -a256 $(ls node* openssl* iojs* win-*/* x64/* 2> /dev/null) > SHASUMS256.txt) || exit 1
 if [[ $version =~ ^v[0] ]]; then
   (cd "${dstdir}/${version}" && shasum $(ls node* openssl* x64/* 2> /dev/null) > SHASUMS.txt) || exit 1
@@ -49,6 +53,19 @@ find "${dstdir}/${version}" -type f -exec chmod 644 '{}' \;
 find "${dstdir}/${version}" -type d -exec chmod 755 '{}' \;
 
 relativedir=${dstdir/$dist_rootdir/"$site/"}
-rclone copyto --log-file=${rclone_log} ${dstdir}/index.json $staging_bucket/$relativedir/index.json > /dev/null
-rclone copyto --log-file=${rclone_log} ${dstdir}/index.tab $staging_bucket/$relativedir/index.tab > /dev/null
-rclone copyto --log-file=${rclone_log} ${dstdir}/${version}/SHASUMS256.txt $staging_bucket/$relativedir/${version}/SHASUMS256.txt > /dev/null
+rclone copyto \
+  --log-level=${rclone_log_level} \
+  --log-file=${rclone_log} \
+  ${dstdir}/index.json \
+  $staging_bucket/$relativedir/index.json > /dev/null
+rclone copyto \
+  --log-level=${rclone_log_level} \
+  --log-file=${rclone_log} \
+  ${dstdir}/index.tab \
+  $staging_bucket/$relativedir/index.tab > /dev/null
+rclone copyto \
+  --log-level=${rclone_log_level} \
+  --log-file=${rclone_log} \
+  ${dstdir}/${version}/SHASUMS256.txt \
+  $staging_bucket/$relativedir/${version}/SHASUMS256.txt > /dev/null
+  

--- a/ansible/www-standalone/tools/promote/settings
+++ b/ansible/www-standalone/tools/promote/settings
@@ -39,3 +39,6 @@ chakracore_release_dirmatch=.*
 
 prod_bucket=r2:dist-prod
 staging_bucket=r2:dist-staging
+
+# format: yyyy-mm-dd-hh-mm-ss.log
+rclone_log=${dist_rootdir}rclone/$(date "+%F-%H-%M-%S.log")

--- a/ansible/www-standalone/tools/promote/settings
+++ b/ansible/www-standalone/tools/promote/settings
@@ -41,4 +41,5 @@ prod_bucket=r2:dist-prod
 staging_bucket=r2:dist-staging
 
 # format: yyyy-mm-dd-hh-mm-ss.log
+rclone_log_level=INFO
 rclone_log=${dist_rootdir}rclone/$(date "+%F-%H-%M-%S.log")

--- a/ansible/www-standalone/tools/promote/settings
+++ b/ansible/www-standalone/tools/promote/settings
@@ -42,4 +42,4 @@ staging_bucket=r2:dist-staging
 
 # format: yyyy-mm-dd-hh-mm-ss.log
 rclone_log_level=INFO
-rclone_log=${dist_rootdir}rclone/$(date "+%F-%H-%M-%S.log")
+rclone_log=/home/dist/rclone/$(date "+%F-%H-%M-%S.log")

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -30,11 +30,15 @@ if [ -z ${staging_bucket+x} ]; then
   echo "\$staging_bucket is not set"
   exit 1
 fi
+if [ -z ${rclone_log+x} ]; then
+    echo "\$rlone_log is not set"
+    exit 1
+fi
 
 relative_srcdir=${srcdir/$staging_rootdir/"$site/"}
 relative_dstdir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
-rclone copy $staging_bucket/$relative_srcdir/$tmpversion/ $prod_bucket/$relative_dstdir/$tmpversion/
-rclone copyto $staging_bucket/$relative_dstdir/index.json $prod_bucket/$relative_dstdir/index.json
-rclone copyto $staging_bucket/$relative_dstdir/index.tab $prod_bucket/$relative_dstdir/index.tab
+rclone copy --log-file=$rclone_log $staging_bucket/$relative_srcdir/$tmpversion/ $prod_bucket/$relative_dstdir/$tmpversion/
+rclone copyto --log-file=$rclone_log $staging_bucket/$relative_dstdir/index.json $prod_bucket/$relative_dstdir/index.json
+rclone copyto --log-file=$rclone_log $staging_bucket/$relative_dstdir/index.tab $prod_bucket/$relative_dstdir/index.tab

--- a/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
+++ b/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh
@@ -34,11 +34,26 @@ if [ -z ${rclone_log+x} ]; then
     echo "\$rlone_log is not set"
     exit 1
 fi
+if [ -z ${rclone_log_level+x} ]; then
+  rclone_log_level=INFO
+fi
 
 relative_srcdir=${srcdir/$staging_rootdir/"$site/"}
 relative_dstdir=${dstdir/$dist_rootdir/"$site/"}
 tmpversion=$2
 
-rclone copy --log-file=$rclone_log $staging_bucket/$relative_srcdir/$tmpversion/ $prod_bucket/$relative_dstdir/$tmpversion/
-rclone copyto --log-file=$rclone_log $staging_bucket/$relative_dstdir/index.json $prod_bucket/$relative_dstdir/index.json
-rclone copyto --log-file=$rclone_log $staging_bucket/$relative_dstdir/index.tab $prod_bucket/$relative_dstdir/index.tab
+rclone copy \
+  --log-level=$rclone_log_level \
+  --log-file=$rclone_log \
+  $staging_bucket/$relative_srcdir/$tmpversion/ \
+  $prod_bucket/$relative_dstdir/$tmpversion/
+rclone copyto \
+  --log-level=$rclone_log_level \
+  --log-file=$rclone_log \
+  $staging_bucket/$relative_dstdir/index.json \
+  $prod_bucket/$relative_dstdir/index.json
+rclone copyto \
+  --log-level=$rclone_log_level \
+  --log-file=$rclone_log \
+  $staging_bucket/$relative_dstdir/index.tab \
+  $prod_bucket/$relative_dstdir/index.tab


### PR DESCRIPTION
Open to suggestion for where the logs should go, this currently writes them to `/home/dist/nodejs/rclone` which requires the creation of that folder