### PR TITLE
ansible: add getaddrinfo config to prefer IPv4

### DIFF
--- a/ansible/roles/bootstrap/files/gai.conf
+++ b/ansible/roles/bootstrap/files/gai.conf
@@ -1,0 +1,12 @@
+# getaddrinfo(3) configuration file
+# Settings to prefer IPv4 addresses for hosts with limited IPv6 connectivity.
+
+# Below settings are documented defaults but need to be duplicated since
+# setting any precedence line means the default table is not used.
+precedence  ::1/128       50
+precedence  ::/0          40
+precedence  2002::/16     30
+precedence ::/96          20
+
+# This line is changed from the default to give IPv4 higher precedence.
+precedence ::ffff:0:0/96  100

--- a/ansible/roles/bootstrap/tasks/partials/linuxonecc/rhel9.yml
+++ b/ansible/roles/bootstrap/tasks/partials/linuxonecc/rhel9.yml
@@ -1,0 +1,11 @@
+---
+
+# LinuxONE Community Cloud Red Hat Enterprise Linux 9
+
+- name: Configure getaddrinfo to prefer IPv4 addresses
+  ansible.builtin.copy:
+    dest: /etc/gai.conf
+    group: root
+    mode: 0644
+    owner: root
+    src: "gai.conf"

--- a/ansible/roles/bootstrap/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/bootstrap/tasks/partials/rhel8-s390x.yml
@@ -48,3 +48,11 @@
     insertafter: ":OUTPUT ACCEPT.*]"
     line: "-A INPUT -s 127.0.0.2/32 -d 127.0.0.1/32 -j ACCEPT"
   notify: restart iptables
+
+- name: Configure getaddrinfo to prefer IPv4 addresses
+  ansible.builtin.copy:
+    dest: /etc/gai.conf
+    group: root
+    mode: 0644
+    owner: root
+    src: "gai.conf"


### PR DESCRIPTION
On some hosts, IPv6 connectivity is limited and may result in DNS lookups returning IPv6 addresses that the host is unable to reach. Add a config file for glibc's getaddrinfo function that configures IPv4 addresses to have higher precedence for such hosts.

Fixes: https://github.com/nodejs/build/issues/3950

---

Deploy status
- [x] [test-ibm-rhel8-s390x-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D1/)
- [x] [test-ibm-rhel8-s390x-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D2/)
- [x] [test-ibm-rhel8-s390x-3](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D3/)
- [x] [test-ibm-rhel8-s390x-4](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D4/)
- [x] [test-linuxonecc-rhel9-s390x-1](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D1/)
- [x] [test-linuxonecc-rhel9-s390x-2](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D2/)
- [x] [test-linuxonecc-rhel9-s390x-3](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D3/)
- [x] [test-linuxonecc-rhel9-s390x-4](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D4/)