### PR TITLE
Add requirement that non-collaborator members be approved by the TSC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -59,7 +59,7 @@ should be aware of the bounds of their expertise and act accordingly.
      working groups and activities. The longer the better. In case of doubt,
      or if the individual is _not_ a Node.js Collaborator, contact the Node.js
      TSC.
-  3. A contractual relationship (such as employment) with a member company of
+  2. A contractual relationship (such as employment) with a member company of
      the OpenJS Foundation. Contractual relationships carry legal weight and
      provide greater likelihood of a stable trust relationship; at a minimum
      they establish strong legal accountability.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -56,8 +56,10 @@ should be aware of the bounds of their expertise and act accordingly.
   the basics of a trust relationship. The most two most straightforward paths
   to trust are:
   1. An established relationship with the Node.js project and its associated
-     working groups and activities. The longer the better.
-  2. A contractual relationship (such as employment) with a member company of
+     working groups and activities. The longer the better. In case of doubt,
+     or if the individual is _not_ a Node.js Collaborator, contact the Node.js
+     TSC.
+  3. A contractual relationship (such as employment) with a member company of
      the OpenJS Foundation. Contractual relationships carry legal weight and
      provide greater likelihood of a stable trust relationship; at a minimum
      they establish strong legal accountability.


### PR DESCRIPTION
To avoid XY-style attacks, build-wg members should be highly trusted. Therefore, if they are not already Node.js collaborators, they should be approved by the TSC.