### PR TITLE
ansible: add test-digitalocean-fedora41-x64-[12]

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -120,6 +120,7 @@ hosts:
         fedora39-x64-2: {ip: 134.209.172.40}
         fedora40-x64-1: {ip: 159.65.248.149}
         fedora40-x64-2: {ip: 162.243.187.89}
+        fedora41-x64-1: {ip: 165.227.191.35}
         freebsd13-x64-1: {ip: 138.197.25.49, user: freebsd, swap_file_size_mb: 2048}
         freebsd13-x64-2: {ip: 159.89.188.229, user: freebsd, swap_file_size_mb: 2048}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -121,6 +121,7 @@ hosts:
         fedora40-x64-1: {ip: 159.65.248.149}
         fedora40-x64-2: {ip: 162.243.187.89}
         fedora41-x64-1: {ip: 165.227.191.35}
+        fedora41-x64-2: {ip: 159.65.246.5}
         freebsd13-x64-1: {ip: 138.197.25.49, user: freebsd, swap_file_size_mb: 2048}
         freebsd13-x64-2: {ip: 159.89.188.229, user: freebsd, swap_file_size_mb: 2048}
         rhel8-x64-1: {ip: 161.35.139.78, build_test_v8: yes, swap_file_size_mb: 2048}

--- a/ansible/roles/bootstrap/tasks/partials/fedora.yml
+++ b/ansible/roles/bootstrap/tasks/partials/fedora.yml
@@ -35,3 +35,8 @@
 - name: remove firewalld
   when: has_firewalld.rc == 0
   raw: dnf remove -y firewalld
+
+# https://github.com/ansible/ansible/issues/84206
+- name: install python3-libdnf5
+  when: os in ("fedora41")
+  raw: dnf install -y python3-libdnf5


### PR DESCRIPTION
Note that I had to manually install an Ansible dependency before running the playbook because of https://github.com/ansible/ansible/issues/84206:

```
dnf install python3-libdnf5
```