### PR TITLE
jenkins: improve x64 node.exe caching for arm64

### DIFF
--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -37,17 +37,11 @@ if "%nodes:~-6%" == "-arm64" (
     :: ARM64 MSI needs x64 node.exe to generate the license file.
     :: It is downloaded from vcbuild.bat and is known to hang,
     :: thus failing the build after timing out (1-2% runs).
-    :: Downloading it from here and updating it weekly should
-    :: decrease, if not remove, these types of CI failures.
-    :: Download and cache x64 node.exe.
-    mkdir C:\node_exe_cache
-    forfiles /p "C:\node_exe_cache" /m "node.exe" /d -7 /c "cmd /c del @path"
-    if not exist C:\node_exe_cache\node.exe (
-      curl -L https://nodejs.org/dist/latest/win-x64/node.exe -o C:\node_exe_cache\node.exe
+    :: Copying it from cache should prevent this from happening.
+    if exist "C:\node_exe_cache\node.exe" (
+      mkdir temp-vcbuild
+      copy C:\node_exe_cache\node.exe temp-vcbuild\node-x64-cross-compiling.exe
     )
-    :: Copy it to where vcbuild expects.
-    mkdir temp-vcbuild
-    copy C:\node_exe_cache\node.exe temp-vcbuild\node-x64-cross-compiling.exe
   )
 ) else if "%nodes:~-4%" == "-x86" (
   set "VCBUILD_EXTRA_ARGS=x86 %VCBUILD_EXTRA_ARGS%"


### PR DESCRIPTION
This is the 3rd, and hopefully the last attempt at solving x64 node.exe caching in the CI needed to generate license files when compiling for ARM64. Compared to the previous 2, this one simplifies caching by removing the downloading step. The x64 node.exe is now expected to be already cached before running compile.cmd.

The same change was already applied successfully to the release CI.

Refs: nodejs#3315
Refs: https://github.com/nodejs/build/pull/3514
Refs: https://github.com/nodejs/build/pull/3533
Refs: https://github.com/nodejs/build/pull/3842
Refs: https://github.com/nodejs/build/pull/3849