### PR TITLE
ansible: update www Node.js version

### DIFF
--- a/ansible/www-standalone/tasks/base.yaml
+++ b/ansible/www-standalone/tasks/base.yaml
@@ -1,5 +1,5 @@
 - name: Base | Add the NodeSource Node.js repo
-  command: "bash -c 'curl -sL https://deb.nodesource.com/setup_16.x | bash -'"
+  command: "bash -c 'curl -sL https://deb.nodesource.com/setup_22.x | bash -'"
   tags: base
 
 - name: Base | APT Update


### PR DESCRIPTION
Update the version of Node.js used on the www server from Node.js 16 (16.20.2) to Node.js 22 (22.11.0).

Refs: https://github.com/nodejs/build/issues/3958#issuecomment-2493955665
