### PR TITLE
ansible: add smartos test hosts and allow for smartos22

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -242,6 +242,23 @@ hosts:
         smartos21-x64-2: {ip: 8.225.232.137}
         smartos23-x64-1: {ip: 8.225.232.134}
         smartos23-x64-2: {ip: 8.225.232.141}
+        smartos22-x64-1:
+          ip: 172.16.9.3
+          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@67.158.54.157"'
+          ansible_user: root
+        smartos22-x64-2:
+          ip: 172.16.9.3
+          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@67.158.54.56"'
+          ansible_user: root
+        smartos23-x64-4:
+          ip: 172.16.9.3
+          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@192.207.255.124"'
+          ansible_user: root
+        smartos23-x64-5:
+          ip: 172.16.9.3
+          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@67.158.54.51"'
+          ansible_user: root
+
 
     - osuosl:
         # secret for -1 was compromised, do not use -1 name

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -238,10 +238,6 @@ hosts:
         # to update the Jenkins worker IP allowlist in github-bot
         ubuntu2204-x64-1: {ip: 67.158.54.159, alias: jenkins-workspace-9}
         ubuntu2204-x64-2: {ip: 8.225.232.44, alias: jenkins-workspace-10}
-        smartos21-x64-1: {ip: 8.225.232.135}
-        smartos21-x64-2: {ip: 8.225.232.137}
-        smartos23-x64-1: {ip: 8.225.232.134}
-        smartos23-x64-2: {ip: 8.225.232.141}
         smartos22-x64-1:
           ip: 172.16.9.3
           ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@67.158.54.157"'

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -11,6 +11,7 @@ ssh_config: /etc/ssh/sshd_config
 
 sshd_service_map: {
   'smartos21': 'ssh',
+  'smartos22': 'ssh',
   'smartos23': 'ssh',
 }
 
@@ -126,11 +127,18 @@ packages: {
     'py310-pip'
   ],
 
+  smartos22: [
+    'gcc12',
+    'ccache',
+    'python311',
+    'py311-pip'
+  ],
+
   smartos23: [
     'gcc13',
     'ccache',
-    'python310',
-    'py310-pip'
+    'python312',
+    'py312-pip'
   ],
 
   ubuntu: [
@@ -145,7 +153,7 @@ packages: {
   # Default gcc/g++ package is 7.
   ubuntu1804: [
     'gcc-6,g++-6,gcc-8,g++-8,python3.8',
-  ],  
+  ],
 
   # Default gcc/g++ package is 11.
   ubuntu2204: [

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -10,7 +10,6 @@ git_version: 2.10.2
 ssh_config: /etc/ssh/sshd_config
 
 sshd_service_map: {
-  'smartos21': 'ssh',
   'smartos22': 'ssh',
   'smartos23': 'ssh',
 }
@@ -119,12 +118,6 @@ packages: {
     'gmake',
     'xz',
     'sudo',
-  ],
-
-  smartos21: [
-    'gcc10',
-    'ccache',
-    'py310-pip'
   ],
 
   smartos22: [

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -16,7 +16,7 @@ packages: {
   'rhel7': 'java-11-openjdk',
   'rhel8': 'java-17-openjdk',
   'rhel9': 'java-17-openjdk',
-  'smartos': 'openjdk11',
+  'smartos': 'openjdk17',
   'ubuntu': 'openjdk-17-jre-headless',
   'ubuntu1604': 'openjdk-8-jre-headless',
   'ubuntu2204': 'openjdk-17-jre-headless',
@@ -25,7 +25,7 @@ packages: {
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default(omit) }}"
 
 # Add os_arch combinations here that should install and use AdoptOpenJDK
-# binaries. Override any variables in the dictionary. 
+# binaries. Override any variables in the dictionary.
 # e.g. on AIX ansible_architecture is 'chrp' on some of our hosts so we
 # override arch to be on the safe side.
 adoptopenjdk: {

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -66,6 +66,7 @@ java_path: {
   'macos11': 'java',
   'macos11.0': 'java',
   'smartos21': '/opt/local/java/openjdk11/bin/java',
+  'smartos22': '/opt/local/java/openjdk11/bin/java',
   'smartos23': '/opt/local/java/openjdk11/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }

--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -65,9 +65,8 @@ java_path: {
   'macos10.15': 'java',
   'macos11': 'java',
   'macos11.0': 'java',
-  'smartos21': '/opt/local/java/openjdk11/bin/java',
-  'smartos22': '/opt/local/java/openjdk11/bin/java',
-  'smartos23': '/opt/local/java/openjdk11/bin/java',
+  'smartos22': '/opt/local/java/openjdk17/bin/java',
+  'smartos23': '/opt/local/java/openjdk17/bin/java',
   'zos24': '/usr/lpp/java/J8.0_64/bin/java'
   }
 


### PR DESCRIPTION
This may not work fully with our ssh configure script.

The smartos instances are vm's inside of a host hypervisor, as such we have to ssh proxy to get all the way into a shell.

There may also be strange ansible issues as a result of the hosts sharing, essentially, the same host IP address. I noticed that the jenkins secret from one host kept ending up on a different host, so Im not sure if ansible has something cached that uses the host IP as a key internally somewhere. 

If that becomes problematic we can adjust the internal IP's of the instances in the future to not conflict with each other. 