### PR TITLE
doc: update release overview

### DIFF
--- a/doc/release-overview.md
+++ b/doc/release-overview.md
@@ -8,28 +8,28 @@ Clicking on most labels will take you to the relevant area of the build reposito
 flowchart TD
     subgraph releaser[Releaser]
       start([<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md'>Start</a>])
-      prepareRelease[/<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#7-ensure-that-the-release-branch-is-stable'>Prepare the release</a>\]
-      startTestBuilds[/<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#7-ensure-that-the-release-branch-is-stable'>Start test builds</a>\]
+      prepareRelease[\<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#7-ensure-that-the-release-branch-is-stable'>Prepare the release</a>/]
+      startTestBuilds[\<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#7-ensure-that-the-release-branch-is-stable'>Start test builds</a>/]
       readyToRelease{Ready for release?}
       
-      startReleaseBuilds[/<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#9-produce-release-builds'>Start release build</a>\]
-      promote[/<a href='https://github.com/nodejs/node/blob/main/tools/release.sh'>Promote</a>\]
-      blog[/<a href='https://github.com/nodejs/nodejs.org/blob/main/apps/site/scripts/release-post/index.mjs'>Create blog post</a>\]
+      startReleaseBuilds[\<a href='https://github.com/nodejs/node/blob/main/doc/contributing/releases.md#9-produce-release-builds'>Start release build</a>/]
+      promote[\<a href='https://github.com/nodejs/node/blob/main/tools/release.sh'>Promote</a>/]
+      blog[\<a href='https://github.com/nodejs/nodejs.org/blob/main/apps/site/scripts/release-post/index.mjs'>Create blog post</a>/]
       done([End])
 
       start-->prepareRelease-->startTestBuilds-->readyToRelease
-      readyToRelease--No-->prepareRelease
-      readyToRelease--Yes-->startReleaseBuilds-->promote-->blog-->done
+      readyToRelease-->|No|prepareRelease
+      readyToRelease-->|Yes|startReleaseBuilds-->promote-->blog-->done
     end
     subgraph github[GitHub]
       ghCode[(<a href='https://github.com/nodejs/node'>nodejs/node</a>)]
       ghWebsite[(<a href='https://github.com/nodejs/nodejs.org'>nodejs/nodejs.org</a>)]
-      ghUnofficial[(<a href='https://github.com/nodejs/unofficial-builds'>nodejs/unofficial-builds</a>)]
+      ghCFWorker[(<a href='https://github.com/nodejs/release-cloudflare-worker'>nodejs/release-cloudflare-worker</a>)]
       
       %% This invisible link is to aid the layout of the flowchart, stacking the repositories vertically
-      ghCode ~~~ ghWebsite ~~~ ghUnofficial
+      ghCode ~~~ ghWebsite ~~~ ghCFWorker
     end
-    subgraph buildInfra[Infrastructure owned by Build WG]
+    subgraph buildInfra[Build WG Infrastructure]
     subgraph ci[Test CI]
       testBuilds(<a href='https://ci.nodejs.org/job/node-test-pull-request/'>Test builds</a>)
     end
@@ -38,89 +38,83 @@ flowchart TD
     end
     subgraph wwwServer[<a href='https://github.com/nodejs/build/tree/main/ansible/www-standalone'>www server</a>]
       staging[(staging)]
-      promotion(<a href='https://github.com/nodejs/build/tree/main/ansible/www-standalone/tools/promote'>Promotion</a>)
       dist[(dist)]
-      rebuildIdx(<a href='https://github.com/nodejs/nodejs-dist-indexer'>Rebuild index</a>)
-      rebuildWebsite(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/build-site.sh'>Rebuild website</a>)
-      www[(www)]
-      queueCDN[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/queue-cdn-purge.sh'>Queue CDN purge</a>]
-      webhook(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/config/github-webhook.json.j2'>Webhook</a>)
+      subgraph promotion[<a href='https://github.com/nodejs/build/tree/main/ansible/www-standalone/tools/promote'>Promotion</a>]
+        subgraph nightlyPromoteCron[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tasks/site-setup.yaml'>nightly promote cron</a>]
+          promoteNightly[[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tools/promote/promote_nightly.sh'>Promote nightly</a>]]
+        end
+        promoteRelease(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tools/promote/promote_release.sh'>Promote release</a>)
+        promoteCommon(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tools/promote/_promote.sh'>Promote</a>)
+        resha(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tools/promote/_resha.sh'>_resha</a>)
+        uploadToCloudflare(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tools/promote/upload_to_cloudflare.sh'>upload_to_cloudflare.sh</a>)
+        rebuildIdx(<a href='https://github.com/nodejs/nodejs-dist-indexer'>Rebuild index</a>)
+        queueCDN[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/queue-cdn-purge.sh'>Queue CDN purge</a>]
+      end
+      
       subgraph nightlyCron[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tasks/tools.yaml'>nightly cron</a>]
         nightlyBuilder[[<a href='https://github.com/nodejs/nodejs-nightly-builder'>nodejs-nightly-builder</a>]]
       end
 
-      staging-->promotion-->dist-->rebuildIdx
+      staging-->promoteCommon-->dist
+      promoteNightly-.->promoteCommon
+      promoteRelease-->promoteCommon
+      promoteCommon-->resha-->rebuildIdx
+      promoteCommon-->uploadToCloudflare
       nightlyBuilder-.->releaseBuilds
+      rebuildIdx-->queueCDN
+      rebuildIdx-->dist
 
-      subgraph chkIndex[Check index]
-        idxChanged{<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/check-build-site.sh'>Index Changed?</a>}
-
-        idxChanged--No-->idxChanged
-      end
-      
-      rebuildIdx-.->idxChanged
-      webhook-->rebuildWebsite
-      idxChanged--Yes-->rebuildWebsite
-      rebuildWebsite-->www-->queueCDN-.->purgeQueued
-
-      subgraph cdn[CDN purge queue]
+      subgraph cdn[<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/tasks/site-setup.yaml'>CDN purge queue</a>]
         purgeQueued{<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2'>CDN purge queued?</a>}
         purge(<a href='https://github.com/nodejs/build/blob/main/ansible/www-standalone/resources/scripts/cdn-purge.sh.j2'>CDN purge</a>)
 
-        purgeQueued--No-->purgeQueued
-        purgeQueued--Yes-->purge
+        purgeQueued-->|No|purgeQueued
+        purgeQueued-->|Yes|purge
       end
-    end
-    subgraph unofficial[<a href='https://github.com/nodejs/build/tree/main/ansible/roles/unofficial-builds'>Unofficial builds server</a>]
-      subgraph unofficialPeriodicTimer[<a href='https://github.com/nodejs/build/blob/main/ansible/roles/unofficial-builds/files/nodejs-periodic.timer'>nodejs-periodic.timer</a>]
-        subgraph unofficialPeriodicService[<a href='https://github.com/nodejs/build/blob/main/ansible/roles/unofficial-builds/files/nodejs-periodic.service'>nodejs-periodic.service</a>]
-          unofficialPeriodicSh[[<a href='https://github.com/nodejs/unofficial-builds/blob/main/bin/periodic.sh'>periodic.sh</a>]]
-          unofficialBuildIfQueued[[<a href='https://github.com/nodejs/unofficial-builds/blob/main/bin/build-if-queued.sh'>build-if-queued.sh</a>]]
-        end
-      end
-      unofficialManualQueue[/<a href='https://github.com/nodejs/unofficial-builds#manual-build-triggers'>Manually queue build</a>\]
-      unofficialQueueBuild[<a href='https://github.com/nodejs/unofficial-builds/blob/main/bin/queue-push.sh'>Queue build</a>]
-      unofficialDownloads[(download)]
-      unofficialWebhook[<a href='https://github.com/nodejs/build/blob/main/ansible/roles/unofficial-builds/files/unofficial-builds-deploy-webhook.service'>Webhook</a>]
-      unofficialDeploy[<a href='https://github.com/nodejs/build/blob/main/ansible/roles/unofficial-builds/files/deploy-unofficial-builds.sh'>Deploy recipes]
-      unofficialRecipes[(Recipe containers)]
-      
-      ghUnofficial-.->|Pull request merged|unofficialWebhook-->unofficialDeploy-->unofficialRecipes
-      unofficialPeriodicSh-->unofficialBuildIfQueued-->unofficialDownloads
-      unofficialPeriodicSh-->unofficialQueueBuild-->unofficialBuildIfQueued
-      unofficialManualQueue-->unofficialQueueBuild
     end
     subgraph unencrypted[www failover server]
       unencryptedRsync[[rsyncmirror.service]]
       unencryptedDist[(dist mirror)]
-      unencryptedWww[(www mirror)]
 
       dist-->unencryptedRsync
-      www-->unencryptedRsync
       unencryptedRsync-->unencryptedDist
-      unencryptedRsync-->unencryptedWww
     end
     end
     prepareRelease-->|Open/update pull request|ghCode
     startTestBuilds-->testBuilds
     startReleaseBuilds-->releaseBuilds
-    ghWebsite-.->|Pull request merged|webhook
-    promote-->promotion
+    ghCode-->testBuilds
+    ghCode-->releaseBuilds
+    ghWebsite-->|Pull request merged|Vercel
+    promote-->promoteRelease
     blog-->|Open pull request|ghWebsite
-    releaseBuilds-->staging
+    releaseBuilds-->|upload via <a href='https://github.com/nodejs/node/blob/main/Makefile'>Makefile</a>/<a href='https://github.com/nodejs/node/blob/main/vcbuild.bat'>vcbuild.bat</a>|staging
+    staging-->|upload via <a href='https://github.com/nodejs/node/blob/main/Makefile'>Makefile</a>/<a href='https://github.com/nodejs/node/blob/main/vcbuild.bat'>vcbuild.bat</a>|r2Staging
+    subgraph vercel[Vercel]
+      Vercel[(Vercel)]
+    end
     subgraph cloudflare[Cloudflare]
+      website[[<a href='https://nodejs.org/'>https://nodejs.org/</a>]]
       cloudflareCDN[(CDN)]
+      cloudflareWorker[[Worker]]
+      r2Staging[(R2 Staging)]
+      r2Dist[(R2 Production)]
     end
     purge-->cloudflareCDN
-    dist-.->cloudflareCDN
-    www-.->cloudflareCDN
-    unencryptedDist-.->cloudflareCDN
-    unencryptedWww-.->cloudflareCDN
+    dist-.->|old route/failover|cloudflareCDN
+    unencryptedDist-.->|old route/failover|cloudflareCDN
+    r2Staging-->uploadToCloudflare-->r2Dist
+    rebuildIdx-->r2Staging
+    ghCFWorker-->cloudflareWorker
+    r2Dist-->cloudflareWorker
+    Vercel-->|non-downloads/API docs|website
+    cloudflareWorker-->cloudflareCDN-->|downloads/API docs|website
 
     %% Invisible links to aid the layout of the flowchart, vertically stacking some subgraphs
-    ci ~~~ ci-release ~~~ unofficial
-    unofficial ~~~ unencrypted
-    buildInfra ~~~ cloudflare
+    ci ~~~ ci-release
+    releaser ~~~ github ~~~ vercel
+    promotion ~~~ cdn
+    r2Staging ~~~ website
 ```
 
 [release process]: https://github.com/nodejs/node/blob/main/doc/contributing/releases.md


### PR DESCRIPTION
Website is now hosted on Vercel.
Add R2 object storage for staging/hosting of downloads. 
Remove unofficial-builds to simplify the overview (it still exists).

---

cc @nodejs/build-infra 
FYI @nodejs/releasers @nodejs/web-infra 

Direct link to view rendered page: https://github.com/richardlau/build/blob/release-overview/doc/release-overview.md