### PR TITLE
ansible: update CRAN repository URL

### DIFF
--- a/ansible/roles/benchmarking/tasks/main.yml
+++ b/ansible/roles/benchmarking/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Install Rscript repo | {{ os }}
   when: os|startswith("ubuntu")
-  shell: echo "deb https://ftp.heanet.ie/mirrors/cran.r-project.org/bin/linux/ubuntu {{ ansible_distribution_release }}-cran40/" > /etc/apt/sources.list.d/r.list
+  shell: echo "deb https://cran.datenrettung360.de/bin/linux/ubuntu {{ ansible_distribution_release }}-cran40/" > /etc/apt/sources.list.d/r.list
 
 - name: Add R key
   apt_key:


### PR DESCRIPTION
The HEAnet mirror is no more. Change the repository URL for the R packages to Hetzner's mirror (Hetzner being the provider of our current `benchmark` machines).

---

This addresses this error from Ansible:
```console
TASK [package-upgrade : upgrade installed packages] *************************************************************************************************************************************************************
fatal: [test-hetzner-ubuntu2204-x64-1]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "Failed to update apt cache: W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., E:The repository 'https://ftp.heanet.ie/mirrors/cran.r-project.org/bin/linux/ubuntu jammy-cran40/ Release' no longer has a Release file."}
```

FWIW the mirror list for CRAN: https://cran.r-project.org/mirrors.html