### PR TITLE
ansible: add new/replacement rhel9-ppc64le VMs

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -264,9 +264,10 @@ hosts:
         rhel8-ppc64_le-2: {ip: 140.211.168.76, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
         rhel8-ppc64_le-3: {ip: 140.211.168.221, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
         rhel8-ppc64_le-4: {ip: 140.211.168.194, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel9-ppc64_le-1: {ip: 140.211.10.92, user: cloud-user, swap_file_size_mb: 2048}
-        rhel9-ppc64_le-2: {ip: 140.211.10.69, user: cloud-user, swap_file_size_mb: 2048}
-        rhel9-ppc64_le-3: {ip: 140.211.10.110, user: cloud-user, swap_file_size_mb: 2048}
+        rhel9-ppc64_le-1: {ip: 140.211.10.105, user: cloud-user, swap_file_size_mb: 2048}
+        rhel9-ppc64_le-2: {ip: 140.211.10.98, user: cloud-user, swap_file_size_mb: 2048}
+        rhel9-ppc64_le-3: {ip: 140.211.10.102, user: cloud-user, swap_file_size_mb: 2048}
+        rhel9-ppc64_le-4: {ip: 140.211.10.107, user: cloud-user, swap_file_size_mb: 2048}
         ubuntu2004_docker-arm64-1: {ip: 140.211.169.11, user: ubuntu}
 
     - orka:


### PR DESCRIPTION
Replace 
- test-osuosl-rhel9-ppc64_le-1
- test-osuosl-rhel9-ppc64_le-2
- test-osuosl-rhel9-ppc64_le-3

Add test-osuosl-rhel9-ppc64_le-4.

Fixes: https://github.com/nodejs/build/issues/3998