### PR TITLE
Enable ccache in Windows CI

### DIFF
--- a/ansible/roles/visual-studio/tasks/main.yml
+++ b/ansible/roles/visual-studio/tasks/main.yml
@@ -66,8 +66,10 @@
       version: "4.10.2"
   - name: make ccache directory
     win_command: 'mkdir C:\ccache'
-  - name: copy ccache to ccache directory as cl.exe
+  - name: copy ccache to ccache directory as cl.exe for MSVC
     win_command: 'cp C:\ProgramData\chocolatey\lib\ccache\tools\ccache-4.10.2-windows-x86_64\ccache.exe C:\ccache\cl.exe'
+  - name: copy ccache to ccache directory as clang-cl.exe for ClangCL
+    win_command: 'cp C:\ProgramData\chocolatey\lib\ccache\tools\ccache-4.10.2-windows-x86_64\ccache.exe C:\ccache\clang-cl.exe'
   - name: make directory for caching
     win_command: 'mkdir C:\ccache\cache'
   - name: set caching directory enviroment variable

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -52,7 +52,7 @@ def buildExclusions = [
   [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(21)        ],
   [ /vs2022-x86$/,                    testType,    gte(23)       ], // x86 was dropped on Windows in v23
-  [ /vs2022_clang(-\w+)?$/,           testType,    lt(23)        ], // ClangCL support was added in v23
+  [ /vs2022_clang(-\w+)?$/,           testType,    lt(24)        ], // ClangCL support was added in v23
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
   [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],

--- a/jenkins/scripts/windows/compile.cmd
+++ b/jenkins/scripts/windows/compile.cmd
@@ -21,6 +21,11 @@ if %not_clang% equ 1 if not defined DISABLE_CLCACHE if exist C:\clcache\dist\clc
   C:\clcache\dist\clcache_main\clcache_main.exe -s
 )
 
+:: Opt-in for ccache
+if %not_clang% equ 0 if defined CCACHE_DIR if not defined DISABLE_CCACHE if exist C:\ccache\cl.exe (
+  set "VCBUILD_EXTRA_ARGS=%VCBUILD_EXTRA_ARGS% ccache C:\ccache"
+)
+
 :: Call vcbuild
 if "%nodes:~-6%" == "-arm64" (
   :: Building MSI is not yet supported for ARM64 with WiX 3.


### PR DESCRIPTION
This PR enables using `ccache` on Windows VMs in the CI if it is present and not disabled.

This PR also has a fixup for https://github.com/nodejs/build/pull/4016 as `ccache` was only enabled for MSVC (copying as cl.exe) and not for ClangCL (copying as clang-cl.exe)

**IMPORTANT: As `ccache` option landed in `vcbuild.bat` in Node.js recently, we should wait some time before landing this as it may break CI runs on branches without that change**