### PR TITLE
ansible: increase swap on V8 builders

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -132,10 +132,10 @@ hosts:
             remote_env:
                 PATH: /opt/freeware/bin:/usr/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin
             server_jobs: 6
-        rhel8-s390x-1: {ip: 148.100.84.98, user: linux1, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-s390x-2: {ip: 148.100.84.38, user: linux1, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-s390x-3: {ip: 148.100.84.17, user: linux1, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-s390x-4: {ip: 148.100.84.239, user: linux1, build_test_v8: yes, swap_file_size_mb: 2048}
+        rhel8-s390x-1: {ip: 148.100.84.98, user: linux1, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-s390x-2: {ip: 148.100.84.38, user: linux1, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-s390x-3: {ip: 148.100.84.17, user: linux1, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-s390x-4: {ip: 148.100.84.239, user: linux1, build_test_v8: yes, swap_file_size_mb: 4096}
         rhel8-x64-1: {ip: 169.61.75.51, build_test_v8: yes}
         rhel8-x64-2: {ip: 169.61.75.58, build_test_v8: yes}
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
@@ -229,10 +229,10 @@ hosts:
         aix72-ppc64_be-4:
             ip: 140.211.9.101
             server_jobs: 6
-        rhel8-ppc64_le-1: {ip: 140.211.168.183, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-ppc64_le-2: {ip: 140.211.168.76, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-ppc64_le-3: {ip: 140.211.168.221, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
-        rhel8-ppc64_le-4: {ip: 140.211.168.194, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 2048}
+        rhel8-ppc64_le-1: {ip: 140.211.168.183, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-ppc64_le-2: {ip: 140.211.168.76, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-ppc64_le-3: {ip: 140.211.168.221, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 4096}
+        rhel8-ppc64_le-4: {ip: 140.211.168.194, user: cloud-user, build_test_v8: yes, swap_file_size_mb: 4096}
         rhel9-ppc64_le-1: {ip: 140.211.10.105, user: cloud-user, swap_file_size_mb: 2048}
         rhel9-ppc64_le-2: {ip: 140.211.10.98, user: cloud-user, swap_file_size_mb: 2048}
         rhel9-ppc64_le-3: {ip: 140.211.10.102, user: cloud-user, swap_file_size_mb: 2048}


### PR DESCRIPTION
Increase the swap on rhel8-ppc64le and rhel8-s390x machines to allow tests on newer V8 to pass.

---

Deployment:
- [ ] [test-osuosl-rhel8-ppc64_le-1](https://ci.nodejs.org/computer/test-osuosl-rhel8-ppc64_le-1/)
- [ ] [test-osuosl-rhel8-ppc64_le-2](https://ci.nodejs.org/computer/test-osuosl-rhel8-ppc64_le-2/)
- [x] [test-osuosl-rhel8-ppc64_le-3](https://ci.nodejs.org/computer/test-osuosl-rhel8-ppc64_le-3/)
- [ ] [test-osuosl-rhel8-ppc64_le-4](https://ci.nodejs.org/computer/test-osuosl-rhel8-ppc64_le-4/)
- [ ] [test-ibm-rhel8-s390x-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D1/)
- [ ] [test-ibm-rhel8-s390x-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D2/)
- [x] [test-ibm-rhel8-s390x-3](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D3/)
- [ ] [test-ibm-rhel8-s390x-4](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D4/)