### PR TITLE
ansible: add openssl-3.5.0-alpha1 to containers

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -124,6 +124,17 @@ RUN mkdir -p /tmp/openssl-$OPENSSL32VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL32VER
 
+ENV OPENSSL35VER 3.5.0-alpha1
+ENV OPENSSL35DIR /opt/openssl-$OPENSSL35VER
+
+RUN mkdir -p /tmp/openssl-$OPENSSL35VER && \
+    cd /tmp/openssl-$OPENSSL35VER && \
+    curl -sL https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL35VER/openssl-$OPENSSL35VER.tar.gz | tar zxv --strip=1 && \
+    ./config --prefix=$OPENSSL35DIR && \
+    make -j $JOBS && \
+    make install && \
+    rm -rf /tmp/openssl-$OPENSSL35VER
+
 ENV ZLIBVER 1.2.13
 ENV ZLIB12DIR /opt/zlib_$ZLIBVER
 

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -69,6 +69,7 @@ def buildExclusions = [
   [ /sharedlibs_debug_x64/,           anyType,     gte(18) ],
   [ /sharedlibs_openssl110/,          anyType,     gte(18) ],
   [ /sharedlibs_openssl102/,          anyType,     gte(18) ],
+  [ /sharedlibs_openssl35/,           anyType,     lt(24)  ], // Temporary until test fixes are backported
   [ /sharedlibs_fips20/,              anyType,     gte(18) ],
 
   // OSX ---------------------------------------------------


### PR DESCRIPTION
Add OpenSSL 3.5.0-alpha1 to sharedlibs containers.

---

Adds new label [ubuntu2204_sharedlibs_openssl35_x64](https://ci.nodejs.org/label/ubuntu2204_sharedlibs_openssl35_x64/).

Deployment:
- [x] test-digitalocean-ubuntu2204_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-2
- [x] test-ibm-ubuntu2204_docker-x64-1