### PR TITLE
jenkins: add check for checked out commit

### DIFF
--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -29,7 +29,7 @@ git rev-parse $REBASE_ONTO
 
 # COMMIT_SHA_CHECK needs to be set in the job. Check that it looks like
 # a SHA and not some other git ref (e.g. branch ref)
-if ! expr "${COMMIT_SHA_CHECK}" : [0-9a-fA-F]\\+\$ > /dev/null; then
+if ! expr "${COMMIT_SHA_CHECK}" : "[0-9a-fA-F]\\+\$" > /dev/null; then
   echo "COMMIT_SHA_CHECK does not look like a SHA"
   exit 1
 fi

--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -27,8 +27,15 @@ git status
 git rev-parse HEAD
 git rev-parse $REBASE_ONTO
 
-# COMMIT_SHA_CHECK needs to be set in the job. Check that the gitref
-# that is checked out hasn't been updated since the job was requested.
+# COMMIT_SHA_CHECK needs to be set in the job. Check that it looks like
+# a SHA and not some other git ref (e.g. branch ref)
+if ! expr "${COMMIT_SHA_CHECK}" : [0-9a-fA-F]\\+\$ > /dev/null; then
+  echo "COMMIT_SHA_CHECK does not look like a SHA"
+  exit 1
+fi
+
+# Check that the gitref that is checked out hasn't been updated since
+# the job was requested.
 if [ "$(git rev-parse HEAD)" != "$(git rev-parse ${COMMIT_SHA_CHECK})" ]; then
     echo "HEAD does not match expected COMMIT_SHA_CHECK"
     exit 1

--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -27,6 +27,13 @@ git status
 git rev-parse HEAD
 git rev-parse $REBASE_ONTO
 
+# COMMIT_SHA_CHECK needs to be set in the job. Check that the gitref
+# that is checked out hasn't been updated since the job was requested.
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse ${COMMIT_SHA_CHECK})" ]; then
+    echo "HEAD does not match expected COMMIT_SHA_CHECK"
+    exit 1
+fi
+
 if [ -n "${REBASE_ONTO}" ]; then
   git rebase --committer-date-is-author-date $REBASE_ONTO
 fi


### PR DESCRIPTION
Add a check that the gitref being built has not been updated since the build was requested. Requires `COMMIT_SHA_CHECK` to be set to the SHA of the commit to build/test.