### PR TITLE
ansible: update containers to openssl-3.5.0-beta1

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -124,7 +124,7 @@ RUN mkdir -p /tmp/openssl-$OPENSSL32VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL32VER
 
-ENV OPENSSL35VER 3.5.0-alpha1
+ENV OPENSSL35VER 3.5.0-beta1
 ENV OPENSSL35DIR /opt/openssl-$OPENSSL35VER
 
 RUN mkdir -p /tmp/openssl-$OPENSSL35VER && \


### PR DESCRIPTION
Replace OpenSSL 3.5.0 alpha1 with OpenSSL 3.5.0 beta1 in sharedlibs containers.