### PR TITLE
jenkins: relax check for trusted nodejs/node branches

### DIFF
--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -27,18 +27,28 @@ git status
 git rev-parse HEAD
 git rev-parse $REBASE_ONTO
 
-# COMMIT_SHA_CHECK needs to be set in the job. Check that it looks like
-# a SHA and not some other git ref (e.g. branch ref)
-if ! echo "${COMMIT_SHA_CHECK}" | grep -qE '^[0-9a-fA-F]+$'; then
-  echo "COMMIT_SHA_CHECK does not look like a SHA"
-  exit 1
-fi
-
-# Check that the gitref that is checked out hasn't been updated since
-# the job was requested.
-if [ "$(git rev-parse HEAD)" != "$(git rev-parse ${COMMIT_SHA_CHECK})" ]; then
-    echo "HEAD does not match expected COMMIT_SHA_CHECK"
+# COMMIT_SHA_CHECK must be specified, unless the
+# org/repo is nodejs/node and the ref is not a GitHub pull request
+if [ -z "${COMMIT_SHA_CHECK}" ]; then
+  if [ "${GITHUB_ORG}" != "nodejs" ] || [ "${REPO_NAME}" != "node" ] || echo "${GIT_REMOTE_REF}" | grep -qE '^(refs/)?pull/[0-9]+'; then
+    echo "Error: Starting CI for ${GIT_REMOTE_REF} from ${GITHUB_ORG}/${REPO_NAME} is not allowed without a specified COMMIT_SHA_CHECK value"
     exit 1
+  fi
+  echo "Allowing ${GIT_REMOTE_REF} for ${GITHUB_ORG}/${REPO_NAME} without a specified COMMIT_SHA_CHECK"
+else
+  # Check COMMIT_SHA_CHECK looks like a SHA and not some other git ref
+  # (e.g. branch ref)
+  if ! echo "${COMMIT_SHA_CHECK}" | grep -qE '^[0-9a-fA-F]+$'; then
+    echo "Error: COMMIT_SHA_CHECK does not look like a SHA"
+    exit 1
+  fi
+
+  # Check that the git ref that is checked out hasn't been updated since
+  # the job was requested.
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse ${COMMIT_SHA_CHECK})" ]; then
+    echo "Error: HEAD does not match expected COMMIT_SHA_CHECK"
+    exit 1
+  fi
 fi
 
 if [ -n "${REBASE_ONTO}" ]; then


### PR DESCRIPTION
Only enforce the COMMIT_SHA_CHECK verification when:
- The org/repo is not nodejs/node (i.e. outside of our project).
- The org/repo is nodejs/node and the reference is for a pull request.

Refs: https://github.com/nodejs/build/pull/4046

---

This relaxes the check added in https://github.com/nodejs/build/pull/4046 to not apply for https://github.com/nodejs/node references that are not pull request references. This will reallow scheduled builds (e.g. daily test builds of `main` and the staging branches).

For pull request references, or requests to build references from other repositories, the check will still be enforced.