### PR TITLE
ansible: add new smartos-22 host

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -200,13 +200,13 @@ hosts:
         # to update the Jenkins worker IP allowlist in github-bot
         ubuntu2204-x64-1: {ip: 67.158.54.159, alias: jenkins-workspace-9}
         ubuntu2204-x64-2: {ip: 8.225.232.44, alias: jenkins-workspace-10}
-        smartos22-x64-2:
-          ip: 172.16.9.3
-          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@67.158.54.56"'
-          ansible_user: root
         smartos22-x64-3:
           ip: 172.16.9.3
           ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@8.225.232.32"'
+          ansible_user: root
+        smartos22-x64-4:
+          ip: 172.16.9.3
+          ansible_ssh_common_args: '-o ProxyCommand="ssh -i ~/.ssh/nodejs_build_test -W %h:%p root@192.207.255.126"'
           ansible_user: root
         smartos23-x64-4:
           ip: 172.16.9.3


### PR DESCRIPTION
Deleted smartos-x64-22-2 when I meant to delete -1. rebuilding as -4