### PR TITLE
ansible: fix build dependencies for `gn` role

### DIFF
--- a/ansible/roles/gn/tasks/main.yml
+++ b/ansible/roles/gn/tasks/main.yml
@@ -1,3 +1,14 @@
+- name: install gn build dependencies
+  include_tasks: "{{ v8deps_include }}"
+  loop_control:
+    loop_var: v8deps_include
+  with_first_found:
+    - files:
+      - "{{ role_path }}/tasks/partials/{{ os }}-{{ arch }}.yml"
+      - "{{ role_path }}/tasks/partials/{{ os }}.yml"
+      - "{{ role_path }}/tasks/partials/{{ os|stripversion }}.yml"
+      skip: true  
+
 - name: check existing gn
   ansible.builtin.command: "{{ gn_dest_dir }}/gn --version"
   changed_when: no
@@ -19,13 +30,12 @@
   ansible.builtin.set_fact:
     rebuild_gn: "{{ not gn_installed_version.stdout|default('') is search(gn_git.after[:7]) }}"
 
-# Requires a C++17 compiler. At the moment we're only building on CentOS/RHEL
-# so have devtoolset-8 available.
+# Requires a C++17 compiler.
 - name: build gn
   ansible.builtin.shell: |
     python3 build/gen.py && \
     {{ gn_select_compiler }} && \
-    {{ gn_dest_dir }}/ninja -C out && \
+    ninja -C out && \
     out/gn_unittests
   args:
     chdir: "{{ gn_git_dir }}"

--- a/ansible/roles/gn/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/gn/tasks/partials/rhel8-ppc64.yml
@@ -1,0 +1,8 @@
+# ninja-build on RHEL 8 is in the CodeReady Linux Builder repository.
+- name: enable codeready-builder repository
+  community.general.rhsm_repository:
+    name: codeready-builder-for-rhel-8-ppc64le-rpms
+    state: enabled
+
+- name: run common RHEL 8 tasks
+  ansible.builtin.include_tasks: rhel8.yml

--- a/ansible/roles/gn/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/gn/tasks/partials/rhel8-s390x.yml
@@ -1,0 +1,8 @@
+# ninja-build on RHEL 8 is in the CodeReady Linux Builder repository.
+- name: enable codeready-builder repository
+  community.general.rhsm_repository:
+    name: codeready-builder-for-rhel-8-s390x-rpms
+    state: enabled
+
+- name: run common RHEL 8 tasks
+  ansible.builtin.include_tasks: rhel8.yml

--- a/ansible/roles/gn/tasks/partials/rhel8.yml
+++ b/ansible/roles/gn/tasks/partials/rhel8.yml
@@ -1,0 +1,16 @@
+---
+# Install gn build dependencies for RHEL 8
+
+- name: install gn build dependencies for {{ os }}-{{ arch }}
+  package:
+    name: "{{ package }}"
+    state: present
+    use: dnf
+  loop_control:
+    loop_var: package
+  notify: package updated
+  with_items:
+    # ansible doesn't like empty lists
+    - "{{ packages[os+'_'+arch]|default('[]') }}"
+    - "{{ packages[os]|default('[]') }}"
+    - "{{ packages[os|stripversion]|default('[]') }}"

--- a/ansible/roles/gn/vars/main.yml
+++ b/ansible/roles/gn/vars/main.yml
@@ -1,9 +1,12 @@
 ---
 
 compiler: {
-  'rhel7': '. /opt/rh/devtoolset-8/enable',
-  'rhel8': '. /opt/rh/gcc-toolset-11/enable'
+  'rhel8': '. /opt/rh/gcc-toolset-12/enable'
 }
 
 gn_select_compiler: "{{ compiler[os]|default(compiler[os|stripversion])|default('true') }}"
 gn_version: 88e8054
+
+packages: {
+  'rhel8': 'ninja-build,gcc-toolset-12'
+}


### PR DESCRIPTION
Install dependencies needed to build `gn` before attempting to build it.

Fixes: https://github.com/nodejs/build/issues/4059