### PR TITLE
ansible: update containers to OpenSSL 3.5.0 release

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -124,7 +124,7 @@ RUN mkdir -p /tmp/openssl-$OPENSSL32VER && \
     make install && \
     rm -rf /tmp/openssl-$OPENSSL32VER
 
-ENV OPENSSL35VER 3.5.0-beta1
+ENV OPENSSL35VER 3.5.0
 ENV OPENSSL35DIR /opt/openssl-$OPENSSL35VER
 
 RUN mkdir -p /tmp/openssl-$OPENSSL35VER && \


### PR DESCRIPTION
Update the version of OpenSSL 3.5.0 in the sharedlibs containers from the OpenSSL 3.5.0-beta1 to the full release OpenSSL 3.5.0 version.

---

**Deployment**

- [x] test-digitalocean-ubuntu2204_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-2
- [x] test-ibm-ubuntu2204_docker-x64-1