### PR TITLE
chore: switch back to `ubuntu-latest`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
 jobs:
   Python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
We previously pinned this workflow to `ubuntu-20.04` to preserve Python 2.7 compatibility, but have since dropped Python 2.7 so can now unpin.

Refs: https://github.com/nodejs/build/pull/3086
Refs: https://github.com/nodejs/build/pull/3093
Refs: https://github.com/actions/runner-images/issues/11101

---

Spotted in https://github.com/nodejs/build/actions/runs/14339365721?pr=4064
> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

I had to bump Python up from 3.7 https://github.com/richardlau/build/pull/3#issuecomment-2787134456 (I initially accidentally opened this PR on my own fork instead of here).

According to https://devguide.python.org/versions/ Python 3.9 goes out of support later this year, but it's still in maintenance now so I'd prefer to land this to keep the workflow working when GitHub retires the ubuntu-20.04 runner and if people feel we should move Python to an even newer version, that can be done in a separate PR.

