### PR TITLE
ansible: update `gn` on V8 build machines

### DIFF
--- a/ansible/roles/gn/tasks/main.yml
+++ b/ansible/roles/gn/tasks/main.yml
@@ -30,6 +30,14 @@
   ansible.builtin.set_fact:
     rebuild_gn: "{{ not gn_installed_version.stdout|default('') is search(gn_git.after[:7]) }}"
 
+- name: clean git checkout
+  ansible.builtin.shell: git clean -fdX
+  args:
+    chdir: "{{ gn_git_dir }}"
+  become: "{{ gn_user|default(omit)|bool }}"
+  become_user: "{{ gn_user|default(omit) }}"
+  when: rebuild_gn
+
 # Requires a C++17 compiler.
 - name: build gn
   ansible.builtin.shell: |

--- a/ansible/roles/gn/vars/main.yml
+++ b/ansible/roles/gn/vars/main.yml
@@ -5,7 +5,7 @@ compiler: {
 }
 
 gn_select_compiler: "{{ compiler[os]|default(compiler[os|stripversion])|default('true') }}"
-gn_version: 88e8054
+gn_version: c0a46c5e8c316010baf1a0eb2d2ee5a86f73e4c2
 
 packages: {
   'rhel8': 'ninja-build,gcc-toolset-12'


### PR DESCRIPTION
Roll forward the version of `gn` used to build V8.

Clean git checkout before building.

Refs: https://github.com/nodejs/node/pull/57753#issuecomment-2789890327

---

**Deployment**

- [x] test-osuosl-rhel8-ppc64_le-1
- [x] test-osuosl-rhel8-ppc64_le-2
- [x] test-osuosl-rhel8-ppc64_le-3
- [x] test-osuosl-rhel8-ppc64_le-4
- [x]  test-ibm-rhel8-s390x-1
- [x]  test-ibm-rhel8-s390x-2
- [x]  test-ibm-rhel8-s390x-3
- [x]  test-ibm-rhel8-s390x-4