### PR TITLE
Moving to ClangCL on Windows for Node.js v24

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -54,6 +54,7 @@ def buildExclusions = [
   [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
   [ /vs2022(-\w+)?$/,                 testType,    lt(21)        ],
   [ /vs2022-x86$/,                    testType,    gte(23)       ], // x86 was dropped on Windows in v23
+  [ /vs2022(?!_clang)(-\w+)?$/,       testType,    gte(24)       ], // MSVC was dropped on Windows in v24
   [ /vs2022_clang(-\w+)?$/,           testType,    lt(24)        ], // ClangCL support was added in v23
   [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -46,6 +46,8 @@ def buildExclusions = [
   [ /vs2019/,                         releaseType, gte(21)       ],
   [ /vs2022-x86/,                     releaseType, gte(23)       ],
   [ /vs2022/,                         releaseType, lt(21)        ],
+  [ /vs2022(?!_clang)(-\w+)?$/,       releaseType, gte(24)       ],
+  [ /vs2022_clang/,                   releaseType, lt(24)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
   [ /vs2015(-\w+)?$/,                 testType,    gte(18)       ],
   [ /vs2017(-\w+)?$/,                 testType,    gte(18)       ],


### PR DESCRIPTION
## TL;DR

This change switches from MSVC to ClangCL for release builds from Node.js v24. It also stops MSVC compilation for v24+ in the test CI.

## Description

This PR is the last step needed to move to the ClangCL-produced binaries on Windows. Currently, we are compiling and testing ClangCL in the test CI alongside MSVC for v24, which creates a manageable bottleneck because of the doubled compilation and testing jobs run on each PR. With this change, we will stop MSVC compilation for v24+ in both test and release CI, meaning that ClangCL will become the only supported compiler for Node.js (I'll open a PR in node to document this).

I've tested the changes from this PR in 2 temporary jobs in [test CI](https://ci.nodejs.org/job/mefi-node-test-commit-windows-fanned/) and [release CI](https://ci-release.nodejs.org/job/iojs+release-mefi-clang/) for versions 24, 23, and 22, and everything works as expected.

Mentioning relevant teams for visibility: @nodejs/build @nodejs/releasers @nodejs/tsc 

Refs: https://github.com/nodejs/build/issues/4001