### PR TITLE
jenkins: re-enable alpine-last-latest on all versions

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -21,7 +21,6 @@ def buildExclusions = [
 
   // Linux -------------------------------------------------
   [ /debian11/,                       anyType,     gte(23) ],
-  [ /alpine-last-latest/,             anyType,     gte(22) ], // Alpine 3.18. Bug in GCC 12.2.
   [ /rhel7/,                          anyType,     gte(18) ],
   [ /^ubuntu1604-32/,                 anyType,     gte(18) ], // 32-bit linux for <10 only
   [ /^ubuntu1604-64/,                 anyType,     gte(18) ],


### PR DESCRIPTION
Since https://github.com/nodejs/build/pull/3989, it's no longer running Alpine 3.18.
