### PR TITLE
ansible: update RHEL 8 machines to Python 3.11

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/rhel8.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/rhel8.yml
@@ -13,9 +13,9 @@
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     state: present
 
-- name: install Python 3.9
+- name: install Python 3.11
   ansible.builtin.dnf:
-    name: ['python39']
+    name: ['python3.11','python3.11-pip']
     state: present
   notify: package updated
 
@@ -23,4 +23,4 @@
   community.general.alternatives:
     link: /usr/bin/python3
     name: python3
-    path: /usr/bin/python3.9
+    path: /usr/bin/python3.11

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
@@ -32,5 +32,5 @@
 - name: install dependencies for V8 build tools (Python 3)
   ansible.builtin.pip:
     executable: pip-3
-    name: ['httplib2','six']
+    name: ['filecheck', 'httplib2', 'six']
     state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
@@ -32,5 +32,5 @@
 - name: install dependencies for V8 build tools (Python 3)
   ansible.builtin.pip:
     executable: pip-3
-    name: ['httplib2', 'six']
+    name: ['filecheck', 'httplib2', 'six']
     state: present

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
@@ -32,5 +32,5 @@
 - name: install dependencies for V8 build tools (Python 3)
   ansible.builtin.pip:
     executable: pip-3
-    name: ['httplib2', 'six']
+    name: ['filecheck', 'httplib2', 'six']
     state: present


### PR DESCRIPTION
The V8 CI now needs Python >= 3.10. Update to a newer version of Python on the RHEL 8 machines used to run the V8 CI.

Also add `filecheck` dependency for running V8 tests.

Fixes: https://github.com/nodejs/build/issues/4078
Refs: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/6508214
Refs: https://chromium-review.googlesource.com/c/v8/v8/+/6083883

---

### Deployment status

- [x] [test-osuosl-rhel8-ppc64_le-1](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D1/)
- [x] [test-osuosl-rhel8-ppc64_le-2](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D2/) 
- [x] [test-osuosl-rhel8-ppc64_le-3](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D3/) 
- [x] [test-osuosl-rhel8-ppc64_le-4](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D4/)
- [x] [test-ibm-rhel8-s390x-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D1/) 
- [x] [test-ibm-rhel8-s390x-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D2/) 
- [x] [test-ibm-rhel8-s390x-3](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D3/) 
- [x] [test-ibm-rhel8-s390x-4](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D4/)