### PR TITLE
ansible: remove Docker from www

### DIFF
--- a/ansible/www-standalone/ansible-playbook.yaml
+++ b/ansible/www-standalone/ansible-playbook.yaml
@@ -12,9 +12,6 @@
     - include_tasks: tasks/user.yaml
       tags: user
 
-    - include_tasks: tasks/docker.yaml
-      tags: docker
-
     - include_tasks: tasks/site-setup.yaml
       tags: setup
 

--- a/ansible/www-standalone/tasks/docker.yaml
+++ b/ansible/www-standalone/tasks/docker.yaml
@@ -1,7 +1,0 @@
-- name: Docker | Add the Docker.io repo
-  command: "bash -c 'curl -sL http://get.docker.io/ | bash -'"
-  tags: docker
-
-- name: Docker | Add nodejs to docker group
-  command: usermod -aG docker nodejs
-  tags: docker


### PR DESCRIPTION
It's unused since we stopped building the website on that server.
