### PR TITLE
ansible: install Clang on Fedora hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -57,7 +57,7 @@ packages: {
   ],
 
   fedora: [
-    'bzip2,ccache,gcc-c++,git,fontconfig,sudo,make,python3-pip',
+    'bzip2,ccache,clang,gcc-c++,git,fontconfig,sudo,make,python3-pip',
   ],
 
   freebsd: [


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4091

Fedora 41 provides Clang 19.1.7.
Fedora 42 provides Clang 20.1.8.