### PR TITLE
ansible: install Clang 19 on Debian 12 hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -53,7 +53,7 @@ packages: {
   ],
 
   debian12: [
-    'systemd-timesyncd,gcc,g++,make,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-venv',
+    'systemd-timesyncd,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-venv',
   ],
 
   fedora: [


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4091
