### PR TITLE
ansible: install Clang on RHEL hosts

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -85,11 +85,11 @@ packages: {
   ],
 
   rhel8: [
-    'ccache,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,git,make,python3',
+    'ccache,clang,cmake,gcc-c++,gcc-toolset-10,gcc-toolset-10-libatomic-devel,gcc-toolset-11,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,gcc-toolset-14-libatomic-devel,git,make,python3',
   ],
 
   rhel9: [
-    'ccache,cmake,gcc-c++,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,git,make,python3',
+    'ccache,clang,cmake,gcc-c++,gcc-toolset-12,gcc-toolset-12-libatomic-devel,gcc-toolset-13,gcc-toolset-13-libatomic-devel,gcc-toolset-14-libatomic-devel,git,make,python3',
   ],
 
   smartos: [

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -18,6 +18,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf update --disableplugin=subscription-manager -y \
     && dnf install --disableplugin=subscription-manager -y \
       ccache \
+      clang \
       gcc-c++ \
       gcc-toolset-12 \
       git \
@@ -30,6 +31,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
+      https://repo.almalinux.org/almalinux/8/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-14-libatomic-devel-14.2.1-1.1.el8_10.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-11.el8.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -18,6 +18,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf update --disableplugin=subscription-manager -y \
     && dnf install --disableplugin=subscription-manager -y \
       ccache \
+      clang \
       gcc-c++ \
       gcc-toolset-12 \
       git \
@@ -30,6 +31,7 @@ RUN dnf install --disableplugin=subscription-manager -y \
     && dnf --disableplugin=subscription-manager clean all
 
 RUN dnf install --disableplugin=subscription-manager -y \
+      https://repo.almalinux.org/almalinux/8/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-14-libatomic-devel-14.2.1-1.1.el8_10.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-binutils-2.35-11.el8.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \
       http://vault.centos.org/centos/8-stream/AppStream/{{ ansible_architecture }}/os/Packages/gcc-toolset-10-gcc-c++-10.3.1-1.2.el8_5.{{ ansible_architecture }}.rpm \

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -50,6 +50,13 @@ if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
       echo "Compiler set to Clang" `${CXX} -dumpversion`
       return
       ;;
+    *rhel*|*ubi*)
+      echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
+      export CC="ccache clang"
+      export CXX="ccache clang++"
+      echo "Compiler set to Clang" `${CXX} -dumpversion`
+      return
+      ;;
   esac
 fi
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4091

---

Deployment status:

- [x] [test-digitalocean-rhel8-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Drhel8%2Dx64%2D1/)
- [x] [test-ibm-rhel8-x64-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Dx64%2D1/)
- [x] [test-ibm-rhel8-x64-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Dx64%2D2/)
- [x] [test-ibm-rhel8-x64-3](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Dx64%2D3/)
- [x] [test-digitalocean-rhel9-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Drhel9%2Dx64%2D1/)
- [x] [test-ibm-rhel9-x64-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel9%2Dx64%2D1/)
- [x] [test-ibm-rhel9-x64-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel9%2Dx64%2D2/)
- [x] [test-digitalocean-ubi81_container-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Dubi81%5Fcontainer%2Dx64%2D1/)
- [x] [test-digitalocean-ubi81_container-x64-2](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Dubi81%5Fcontainer%2Dx64%2D2/)
- [x] [test-ibm-ubi81_container-x64-1](https://ci.nodejs.org/computer/test%2Dibm%2Dubi81%5Fcontainer%2Dx64%2D1/)
- [x] [test-equinix-rhel8_container-arm64-1](https://ci.nodejs.org/computer/test%2Dequinix%2Drhel8%5Fcontainer%2Darm64%2D1/)
- [x] [test-equinix-rhel8_container-arm64-2](https://ci.nodejs.org/computer/test%2Dequinix%2Drhel8%5Fcontainer%2Darm64%2D2/)
- [x] [test-osuosl-rhel8_container-arm64-1](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%5Fcontainer%2Darm64%2D1/)
- [x] [test-ibm-rhel8-s390x-1](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D1/)
- [x] [test-ibm-rhel8-s390x-2](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D2/)
- [x] [test-ibm-rhel8-s390x-3](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D3/)
- [x] [test-ibm-rhel8-s390x-4](https://ci.nodejs.org/computer/test%2Dibm%2Drhel8%2Ds390x%2D4/)
- [x] [test-linuxonecc-rhel9-s390x-1](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D1/)
- [x] [test-linuxonecc-rhel9-s390x-2](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D2/)
- [x] [test-linuxonecc-rhel9-s390x-3](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D3/)
- [x] [test-linuxonecc-rhel9-s390x-4](https://ci.nodejs.org/computer/test%2Dlinuxonecc%2Drhel9%2Ds390x%2D4/)
- [x] [test-osuosl-rhel8-ppc64_le-1](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D1/)
- [x] [test-osuosl-rhel8-ppc64_le-2](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D2/)
- [x] [test-osuosl-rhel8-ppc64_le-3](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D3/)
- [x] [test-osuosl-rhel8-ppc64_le-4](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D4/)
- [x] [test-osuosl-rhel9-ppc64_le-1](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel9%2Dppc64%5Fle%2D1/)
- [x] [test-osuosl-rhel9-ppc64_le-2](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel9%2Dppc64%5Fle%2D2/)
- [x] [test-osuosl-rhel9-ppc64_le-3](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel9%2Dppc64%5Fle%2D3/)
- [x] [test-osuosl-rhel9-ppc64_le-4](https://ci.nodejs.org/computer/test%2Dosuosl%2Drhel9%2Dppc64%5Fle%2D4/)
- [x] [release-digitalocean-rhel8-x64-1](https://ci-release.nodejs.org/computer/release%2Ddigitalocean%2Drhel8%2Dx64%2D1/)
- [x] [release-ibm-rhel8-s390x-1](https://ci-release.nodejs.org/computer/release%2Dibm%2Drhel8%2Ds390x%2D1/)
- [x] [release-ibm-rhel8-x64-1](https://ci-release.nodejs.org/computer/release%2Dibm%2Drhel8%2Dx64%2D1/)
- [x] [release-ibm-rhel8-x64-2](https://ci-release.nodejs.org/computer/release%2Dibm%2Drhel8%2Dx64%2D2/)
- [x] [release-osuosl-rhel8-arm64-1](https://ci-release.nodejs.org/computer/release%2Dosuosl%2Drhel8%2Darm64%2D1/)
- [x] [release-osuosl-rhel8-ppc64_le-1](https://ci-release.nodejs.org/computer/release%2Dosuosl%2Drhel8%2Dppc64%5Fle%2D1/)