### PR TITLE
docs: older version of Ansible needed for RHEL 8

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -7,6 +7,10 @@
 
 1. Follow the [instructions to install the latest version of Ansible][ansible-install].
    * In most cases, using pip: `pip install ansible`.
+     * Newer versions of Ansible are incompatible with some older operating systems in the inventory (e.g. RHEL 8). In those cases you will need to install an older version of Ansible, e.g. if using `pip`:
+      ```console
+      pip install ansible-core==2.16.14 ansible==9.13
+      ```
    * If you use brew, then `brew install python3 ansible`, and then run
    `export PYTHONPATH=$(pip show pyyaml | grep Location | awk '{print $2}') `
    before you use `ansible-playbook`.


### PR DESCRIPTION
Update our Ansible documentation to note that newer versions of Ansible are not compatible with RHEL 8 and provide the last known back-level compatible versions of `ansible` and `ansible-core` that work.

---

With the latest Ansible, I was getting this error when running against our RHEL 8 hosts:
```
TASK [package-upgrade : upgrade installed packages] *************************************************************************************************************************************************************
fatal: [release-osuosl-rhel8-arm64-1]: FAILED! => {"changed": false, "msg": "Could not import the dnf python module using /usr/bin/python3.12 (3.12.11 (main, Jun 19 2025, 15:40:50) [GCC 8.5.0 20210514 (Red Hat 8.5.0-27)]). Please install `python3-dnf` package or ensure you have specified the correct ansible_python_interpreter. (attempted ['/usr/libexec/platform-python', '/usr/bin/python3', '/usr/bin/python'])", "results": []}
```

`python3-dnf` is required for Ansible, but on RHEL 8 is only provided for the system python (`/usr/libexec/platform-python`, Python 3.6). Attempting to set the Python interpreter to the system Python (as opposed to 3.12) fails, and this appears to be known/deliberate:
Refs: https://forum.ansible.com/t/almalinux-and-python3-dnf/44262/4
Refs: https://forum.ansible.com/t/python-3-7-impact-on-el8-future-for-el9/6229/13