### PR TITLE
Add Azure nodes, fix ansible builds for Ubuntu24.04 hosts

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -9,6 +9,7 @@ hosts:
 
   - infra:
     - azure:
+        #This is under the OpenJS Foundation Azure subscription
         ubuntu2404-x64-1: {ip: 172.203.217.211, alias: rsync, user: iojs}
 
     - digitalocean:
@@ -87,6 +88,10 @@ hosts:
         msft-win11_vs2022-x64-4: {ip: nodejs.westus3.cloudapp.azure.com}
         msft-win2016_vs2017-x64-1: {ip: nodejs.westeurope.cloudapp.azure.com}
         msft-win2016_vs2017-x64-2: {ip: nodejs.westus3.cloudapp.azure.com}
+        # OpenJS Foundation Azure account
+        ubuntu2404_docker-arm64-1: {ip: 4.242.42.14, user: nodejs}
+        ubuntu2404_docker-arm64-2: {ip: 20.84.43.2, user: nodejs}
+        ubuntu2404_docker-arm64-3: {ip: 20.172.67.207, user: nodejs}
 
     - digitalocean:
         debian11-x64-1: {ip: 174.138.79.159, swap_file_size_mb: 2048}

--- a/ansible/roles/baselayout/tasks/partials/ntp/systemd.yml
+++ b/ansible/roles/baselayout/tasks/partials/ntp/systemd.yml
@@ -7,5 +7,8 @@
 - name: remove ntpd
   package: name=ntp state=absent
 
+- name: install systemd-timesyncd
+  package: name=systemd-timesyncd state=present
+
 - name: enable timesyncd at boot
   service: name=systemd-timesyncd enabled=yes state=started

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -9,7 +9,7 @@ ssh_config: /etc/ssh/sshd_config
 sshd_service_name: 'sshd'
 
 ntp_service: {
-  systemd: ['ubuntu1604', 'ubuntu1804', 'ubuntu2204', 'ubuntu2404']
+  systemd: ['ubuntu1604', 'ubuntu1804', 'ubuntu2204', 'ubuntu2404', 'ubuntu2404_docker']
 }
 
 common_packages: [

--- a/ansible/roles/github/tasks/main.yml
+++ b/ansible/roles/github/tasks/main.yml
@@ -16,17 +16,20 @@
     key: "{{ item }}"
     path: "{{ user_home_dir }}/.ssh/known_hosts"
     state: present
-  become: yes
-  become_user: "{{ server_user }}"
   loop: "{{ lookup('file', 'files/github_known_hosts').splitlines() }}"
+
+- name: set ownership of known_hosts file
+  ansible.builtin.file:
+    path: "{{ user_home_dir }}/.ssh/known_hosts"
+    owner: "{{ server_user }}"
+    group: "{{ (os|startswith('zos') or os|startswith('ibmi'))|ternary(omit, server_user) }}"
+    mode: "0600"
 
 - name: remove old github.com ssh keys
   ansible.builtin.lineinfile:
     path: "{{ user_home_dir }}/.ssh/known_hosts"
     search_string: "{{ item }}"
     state: absent
-  become: yes
-  become_user: "{{ server_user }}"
   loop: "{{ lookup('file', 'files/github_bad_hosts').splitlines() }}"
 
 # Entries in `files/binary_tmp_known_hosts` are generated via
@@ -37,7 +40,12 @@
     path: "{{ user_home_dir }}/.ssh/known_hosts"
     line: "{{ item }}"
     state: present
-  become: yes
-  become_user: "{{ server_user }}"
   loop: "{{ lookup('file', 'files/binary_tmp_known_hosts').splitlines() }}"
   when: (user_home_dir.find('_arm_cross') != -1) or (user_home_dir.find('armv7l') != -1)
+
+- name: ensure final ownership of known_hosts file
+  ansible.builtin.file:
+    path: "{{ user_home_dir }}/.ssh/known_hosts"
+    owner: "{{ server_user }}"
+    group: "{{ (os|startswith('zos') or os|startswith('ibmi'))|ternary(omit, server_user) }}"
+    mode: "0600"


### PR DESCRIPTION
This adds the new azure nodes to the Inventory.

It also makes a couple of small ansible adjustments that make these work on Ubuntu24.04.