### PR TITLE
ansible: move all ubuntu2204-64 hosts to ubuntu2404-x64

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -106,10 +106,8 @@ hosts:
         rhel9-x64-1: {ip: 134.122.12.240, swap_file_size_mb: 2048}
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu2204_docker-x64-2: {ip: 159.89.183.200}
-        ubuntu1804-x64-1: {ip: 178.128.181.213}
-        ubuntu2204-x64-1: {ip: 138.197.4.1, swap_file_size_mb: 2048}
-        ubuntu2204-x64-2: {ip: 167.99.124.188, swap_file_size_mb: 2048}
         ubuntu2404-x64-1: {ip: 165.227.180.106, swap_file_size_mb: 2048}
+        ubuntu2404-x64-2: {ip: 167.99.124.188, swap_file_size_mb: 2048}
 
     - ibm:
         aix72-ppc64_be-1:
@@ -138,7 +136,7 @@ hosts:
         rhel8-x64-3: {ip: 52.117.26.13, build_test_v8: yes}
         rhel9-x64-1: {ip: 169.60.150.92, swap_file_size_mb: 2048}
         rhel9-x64-2: {ip: 169.44.168.2}
-        ubuntu2204-x64-1: {ip: 169.60.150.82}
+        ubuntu2404-x64-1: {ip: 169.60.150.82}
         # when adding, removing or changing the IPs for any
         # `jenkins-workspace-*` machine, remember to rerun
         # the `ansible/playbooks/create-github-bot.yml` playbook
@@ -246,7 +244,7 @@ hosts:
     - rackspace:
         debian11-x64-1: {ip: 23.253.109.216, swap_file_size_mb: 4096}
         debian12-x64-1: {ip: 104.130.124.194, swap_file_size_mb: 4096}
-        ubuntu2204-x64-1: {ip: 119.9.52.75, swap_file_size_mb: 4096, user: ubuntu}
+        ubuntu2404-x64-1: {ip: 119.9.52.75, swap_file_size_mb: 4096, user: ubuntu}
         win2016_vs2015-x64-1: {}
         win2016_vs2015-x64-2: {}
         win2019_vs2019-x64-1: {}


### PR DESCRIPTION
Also delete test-digitalocean-ubuntu1804-x64-1, which has been unused
for a long time.

Refs: https://github.com/nodejs/build/issues/4144
