### PR TITLE
ansible: enable swapfile creation for Ubuntu 24.04

### DIFF
--- a/ansible/roles/bootstrap/tasks/partials/ubuntu2404.yml
+++ b/ansible/roles/bootstrap/tasks/partials/ubuntu2404.yml
@@ -1,0 +1,9 @@
+---
+
+#
+# Ubuntu 24.04
+#
+
+- name: set up swap on Linux
+  include_tasks: linux-swap.yml
+  when: swap_file_size_mb is defined


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4144

---

Deployment

- [x] [test-digitalocean-ubuntu2404-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Dubuntu2404%2Dx64%2D1/)
- [x] [test-digitalocean-ubuntu2404-x64-2](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Dubuntu2404%2Dx64%2D2/)
- [ ] ~[test-ibm-ubuntu2404-x64-1](https://ci.nodejs.org/computer/test%2Dibm%2Dubuntu2404%2Dx64%2D1/)~ N/A as IBM Cloud machine provisioned with swap
- [x] [test-rackspace-ubuntu2404-x64-1](https://ci.nodejs.org/computer/test%2Drackspace%2Dubuntu2404%2Dx64%2D1/)
