### PR TITLE
ansible: install `llvm-toolset` for building V8

### DIFF
--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-ppc64.yml
@@ -13,7 +13,7 @@
 # V8 builds still require Python 2.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['glib2-devel', 'ninja-build', 'python2', 'python2-pip']
+    name: ['glib2-devel', 'llvm-toolset', 'ninja-build', 'python2', 'python2-pip']
     state: present
   notify: package updated
 

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-s390x.yml
@@ -13,7 +13,7 @@
 # Older V8 builds still require Python 2.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['GConf2-devel', 'ninja-build', 'python2', 'python2-pip']
+    name: ['GConf2-devel', 'llvm-toolset', 'ninja-build', 'python2', 'python2-pip']
     state: present
   notify: package updated
 

--- a/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/rhel8-x64.yml
@@ -13,7 +13,7 @@
 # V8 builds still require Python 2.
 - name: install packages required to build V8
   ansible.builtin.dnf:
-    name: ['ninja-build', 'python2', 'python2-pip']
+    name: ['llvm-toolset', 'ninja-build', 'python2', 'python2-pip']
     state: present
   notify: package updated
 


### PR DESCRIPTION
When building with `clang`, the V8 CI needs other tools such as `llvm-ar` found in `llvm-toolset` on RHEL.