### PR TITLE
chore: migrate off Python 3.9

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.9
+    - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Update lint workflow to Python 3.14.

Refs: https://github.com/nodejs/build/issues/4208

---

Let's see how the linter fares with Python 3.14.