### PR TITLE
ansible: fix Python 3 set up on RHEL 9

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/rhel9.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/rhel9.yml
@@ -12,15 +12,3 @@
   ansible.builtin.dnf:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     state: present
-
-- name: install Python 3.12
-  ansible.builtin.dnf:
-    name: ['python3.12','python3.12-pip']
-    state: present
-  notify: package updated
-
-- name: update python3 package alternatives
-  community.general.alternatives:
-    link: /usr/bin/python3
-    name: python3
-    path: /usr/bin/python3.12

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel9.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/rhel9.yml
@@ -6,11 +6,12 @@
 
 - name: install pip
   ansible.builtin.dnf: 
-    name: python3-pip
+    name: ['python3.12','python3.12-pip']
     state: present
 
 - name: install tap2junit
   ansible.builtin.pip:
-    executable: /usr/bin/pip3
     name: tap2junit=={{ tap2junit_version }}
     state: present
+    virtualenv: /home/{{ server_user }}/venv
+    virtualenv_command: python3.12 -m venv


### PR DESCRIPTION
Overwriting `/usr/bin/python3` on RHEL 9 breaks `subscription-manager` (but does not on RHEL 8).

Instead create and use a Python 3.12 virtual environment for the CI.

Refs: https://github.com/nodejs/build/pull/4215

--- 

Deployment

- [x] test-digitalocean-rhel9-x64-1
- [x] test-ibm-rhel9-x64-1
- [x] test-ibm-rhel9-x64-2
- [x] test-linuxonecc-rhel9-s390x-1
- [x] test-linuxonecc-rhel9-s390x-2
- [x] test-linuxonecc-rhel9-s390x-3
- [x] test-linuxonecc-rhel9-s390x-4
- [x] test-osuosl-rhel9-ppc64_le-1
- [x] test-osuosl-rhel9-ppc64_le-2
- [x] test-osuosl-rhel9-ppc64_le-3
- [x] test-osuosl-rhel9-ppc64_le-4