### PR TITLE
ansible: update OSUOSL hosted arm64 Docker host

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -237,7 +237,7 @@ hosts:
         rhel9-ppc64_le-2: {ip: 140.211.10.98, user: cloud-user, swap_file_size_mb: 2048}
         rhel9-ppc64_le-3: {ip: 140.211.10.102, user: cloud-user, swap_file_size_mb: 2048}
         rhel9-ppc64_le-4: {ip: 140.211.10.107, user: cloud-user, swap_file_size_mb: 2048}
-        ubuntu2004_docker-arm64-1: {ip: 140.211.169.11, user: ubuntu}
+        ubuntu2404_docker-arm64-1: {ip: 140.211.169.11, user: ubuntu}
 
     - iinthecloud:
         ibmi74-ppc64_be-1: {ip: 65.183.160.52, user: nodejs}


### PR DESCRIPTION
Update and rename test-osuosl-ubuntu2004-docker_arm64-1 to Ubuntu 24.04.

Fixes: https://github.com/nodejs/build/issues/4227

---

I updated the instance by renaming it in OpenStack and then rebuilding it with an Ubuntu 24.04 image.
Had an issue with the hostname -- it kept resetting back to the original name when restarting the VM. In the end I added a file `/etc/cloud/cloud.cfg.d/99_hostname.cfg` with
```
#cloud-config
hostname: test-osuosl-ubuntu2404-docker-arm64-1
fqdn: test-osuosl-ubuntu2404-docker-arm64-1.novalocal
```
I haven't done that in Ansible because it should not be necessary if provisioning a new instance (as opposed to rebuilding the existing one).