### PR TITLE
aix: install clang

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -26,6 +26,7 @@ become_method       = sudo
 
 [hosts:aix]
 ansible_python_interpreter = /opt/freeware/libexec/python3
+ansible_remote_tmp = /tmp
 
 [hosts:smartos]
 ansible_python_interpreter = /opt/local/bin/python

--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -1,29 +1,41 @@
 # Manual steps required to setup machines
 
-* [Adding firewall entries for Jenkins workers](#adding-firewall-entries-for-jenkins-workers)
-* [`release-*` machines](#release--machines)
-  * [`release-*container*` machines](#release-container-machines)
-* [AIX](#aix)
-  * [Disk layout](#disk-layout)
-  * [OpenSSL](#openssl)
-  * [Remove en1 network interface](#remove-en1-network-interface)
-* [AIX 7.1](#aix-71)
-  * [Update XL C/C++ Runtime](#update-xl-cc-runtime)
-* [AIX 7.2 Install](#aix-72-install)
-  * [ccache 3.7.4 on AIX 7.2](#ccache-374-on-aix-72)
-  * [Enable the AHA fs](#enable-the-aha-fs)
-  * [Install XL compilers](#install-xl-compilers)
-  * [Preparing gcc distributables](#preparing-gcc-distributables)
-* [Windows (Azure/Rackspace)](#windows-azurerackspace)
-  * [Control machine (where Ansible is run)](#control-machine-where-ansible-is-run)
-  * [Target machines](#target-machines)
-* [jenkins-workspace](#jenkins-workspace)
-* [benchmark](#benchmark)
-  * [Static analysis](#static-analysis)
-* [Docker hosts](#docker-hosts)
-* [SmartOS](#smartos)
-* [IBM i](#ibm-i)
-* [z/OS](#zos)
+- [Manual steps required to setup machines](#manual-steps-required-to-setup-machines)
+  - [Adding firewall entries for Jenkins workers](#adding-firewall-entries-for-jenkins-workers)
+  - [`release-*` machines](#release--machines)
+    - [`release-*container*` machines](#release-container-machines)
+  - [AIX](#aix)
+    - [Disk Layout](#disk-layout)
+    - [OpenSSL](#openssl)
+    - [Remove en1 network interface](#remove-en1-network-interface)
+  - [AIX 7.1](#aix-71)
+    - [Update XL C/C++ Runtime](#update-xl-cc-runtime)
+  - [AIX 7.2 Install](#aix-72-install)
+    - [ccache 3.7.4 on AIX 7.2](#ccache-374-on-aix-72)
+    - [Enable the AHA fs](#enable-the-aha-fs)
+    - [Install XL compilers](#install-xl-compilers)
+    - [Preparing gcc distributables](#preparing-gcc-distributables)
+    - [Install Clang Backend](#install-clang-backend)
+    - [Preparing ccache distributables](#preparing-ccache-distributables)
+  - [Windows (Azure/Rackspace)](#windows-azurerackspace)
+    - [Control machine (where Ansible is run)](#control-machine-where-ansible-is-run)
+    - [Target machines](#target-machines)
+      - [Port Configuration](#port-configuration)
+      - [Test](#test)
+  - [jenkins-workspace](#jenkins-workspace)
+  - [benchmark](#benchmark)
+    - [Static analysis](#static-analysis)
+  - [Docker hosts](#docker-hosts)
+  - [SmartOS](#smartos)
+    - [Provisioning the Machines](#provisioning-the-machines)
+    - [Configuring the Host Environment](#configuring-the-host-environment)
+  - [IBM i](#ibm-i)
+    - [Install open source ecosystem](#install-open-source-ecosystem)
+    - [Create Nodejs user](#create-nodejs-user)
+    - [Create Nodejs user's home directory](#create-nodejs-users-home-directory)
+    - [Set global PATH and .bashrc to use Open Source Ecosystem](#set-global-path-and-bashrc-to-use-open-source-ecosystem)
+    - [Use bash as the default shell for your user (maintainer convenience) and the nodejs user](#use-bash-as-the-default-shell-for-your-user-maintainer-convenience-and-the-nodejs-user)
+  - [z/OS](#zos)
 
 ## Adding firewall entries for Jenkins workers
 
@@ -486,6 +498,42 @@ the version numbers.
 
 Example search for 4.8.5 gcc on bullfreeware:
 - http://www.bullfreeware.com/?searching=true&package=gcc&from=&to=&libraries=false&exact=true&version=5
+
+### Install Clang Backend
+
+The clang frontend will be auto installed via ansible playbook from:
+https://github.com/IBM/llvm-project/releases
+
+The clang backend requires manually installing xl runtime and xl utilities
+
+runtime:
+
+1. Download the current *.tar.Z from https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix
+
+2. scp the tar onto the target
+
+3. On the target
+
+  ```sh
+  uncompress IBM_OPEN_XL_CPP_RUNTIME_17.1.4.1_AIX.tar.Z 
+  tar -xf IBM_OPEN_XL_CPP_RUNTIME_17.1.4.1_AIX.tar
+  installp -aFXYd . ALL
+  ```
+
+
+utilities:
+
+1. Download the current *.tar.Z from https://www.ibm.com/support/pages/ibm-open-xl-cc-utilities-aix-1712#DNLD
+2. scp tar onto the target
+3. On the target
+
+  ```sh
+  uncompress IBM_OPEN_XL_CPP_UTILITIES_17.1.2.8_AIX.tar.Z
+  tar -xf IBM_OPEN_XL_CPP_RUNTIME_17.1.4.1_AIX.tar
+  installp -aFXYd . ALL
+  ```
+
+
 
 ### Preparing ccache distributables
 

--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -510,7 +510,7 @@ runtime:
 
 1. Download the current *.tar.Z from https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix
 
-2. scp the tar onto the target
+2. scp the tar onto the target - it helps to put both tarfiles into a single folder and scp the folder
 
 3. On the target
 
@@ -529,7 +529,8 @@ utilities:
 
   ```sh
   uncompress IBM_OPEN_XL_CPP_UTILITIES_17.1.2.8_AIX.tar.Z
-  tar -xf IBM_OPEN_XL_CPP_RUNTIME_17.1.4.1_AIX.tar
+  tar -xf IBM_OPEN_XL_CPP_UTILITIES_17.1.2.8_AIX.tar
+  inutoc .
   installp -aFXYd . ALL
   ```
 

--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -533,6 +533,12 @@ utilities:
   installp -aFXYd . ALL
   ```
 
+After installing these packages we will need to update dnf:
+
+```sh
+/usr/sbin/updtvpkg
+```
+
 
 
 ### Preparing ccache distributables

--- a/ansible/roles/baselayout/tasks/main.yml
+++ b/ansible/roles/baselayout/tasks/main.yml
@@ -177,3 +177,15 @@
         - "{{ role_path }}/tasks/partials/ntp/{{ os|stripversion }}.yml"
         - "{{ role_path }}/tasks/partials/ntp/{{ os|match_key(ntp_service, raise_error=False) }}.yml"
       skip: true
+
+
+- name: install clang
+  include_tasks: "{{ clang_include }}"
+  loop_control:
+    loop_var: clang_include
+  with_first_found:
+    - files:
+        - "{{ role_path }}/tasks/partials/clang/{{ os }}-{{ arch }}.yml"
+        - "{{ role_path }}/tasks/partials/clang/{{ os }}.yml"
+        - "{{ role_path }}/tasks/partials/clang/{{ os|stripversion }}.yml"
+      skip: true

--- a/ansible/roles/baselayout/tasks/partials/clang/aix.yml
+++ b/ansible/roles/baselayout/tasks/partials/clang/aix.yml
@@ -1,0 +1,10 @@
+---
+#
+# Downloads and installs clang
+#
+
+- name: "clang : extract tarball - aix"
+  ansible.builtin.unarchive:
+    src: https://github.com/IBM/llvm-project/releases/download/llvmorg-20.1.7/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2.tar.xz
+    dest: /opt
+    remote_src: yes

--- a/ansible/roles/baselayout/tasks/partials/clang/aix.yml
+++ b/ansible/roles/baselayout/tasks/partials/clang/aix.yml
@@ -39,7 +39,7 @@
     src: "{{ clang_local.dest }}"
   when: update_clang == True
 
-
+# if we don't have the clang runtime libraries installed this will fail
 - name: Check if we have a runnable clang
   changed_when: no
   check_mode: no

--- a/ansible/roles/baselayout/tasks/partials/clang/aix.yml
+++ b/ansible/roles/baselayout/tasks/partials/clang/aix.yml
@@ -3,8 +3,44 @@
 # Downloads and installs clang
 #
 
-- name: "clang : extract tarball - aix"
-  ansible.builtin.unarchive:
-    src: https://github.com/IBM/llvm-project/releases/download/llvmorg-20.1.7/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2.tar.xz
-    dest: /opt
+- name: Check if clang is already installed
+  changed_when: no
+  check_mode: no
+  command: "/opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/clang --version"
+  register: clang
+  ignore_errors: yes
+
+# If we're already using the latest there is no need to do anything.
+# TODO improve the error handling
+- name: check existing clang version is up to date
+  set_fact:
+    update_clang: "{{ 'clang version 20.1.7' not in clang.stdout }}"
+
+- name: create cache directory for clang binaries
+  file:
+    path: "/var/cache/clang-binaries"
+    state: directory
+  when: update_clang == True
+
+- name: download clang binary
+  get_url:
+    checksum: sha256:a18aea07f5b977e64bc7fe7358e95897c7ba05fbe68eeefb1614631347be4b3a
+    dest: "/var/cache/clang-binaries/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2.tar.xz"
+    url: "https://github.com/IBM/llvm-project/releases/download/llvmorg-20.1.7/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2.tar.xz"
+  register: clang_local
+  when: update_clang == True
+
+- name: unpack clang binary
+  register: clang_unpacked
+  unarchive:
+    dest: "/opt/"
+    list_files: yes
     remote_src: yes
+    src: "{{ clang_local.dest }}"
+  when: update_clang == True
+
+
+- name: Check if we have a runnable clang
+  changed_when: no
+  check_mode: no
+  ansible.builtin.command: "/opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/clang --version"

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -37,7 +37,7 @@ common_packages: [
 # % ansible -m debug -a "var=os"  HOST
 packages: {
   aix: [
-    'bash,cmake,coreutils,curl,gcc-c++,tar,unzip,git,make,sudo,python3-setuptools,python3',
+    'bash,cmake,coreutils,curl,gcc-c++,tar,unzip,git,make,sudo,python3-setuptools,python3,xz',
   ],
 
   # Appears to be some issue with the Ansible dnf task on AIX and gcc10-c++, so handle separately.

--- a/ansible/roles/bootstrap/tasks/partials/aix.yml
+++ b/ansible/roles/bootstrap/tasks/partials/aix.yml
@@ -16,10 +16,10 @@
     size: 6G
     state: present    
 
-- name: Set size of /var to 2G
+- name: Set size of /var to 5G
   aix_filesystem:
     filesystem: /var
-    size: 2G
+    size: 5G
     state: present
 
 - name: Set size of /tmp to 2G
@@ -34,10 +34,10 @@
     size: 50G
     state: present
 
-- name: Set size of /opt to 5G
+- name: Set size of /opt to 12G
   aix_filesystem:
     filesystem: /opt
-    size: 5G
+    size: 12G
     state: present
 
 # This is to mount the AIX file event infrastructure to get the file watcher tests passing


### PR DESCRIPTION
This PR installs precompiled clang binaries from IBM repo: https://github.com/IBM/llvm-project/releases

These changes install the clang frontend but there are some manual steps needed to install the clang backend as well.


If you don't have the clang backend installed you will run into an error like this:


```sh
$ /opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/clang --version
Could not load program /opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/clang:
        Dependent module /usr/lib/libc++.a(shr2_64.o) could not be loaded.
        Member shr2_64.o is not found in archive
```

Here are some refs on what needs to get installed Manually:

- runtime: https://www.ibm.com/support/pages/fix-list-xl-cc-runtime-aix
- utilities: ttps://www.ibm.com/support/pages/ibm-open-xl-cc-utilities-aix-1713

After installing these packages we will need to update dnf:

```sh
/usr/sbin/updtvpkg
```