### PR TITLE
ansible: fix `tap2junit` installation

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -63,7 +63,7 @@ packages: {
   ],
 
   fedora: [
-    'bzip2,ccache,clang,gcc-c++,git,fontconfig,sudo,make,python3-pip,rust,cargo',
+    'bzip2,ccache,clang,gcc-c++,git,fontconfig,sudo,make,python3-pip,python3-setuptools,rust,cargo',
   ],
 
   freebsd: [

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/fedora.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/fedora.yml
@@ -1,0 +1,11 @@
+---
+
+#
+# install tap2junit from pip
+#
+
+- name: install tap2junit
+  pip:
+    name: tap2junit=={{ tap2junit_version }}
+    virtualenv: /home/{{ server_user }}/venv
+    virtualenv_command: python3 -m venv


### PR DESCRIPTION
`tap2junit` requires `packaging`, which is part of `python3-setuptools`. Also install `tap2junit` into a Python venv to avoid warnings about running `pip` as the `root` user.

Fixes: https://github.com/nodejs/build/issues/4255