### PR TITLE
build: disable jenkins reload after backup/clearup

### DIFF
--- a/backup/backup_scripts/remove_old.sh
+++ b/backup/backup_scripts/remove_old.sh
@@ -22,7 +22,7 @@ REGEX="${ROOTDIR}/.*/builds/[0-9]+"
 #MULTIJOBS="$ROOTDIR/*/configurations/axis-*/*/builds/"
 CREDENTIALS=$(</root/.jenkins_credentials)
 ssh -i /root/.ssh/nodejs_build_backup $HOST find "$ROOTDIR" -depth -type d -regex "$REGEX" -mtime +$DAYS -exec "rm -rvf '{}' \;"
-JENKINS_CRUMB=$(curl -sL --user "$CREDENTIALS" https://$HOST/'crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
 # sxa: Skip due to jenkins bug - https://github.com/nodejs/build/issues/4247#issuecomment-4019757795
+# JENKINS_CRUMB=$(curl -sL --user "$CREDENTIALS" https://$HOST/'crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
 # curl -X POST -q --user "$CREDENTIALS" -H "$JENKINS_CRUMB" https://$HOST/reload
 


### PR DESCRIPTION
This is potentially a temporary fix until we get the upstream jenkins fix for https://github.com/nodejs/build/issues/4247 but I'm not sure the reload is strictly needed. Note that this change has been made on the backup system so is already live, but won't kick in until it runs next weekend.

This PR also adds `-v` to the `rm` command (GNU-specific, but our backup server is Linux) with the intention of having a log of what files are deleted in case it's useful in debugging anything.

To support such debugging I've also modified the crontab on the backup server to `tee` the output of the script to `/root/backup_scripts/remote_old.sh.{testci,releaseci}.log`. This could be compressed if anyone would prefer it that way. Logs are not retained once the next run kicks in.