### PR TITLE
jenkins: drop AIX on Power 8 for Node.js 26

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -63,6 +63,10 @@ def buildExclusions = [
   [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],
   [ /vs2017-COMPILED_BY/,             testType,    gte(22)       ],
 
+  // AIX ---------------------------------------------------
+  [ /^aix72-ppc64/,                     anyType,     gte(26) ], // Power 8 was dropped in v26
+  [ /^aix72-power9/,                    releaseType, lt(26)  ], // Build releases on Power 9 for >=26
+
   // SmartOS -----------------------------------------------
   [ /^smartos18/,                     anyType,     gte(18) ],
 


### PR DESCRIPTION
Node.js 26 drops support for Power 8.

- Exclude all AIX 7.2 Power 8 machines for Node.js 26 onwards.
- Only build releases on AIX 7.2 Power 9 for Node.js 26 onwards.

Refs: https://github.com/nodejs/build/issues/4230