### PR TITLE
ansible: update benchmark/v8 roles for Ubuntu 24.04

### DIFF
--- a/ansible/roles/benchmarking/meta/main.yml
+++ b/ansible/roles/benchmarking/meta/main.yml
@@ -1,0 +1,7 @@
+---
+
+dependencies:
+  - role: user-create
+  - role: github
+    vars:
+      user_home_dir: "{{ home }}/{{ server_user }}"

--- a/ansible/roles/build-test-v8/tasks/partials/ubuntu2404.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/ubuntu2404.yml
@@ -1,0 +1,16 @@
+---
+
+#
+# Install packages for V8 builds.
+#
+
+- name: install apt packages required to build V8
+  ansible.builtin.apt:
+    name: ['ninja-build']
+    state: present
+
+- name: install Python packages required to build V8
+  ansible.builtin.pip:
+    name: ['httplib2==0.22.0']
+    virtualenv: /home/{{ server_user }}/venv
+    virtualenv_command: python3 -m venv

--- a/ansible/roles/build-test-v8/tasks/partials/ubuntu2404.yml
+++ b/ansible/roles/build-test-v8/tasks/partials/ubuntu2404.yml
@@ -11,6 +11,6 @@
 
 - name: install Python packages required to build V8
   ansible.builtin.pip:
-    name: ['httplib2==0.22.0']
+    name: ['filecheck', 'httplib2==0.22.0', 'six']
     virtualenv: /home/{{ server_user }}/venv
     virtualenv_command: python3 -m venv


### PR DESCRIPTION
Add role dependencies to the `benchmarking` role to ensure the user is created and github.com keys are present.

Add V8 build dependencies for Ubuntu 24.04.

---

### Deployment

- [x] [test-hetzner-ubuntu2404-x64-1](https://ci.nodejs.org/computer/test%2Dhetzner%2Dubuntu2404%2Dx64%2D1/)
- [x] [test-hetzner-ubuntu2404-x64-2](https://ci.nodejs.org/computer/test%2Dhetzner%2Dubuntu2404%2Dx64%2D2/)
