### PR TITLE
ansible,win: add rust

### DIFF
--- a/ansible/roles/baselayout-windows/tasks/main.yml
+++ b/ansible/roles/baselayout-windows/tasks/main.yml
@@ -26,6 +26,13 @@
     pinned: yes
     version: "3.10.8"
 
+- name: Install rustup
+  win_chocolatey:
+    name: rustup.install
+
+- name: Add arm64 Rust target
+  win_command: rustup target add aarch64-pc-windows-msvc
+
 - block:
   - name: install Git
     win_chocolatey:


### PR DESCRIPTION
This change will ensure Rust is installed (and regularly updated) on all newly created Windows CI machines.

Refs: https://github.com/nodejs/build/issues/4245