### PR TITLE
aix: select clang for Node.26+ builds

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/ccache/aix.yml
+++ b/ansible/roles/baselayout/tasks/partials/ccache/aix.yml
@@ -61,6 +61,8 @@
     - g++-10
     - gcc-12
     - g++-12
+    - clang
+    - clang++
 
 - name: "ccache : cleanup - aix tarball"
   file:

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -36,6 +36,14 @@ fi
 # Gradual transition to Clang from Node.js 25 (https://github.com/nodejs/build/issues/4091).
 if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
   case $NODE_NAME in
+    *aix*)
+      echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
+      export PATH="/opt/ccache-3.7.4/libexec:/opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/:$PATH"
+      export CC="clang"
+      export CXX="clang++"
+      echo "Compiler set to Clang" `${CXX} -dumpversion`
+      return
+      ;;
     *fedora*)
       echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
       export CC="ccache clang"


### PR DESCRIPTION
Selects clang complier for Node.js 26+ builds

This is expected to land after we merge: https://github.com/nodejs/node/pull/62656