### PR TITLE
ansible: install cargo/rustc on Debian and Ubuntu

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -93,8 +93,9 @@ hosts:
         ubuntu2404_docker-arm64-3: {ip: 20.172.67.207, user: nodejs}
 
     - digitalocean:
-        debian11-x64-1: {ip: 174.138.79.159, swap_file_size_mb: 2048}
         debian12-x64-1: {ip: 159.203.105.159, swap_file_size_mb: 2048}
+        debian13-x64-1: {ip: 174.138.79.159, swap_file_size_mb: 2048}
+        debian13-x64-2: {ip: 137.184.225.39, swap_file_size_mb: 2048}
         fedora42-x64-1: {ip: 174.138.62.120}
         fedora42-x64-2: {ip: 104.131.92.208}
         fedora43-x64-1: {ip: 165.227.191.35}
@@ -106,7 +107,6 @@ hosts:
         ubuntu2204_docker-x64-1: {ip: 134.209.55.216}
         ubuntu2204_docker-x64-2: {ip: 159.89.183.200}
         ubuntu2404-x64-1: {ip: 165.227.180.106, swap_file_size_mb: 2048}
-        ubuntu2404-x64-2: {ip: 167.99.124.188, swap_file_size_mb: 2048}
 
     - ibm:
         aix72-ppc64_be-1:
@@ -266,9 +266,9 @@ hosts:
             server_jobs: 32
 
     - rackspace:
-        debian11-x64-1: {ip: 23.253.109.216, swap_file_size_mb: 4096}
         debian12-x64-1: {ip: 104.130.124.194, swap_file_size_mb: 4096}
         ubuntu2404-x64-1: {ip: 119.9.52.75, swap_file_size_mb: 4096, user: ubuntu}
+        ubuntu2404-x64-2: {ip: 104.130.124.245, swap_file_size_mb: 4096, user: ubuntu}
         win2016_vs2015-x64-1: {}
         win2016_vs2015-x64-2: {}
         win2019_vs2019-x64-1: {}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -54,12 +54,12 @@ packages: {
     'autoconf,automake,ca-certificates-mozilla,tar-gnu,gzip,ccache,cmake,coreutils-gnu,gcc12,gcc12-cplusplus,gcc12-cpp,libstdcplusplus6-12-devel,gcc10,gcc10-cplusplus,gcc10-cpp,git,libstdcplusplus6-10-devel,m4-gnu,openssl-devel,python2-setuptools,python3,python3-pip,python39,python39-pip,python39-setuptools,python3.13,python3.13-pip,python3.13-setuptools,sed-gnu,zlib-devel,icu-devel,c-ares-devel,brotli-devel,grep-gnu,pkg-config,xz',
   ],
 
-  debian11: [
-    'gcc-10,g++-10,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-pip',
-  ],
-
   debian12: [
     'systemd-timesyncd,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-venv',
+  ],
+
+  debian13: [
+    'apt-transport-https,ca-certificates,cargo,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,python3-packaging,python3-venv,rustc,sudo,systemd-timesyncd',
   ],
 
   fedora: [
@@ -141,6 +141,6 @@ packages: {
 
   # Default gcc/g++ package is 13.
   ubuntu2404: [
-    'clang-19,gcc,g++,python3,python3-pip,python-is-python3,python3-venv',
+    'cargo-1.82,clang-19,gcc,g++,python3,python3-pip,python-is-python3,python3-venv,rustc-1.82',
   ],
 }

--- a/ansible/roles/bootstrap/tasks/partials/debian13.yml
+++ b/ansible/roles/bootstrap/tasks/partials/debian13.yml
@@ -1,7 +1,7 @@
 ---
 
 #
-# debian 11
+# debian 13
 #
 
 - name: set up swap on Linux

--- a/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     g++ \
     gcc \
     clang-19 \
+    cargo-1.82 \
+    rustc-1.82 \
     git \
     openjdk-21-jre-headless \
     curl \

--- a/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install apt-utils -y && \
       g++ \
       gcc \
       clang-19 \
+      cargo-1.82 \
+      rustc-1.82 \
       git \
       openjdk-21-jre-headless \
       pkg-config \

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -6,8 +6,8 @@
 
 packages: {
   'centos': 'java-11-openjdk-headless',
-  'debian11': 'openjdk-17-jre-headless',
   'debian12': 'openjdk-17-jre-headless',
+  'debian13': 'openjdk-25-jre-headless',
   'fedora42': 'java-21-openjdk-headless',
   'fedora43': 'java-25-openjdk-headless',
   'freebsd': 'openjdk17-jre',

--- a/ansible/roles/jenkins-worker/tasks/partials/tap2junit/debian13.yml
+++ b/ansible/roles/jenkins-worker/tasks/partials/tap2junit/debian13.yml
@@ -1,0 +1,11 @@
+---
+
+#
+# install tap2junit from pip
+#
+
+- name: install tap2junit
+  pip:
+    name: tap2junit=={{ tap2junit_version }}
+    virtualenv: /home/{{ server_user }}/venv
+    virtualenv_command: python3 -m venv

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -43,7 +43,7 @@ if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
       echo "Compiler set to Clang" `${CXX} -dumpversion`
       return
       ;;
-    *debian12*)
+    *debian12*|*debian13*)
       echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
       export CC="ccache clang-19"
       export CXX="ccache clang++-19"
@@ -65,6 +65,8 @@ if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
       return
       ;;
     *ubuntu2404*)
+      export CARGO=cargo-1.82
+      export RUSTC=rustc-1.82
       echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
       export CC="ccache clang-19"
       export CXX="ccache clang++-19"


### PR DESCRIPTION
Install cargo/rustc on Debian 13 and Ubuntu 24.04 machines used for Node.js 26 onwards.

Replace Debian 11 x64 with Debian 13 x64.

Update `select-compiler.sh` to pick clang-19 on Debian 13 and set environment variable for cargo/rustc on Ubuntu 24.04.

Refs: https://github.com/nodejs/build/issues/4245
Refs: https://github.com/nodejs/build/issues/4282