### PR TITLE
ansible: fix existing Java detection edge case

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -50,7 +50,7 @@
 # If we're already using the latest there is no need to do anything.
 - name: check existing adoptopenjdk version is up to date
   set_fact:
-    update_adoptopenjdk: "{{ adoptopenjdk_metadata.json[0].version_data.openjdk_version not in java.stdout }}"
+    update_adoptopenjdk: "{{ java.rc != 0 or adoptopenjdk_metadata.json[0].version_data.openjdk_version not in java.stdout }}"
   when: use_adoptopenjdk == True
 
 - name: create cache directory for adoptopenjdk binaries


### PR DESCRIPTION
Add additional check for whether an existing `java` ran successfully as the original check could erroneously match if the Java version being checked for was in an error message (e.g. part of the directory name included in the message).

---

An example (from playbook runs for https://github.com/nodejs/build/issues/4294):
```
TASK [java-base : Check if java is already installed] ***********************************************************************************************************************************************************
[WARNING]: raw module does not support the environment keyword
fatal: [test-ibm-aix72-ppc64_be-1]: FAILED! => {"changed": false, "msg": "non-zero return code", "rc": 6, "stderr": "Shared connection to 169.54.113.142 closed.\r\n", "stderr_lines": ["Shared connection to 169.54.113.142 closed."], "stdout": "Error: dl failure on line 591\r\nError: failed /opt/jdk-17.0.18+8-jre/lib/server/libjvm.so, because Could not load module /opt/jdk-17.0.18+8-jre/lib/server/libjvm.so.\r\nSystem error: Exec format error\r\n", "stdout_lines": ["Error: dl failure on line 591", "Error: failed /opt/jdk-17.0.18+8-jre/lib/server/libjvm.so, because Could not load module /opt/jdk-17.0.18+8-jre/lib/server/libjvm.so.", "System error: Exec format error"]}
...ignoring
```

The original check was passing because `jdk-17.0.18+8` was in stdout from the failing command.