### PR TITLE
restrict AIX use of clang to 26+ instead of 25+

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -37,11 +37,14 @@ fi
 if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
   case $NODE_NAME in
     *aix*)
-      echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
-      export PATH="/opt/ccache-3.7.4/libexec:/opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/:$PATH"
-      export CC="clang"
-      export CXX="clang++"
-      echo "Compiler set to Clang" `${CXX} -dumpversion`
+      # AIX does not support building v25 with clang so restrict to >25
+      if [ "$NODEJS_MAJOR_VERSION" -ge "26" ]; then
+        echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
+        export PATH="/opt/ccache-3.7.4/libexec:/opt/clang+llvm-20.1.7-powerpc64-ibm-aix-7.2/bin/:$PATH"
+        export CC="clang"
+        export CXX="clang++"
+        echo "Compiler set to Clang" `${CXX} -dumpversion`
+      fi
       return
       ;;
     *fedora*)

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -44,8 +44,8 @@ if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
         export CC="clang"
         export CXX="clang++"
         echo "Compiler set to Clang" `${CXX} -dumpversion`
+        return
       fi
-      return
       ;;
     *fedora*)
       echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"


### PR DESCRIPTION
Draft until tested. Building node 25 with clang results in a build failure after https://github.com/nodejs/build/pull/4286 selected clang for 25+ (like the other platforms) instead of 26+
```
clang++: error: unknown argument '-mno-popcntb'; did you mean '-mno-popcntd'?
clang++: error: unknown argument: '-fno-extern-tls-init'
```
Other option would be to have a separate "if 26 and AIX" section outside the 25+ block but I think this is simpler.