### PR TITLE
ansible: update Java on RHEL machines

### DIFF
--- a/ansible/roles/java-base/tasks/main.yml
+++ b/ansible/roles/java-base/tasks/main.yml
@@ -35,6 +35,20 @@
         name: "{{ java_package_name }}"
         state: present
 
+- name: uninstall previous java
+  when:
+    - previous_java_package_name is defined and previous_java_package_name != ""
+    - not os|startswith("zos")
+    - not os|startswith("macos")
+  notify:
+    - package updated
+    - restart Jenkins
+  package:
+    name: "{{ previous_java_package_name }}"
+    state: "absent"
+    # Package manager mapping in ansible/roles/package-upgrade/vars/main.yml.
+    use: "{{ os|match_key(pm)|default(omit) }}"
+
 # Uses the AdoptOpenJDK API https://github.com/adoptopenjdk/openjdk-api-v3
 # to discover the most recent release for the given adoptopenjdk_version and
 # platform.

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -4,22 +4,29 @@
 # different os'es have different names for java
 #
 
+# When updating Java version, put the old version in the `previous_packages`
+# map below so it can be removed.
 packages: {
-  'centos': 'java-11-openjdk-headless',
   'debian12': 'openjdk-17-jre-headless',
   'debian13': 'openjdk-25-jre-headless',
   'fedora42': 'java-21-openjdk-headless',
   'fedora43': 'java-25-openjdk-headless',
   'freebsd': 'openjdk17-jre',
   'macos': 'temurin17',
-  'rhel7': 'java-11-openjdk',
-  'rhel8': 'java-17-openjdk',
-  'rhel9': 'java-17-openjdk',
+  'rhel8': 'java-21-openjdk-headless',
+  'rhel9': 'java-25-openjdk-headless',
   'smartos': 'openjdk17',
   'ubuntu': 'openjdk-25-jre-headless',
   }
 
+previous_packages: {
+  'rhel8': 'java-17-openjdk-headless',
+  'rhel9': 'java-17-openjdk-headless',
+  'ubuntu': 'openjdk-17-jre-headless',
+  }
+
 java_package_name: "{{ packages[os]|default(packages[os|stripversion])|default(omit) }}"
+previous_java_package_name: "{{ previous_packages[os]|default(previous_packages[os|stripversion])|default(omit) }}"
 
 # Add os_arch combinations here that should install and use AdoptOpenJDK
 # binaries. Override any variables in the dictionary.


### PR DESCRIPTION
Update Java on RHEL 8 machines to Java 21.
Update Java on RHEL 9 machines to Java 25.
Add task to remove old versions of Java.
Remove obsolete entries for centos and rhel7.

Refs: https://github.com/nodejs/build/issues/4304

---

Just the machines (non-containers) for now. Will do the containers separately.

## Deployment

- [x] release-digitalocean-rhel8-x64-1
- [x] release-ibm-rhel8-s390x-1
- [x] release-ibm-rhel8-x64-1
- [x] release-ibm-rhel8-x64-2
- [x] release-osuosl-rhel8-arm64-1
- [x] release-osuosl-rhel8-ppc64_le-1
- [x] release-osuosl-rhel8-ppc64_le-2
- [x] test-digitalocean-rhel8-x64-1
- [x] test-digitalocean-rhel9-x64-1
- [x] test-ibm-rhel8-ppc64_le-1
- [x] test-ibm-rhel8-s390x-1
- [x] test-ibm-rhel8-s390x-2
- [x] test-ibm-rhel8-s390x-3
- [x] test-ibm-rhel8-s390x-4
- [x] test-ibm-rhel8-x64-1
- [x] test-ibm-rhel8-x64-2
- [x] test-ibm-rhel8-x64-3
- [x] test-ibm-rhel9-ppc64_le-1
- [x] test-ibm-rhel9-x64-1
- [x] test-ibm-rhel9-x64-2
- [x] test-linuxonecc-rhel9-s390x-1
- [x] test-linuxonecc-rhel9-s390x-2
- [x] test-linuxonecc-rhel9-s390x-3
- [x] test-linuxonecc-rhel9-s390x-4
- [x] test-osuosl-rhel8-ppc64_le-1
- [x] test-osuosl-rhel8-ppc64_le-2
- [x] test-osuosl-rhel8-ppc64_le-3
- [x] test-osuosl-rhel8-ppc64_le-4
- [x] test-osuosl-rhel8-ppc64_le-5
- [x] test-osuosl-rhel9-ppc64_le-1
- [x] test-osuosl-rhel9-ppc64_le-2
