### PR TITLE
ansible: update gn on Linux ppc64le and s390x

### DIFF
--- a/ansible/roles/gn/tasks/main.yml
+++ b/ansible/roles/gn/tasks/main.yml
@@ -41,7 +41,7 @@
 # Requires a C++17 compiler.
 - name: build gn
   ansible.builtin.shell: |
-    python3 build/gen.py && \
+    python3 build/gen.py --allow-warning && \
     {{ gn_select_compiler }} && \
     {{ gn_dest_dir }}/ninja -C out && \
     out/gn_unittests

--- a/ansible/roles/gn/vars/main.yml
+++ b/ansible/roles/gn/vars/main.yml
@@ -5,7 +5,7 @@ compiler: {
 }
 
 gn_select_compiler: "{{ compiler[os]|default(compiler[os|stripversion])|default('true') }}"
-gn_version: 304bbef6c7e9a86630c12986b99c8654eb7fe648
+gn_version: e2f38fa47b6a6e58e1d427e9d2af246a19cb980c
 
 packages: {
   'rhel8': 'gcc-toolset-12'


### PR DESCRIPTION
Update to a newer version of `gn` for compatibility with more recent versions of V8.

Refs: https://github.com/nodejs/node/pull/62572#issuecomment-4305823842

---

Had been deployed onto all of the Linux ppc64le and s390x machines used to build V8.