### PR TITLE
packer: add multiarch rust support to orka images

### DIFF
--- a/orka/templates/macos-test.pkr.hcl
+++ b/orka/templates/macos-test.pkr.hcl
@@ -259,6 +259,7 @@ build {
       "${local.homebrew_path}/bin/brew install rustup",
       "echo 'Installing Rust ${var.rust_version} toolchain...'",
       "rustup-init -y --no-modify-path --default-toolchain ${var.rust_version} --profile minimal",
+      "rustup target add x86_64-apple-darwin",
       "echo 'export PATH=\"/Users/admin/.cargo/bin:$PATH\"' >> /Users/admin/.zprofile",
       "/Users/admin/.cargo/bin/rustup --version",
       "/Users/admin/.cargo/bin/rustc --version",


### PR DESCRIPTION
Needed to allow https://github.com/nodejs/node/pull/63015 to work as it requires the ability to target x64 for producing the dual binaries in the `macos15-release-pkg` axis of the `iojs+release` job.

This has been tested using [an additional patch on top of that PR](https://github.com/nodejs/node/commit/496831f750732179f2f6b46c07ce6ac5a655c71d) which ran the same command within the build on the dynamic orka node (so isn't permanent and is removed when the machine is deprovisioned).

I don't think there's value in running this to force the installation of the arm64 target too (so x64 could do both) but if anyone disagrees and thinks that should be added we can update it.

@ryanaslett It would be good if we can jump on a call today related to this if you're available. I presume that even though the existing rust stuff is only in the `test` template it still takes effect on the release machines (on the basis that the release ones definitely do have rust!)

