### PR TITLE
jenkins: cleanup version selector script

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -20,47 +20,31 @@ def buildExclusions = [
   // Machine Label,                   Build Type,  Node Version
 
   // Linux -------------------------------------------------
-  [ /debian11/,                       anyType,     gte(23) ],
-  [ /rhel7/,                          anyType,     gte(18) ],
+  [ /debian11/,                       anyType,     gte(24) ],
   [ /rhel8-ppc64le/,                  anyType,     gte(26) ], // Power 8 was dropped in v26
   [ /rhel8-power9le/,                 releaseType, lt(26)  ], // Power 8 was dropped in v26
-  [ /^ubuntu1604-32/,                 anyType,     gte(18) ], // 32-bit linux for <10 only
-  [ /^ubuntu1604-64/,                 anyType,     gte(18) ],
 
   // ARM  --------------------------------------------------
-  [ /^ubuntu1804-arm64/,                             anyType, gte(20) ], // 20.x: gcc8 builds stop
-  [ /^cross-compiler-ubuntu1604-armv[67]-gcc-4.9/,   anyType, gte(18) ],
-  [ /^cross-compiler-ubuntu1604-armv[67]-gcc-6/,     anyType, gte(18) ],
-  [ /^cross-compiler-ubuntu1804-armv7-gcc-6/,        anyType, gte(18) ],
-  [ /^cross-compiler-ubuntu1804-armv7-gcc-8/,        anyType, gte(18) ],
-  [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, gte(20) ],
-  [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/, anyType, lt(20)  ],
-  [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/, anyType, gte(23) ],
-  [ /^cross-compiler-rhel9-armv7-gcc-12-glibc-2.28/, anyType, lt(23)  ],
+  [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, gte(22) ],
+  [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/, anyType, gte(24) ],
+  [ /^cross-compiler-rhel9-armv7-gcc-12-glibc-2.28/, anyType, lt(24)  ],
   [ /armv7/,                                         anyType, gte(24) ],
 
   // Windows -----------------------------------------------
   // https://github.com/nodejs/build/blob/main/doc/windows-visualstudio-supported-versions.md
   // Release Builders - should only match one VS version per Node.js version
-  [ /vs2015/,                         releaseType, gte(18)       ],
-  [ /vs2017/,                         releaseType, gte(18)       ],
-  [ /vs2019-arm64/,                   releaseType, lt(20)        ],
-  [ /vs2019/,                         releaseType, gte(21)       ],
-  [ /vs2022-x86/,                     releaseType, gte(23)       ],
-  [ /vs2022/,                         releaseType, lt(21)        ],
+  [ /vs2017/,                         releaseType, gte(22)       ],
+  [ /vs2019/,                         releaseType, gte(24)       ],
+  [ /vs2022-x86/,                     releaseType, gte(24)       ],
   [ /vs2022(?!_clang)(-\w+)?$/,       releaseType, gte(24)       ],
   [ /vs2022_clang/,                   releaseType, lt(24)        ],
   // VS versions supported to compile Node.js - also matches labels used by test runners
-  [ /vs2015(-\w+)?$/,                 testType,    gte(18)       ],
-  [ /vs2017(-\w+)?$/,                 testType,    gte(18)       ],
-  [ /vs2019(-\w+)?$/,                 testType,    gte(21)       ],
-  [ /vs2022(-\w+)?$/,                 testType,    lt(21)        ],
-  [ /vs2022-x86$/,                    testType,    gte(23)       ], // x86 was dropped on Windows in v23
+  [ /vs2017(-\w+)?$/,                 testType,    gte(22)       ],
+  [ /vs2019(-\w+)?$/,                 testType,    gte(22)       ],
+  [ /vs2022-x86$/,                    testType,    gte(24)       ], // x86 was dropped on Windows in v23
   [ /vs2022(?!_clang)(-\w+)?$/,       testType,    gte(24)       ], // MSVC was dropped on Windows in v24
   [ /vs2022_clang(-\w+)?$/,           testType,    lt(24)        ], // ClangCL support was added in v23
-  [ /COMPILED_BY-\w+-arm64$/,         testType,    lt(20)        ], // run tests on arm64 for >=19
   // VS versions supported to build add-ons
-  [ /vs2015-COMPILED_BY/,             testType,    gte(20)       ],
   [ /vs2017-COMPILED_BY/,             testType,    gte(22)       ],
 
   // AIX ---------------------------------------------------
@@ -71,22 +55,18 @@ def buildExclusions = [
   [ /^smartos22/,                     anyType,     gte(26) ],
 
   // FreeBSD -----------------------------------------------
-  [ /^freebsd12/,                     anyType,     gte(22) ],
   [ /^freebsd13/,                     anyType,     gte(22) ], // https://github.com/nodejs/node/issues/54576
 
   // Shared libs docker containers -------------------------
-  [ /sharedlibs_debug_x64/,           anyType,     gte(18) ],
-  [ /sharedlibs_openssl110/,          anyType,     gte(18) ],
-  [ /sharedlibs_openssl102/,          anyType,     gte(18) ],
+  [ /sharedlibs_debug_x64/,           anyType,     gte(22) ],
+  [ /sharedlibs_openssl110/,          anyType,     gte(22) ],
+  [ /sharedlibs_openssl102/,          anyType,     gte(22) ],
   [ /sharedlibs_openssl35/,           anyType,     lt(24)  ], // Temporary until test fixes are backported
-  [ /sharedlibs_fips20/,              anyType,     gte(18) ],
+  [ /sharedlibs_fips20/,              anyType,     gte(22) ],
 
   // macOS -------------------------------------------------
   [ /^osx13/,                         anyType,     gte(25) ],
   [ /^macos15/,                       anyType,     lt(25)  ],
-
-  // Source / headers / docs -------------------------------
-  [ /^rhel8-release-sources$/,        releaseType, lt(18)  ],
 
   // -------------------------------------------------------
 ]


### PR DESCRIPTION
- Remove labels that are clearly no longer in use
- Update Node versions to reference supported versions
