### PR TITLE
ansible: use adoptium 25 instead of 17

### DIFF
--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -39,5 +39,5 @@ adoptopenjdk: {
 
 adoptopenjdk_arch: "{{ adoptopenjdk[os+'_'+arch].arch | default(ansible_architecture) }}"
 adoptopenjdk_os: "{{ adoptopenjdk[os+'_'+arch].os | default(ansible_system | lower) }}"
-adoptopenjdk_version: "{{ adoptopenjdk[os+'_'+arch].version | default('17') }}"
+adoptopenjdk_version: "{{ adoptopenjdk[os+'_'+arch].version | default('25') }}"
 use_adoptopenjdk: "{{ adoptopenjdk[os+'_'+arch] is defined | bool }}"


### PR DESCRIPTION
Required for the next jenkins update https://github.com/nodejs/build/issues/4304
