### PR TITLE
jenkins: fix vs2019 exclusion

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -34,7 +34,7 @@ def buildExclusions = [
   // https://github.com/nodejs/build/blob/main/doc/windows-visualstudio-supported-versions.md
   // Release Builders - should only match one VS version per Node.js version
   [ /vs2017/,                         releaseType, gte(22)       ],
-  [ /vs2019/,                         releaseType, gte(24)       ],
+  [ /vs2019/,                         releaseType, gte(22)       ],
   [ /vs2022-x86/,                     releaseType, gte(24)       ],
   [ /vs2022(?!_clang)(-\w+)?$/,       releaseType, gte(24)       ],
   [ /vs2022_clang/,                   releaseType, lt(24)        ],


### PR DESCRIPTION
The exclusion for `/vs2019/` was [originally `gte(21)`](https://github.com/nodejs/build/blob/601c84b51fc65bca1fc2c3f4e64097267b8afae3/jenkins/scripts/VersionSelectorScript.groovy#L48) and mistakenly [updated to `gte(24)`](https://github.com/nodejs/build/blob/3f78e25f188f98aceb62bfb018478fb8badded94/jenkins/scripts/VersionSelectorScript.groovy#L37) when it should have been `gte(22)`.

Refs: https://github.com/nodejs/build/pull/4320