### PR TITLE
ansible: bump RHEL rust and llvm versions

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/postinstall/rhel.yml
+++ b/ansible/roles/baselayout/tasks/partials/postinstall/rhel.yml
@@ -51,6 +51,7 @@
       - lld-{{rhel_llvm_version}}
       - lld-libs-{{rhel_llvm_version}}
       - llvm-{{rhel_llvm_version}}
+      - llvm-filesystem-{{rhel_llvm_version}}
       - llvm-libs-{{rhel_llvm_version}}
       - llvm-toolset-{{rhel_llvm_version}}
       - rust-{{rhel_rust_version}}

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -7,9 +7,12 @@
 git_no_binpkg: [ ]
 git_version: 2.10.2
 
-# toolchain versions
-rhel_llvm_version: 19.1.7
-rhel_rust_version: 1.84.1
+# Toolchain versions.
+# If changing the RHEL versions, you may need to run `dnf versionlock clear`
+# before running the playbook to undo previous version locking in
+# ansible\roles\baselayout\tasks\partials\postinstall\rhel.yml.
+rhel_llvm_version: 20.1.8
+rhel_rust_version: 1.88.0
 
 ssh_config: /etc/ssh/sshd_config
 

--- a/ansible/roles/docker/templates/rhel8.Dockerfile.j2
+++ b/ansible/roles/docker/templates/rhel8.Dockerfile.j2
@@ -28,13 +28,13 @@ RUN . /secrets.txt \
       gcc-toolset-12 \
       gcc-toolset-14-libatomic-devel \
       git \
-      java-17-openjdk-headless \
-      llvm-toolset-19.1.7 \
+      java-21-openjdk-headless \
+      llvm-toolset-20.1.8 \
       make \
       python3.12 \
       python3.12-pip \
       procps-ng \
-      rust-toolset-1.84.1 \
+      rust-toolset-1.88.0 \
       xz \
     && dnf clean all \
     && subscription-manager unregister

--- a/ansible/roles/docker/templates/ubi81.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubi81.Dockerfile.j2
@@ -28,14 +28,14 @@ RUN chmod u+x /secrets.txt && . /secrets.txt \
       gcc-toolset-12 \
       gcc-toolset-14-libatomic-devel \
       git \
-      java-17-openjdk-headless \
-      llvm-toolset-19.1.7 \
+      java-21-openjdk-headless \
+      llvm-toolset-20.1.8 \
       make \
       python3.12 \
       python3.12-pip \
       openssl-devel \
       procps-ng \
-      rust-toolset-1.84.1 \
+      rust-toolset-1.88.0 \
     && dnf clean all \
     && subscription-manager unregister
 


### PR DESCRIPTION
Update Rust on RHEL from 1.84 to 1.88.

Refs: https://github.com/nodejs/build/issues/4265

---

## Deployment

- [x] release-digitalocean-rhel8-x64-1
- [x] release-ibm-rhel8-s390x-1
- [x] release-ibm-rhel8-x64-1
- [x] release-ibm-rhel8-x64-2
- [x] release-osuosl-rhel8-arm64-1
- [x] release-osuosl-rhel8-ppc64_le-1
- [x] test-digitalocean-rhel8-x64-1
- [x] test-digitalocean-rhel9-x64-1
- [x] test-ibm-rhel8-ppc64_le-1
- [x] test-ibm-rhel9-ppc64_le-1
- [x] test-ibm-rhel8-s390x-1
- [x] test-ibm-rhel8-s390x-2
- [x] test-ibm-rhel8-s390x-3
- [x] test-ibm-rhel8-s390x-4
- [x] test-ibm-rhel8-x64-1
- [x] test-ibm-rhel8-x64-2
- [x] test-ibm-rhel8-x64-3
- [x] test-ibm-rhel9-x64-1
- [x] test-ibm-rhel9-x64-2
- [x] test-linuxonecc-rhel9-s390x-1
- [x] test-linuxonecc-rhel9-s390x-2
- [x] test-linuxonecc-rhel9-s390x-3
- [x] test-linuxonecc-rhel9-s390x-4
- [x] test-osuosl-rhel8-ppc64_le-1
- [x] test-osuosl-rhel8-ppc64_le-2
- [x] test-osuosl-rhel8-ppc64_le-3
- [x] test-osuosl-rhel8-ppc64_le-4
- [x] test-osuosl-rhel8-ppc64_le-5
- [x] test-osuosl-rhel9-ppc64_le-1
- [x] test-osuosl-rhel9-ppc64_le-2

### containers

- [x] test-azure-ubuntu2404_docker-arm64-1
- [x] test-azure-ubuntu2404_docker-arm64-2
- [x] test-azure-ubuntu2404_docker-arm64-3
- [x] test-osuosl-ubuntu2404_docker-arm64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-2
- [x] test-ibm-ubuntu2204_docker-x64-1