### PR TITLE
jenkins: enable node 26+ (clang) builds on AIX 7.3

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -50,6 +50,7 @@ def buildExclusions = [
   // AIX ---------------------------------------------------
   [ /^aix72-ppc64/,                     anyType,     gte(26) ], // Power 8 was dropped in v26
   [ /^aix72-power9/,                    releaseType, lt(26)  ], // Build releases on Power 9 for >=26
+  [ /^aix73-power9/,                    releaseType, lt(26)  ], // Build releases on Power 9 for >=26
 
   // SmartOS -----------------------------------------------
   [ /^smartos22/,                     anyType,     gte(26) ],


### PR DESCRIPTION
Ref: https://github.com/nodejs/build/issues/4230#issuecomment-4496631570 which is why I don't want to enable this for earlier versions yet.