### PR TITLE
jenkins: fetch refs before test commit rebase

### DIFF
--- a/jenkins/scripts/node-test-commit-pre.sh
+++ b/jenkins/scripts/node-test-commit-pre.sh
@@ -17,6 +17,27 @@ echo $GIT_COMMITTER_NAME
 echo $GIT_AUTHOR_NAME
 
 git rebase --abort || true
+
+# Refresh the refs used below in case the Jenkins checkout left a stale or
+# shallow copy. If REBASE_ONTO is present locally without its parents, rebase
+# can replay almost the entire Node.js history instead of only the PR commits.
+fetch_from_origin() {
+  fetch_args="--no-tags"
+  if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+    fetch_args="${fetch_args} --unshallow"
+  fi
+
+  git fetch ${fetch_args} origin "$@"
+}
+
+if [ -n "${GIT_REMOTE_REF}" ]; then
+  fetch_from_origin "+${GIT_REMOTE_REF}:refs/remotes/origin/_jenkins_local_branch"
+fi
+
+if [ -n "${REBASE_ONTO}" ]; then
+  fetch_from_origin "${REBASE_ONTO}"
+fi
+
 git checkout -f refs/remotes/origin/_jenkins_local_branch
 git config user.name
 git config user.email


### PR DESCRIPTION
Fixes: https://github.com/nodejs/build/issues/4345

Refresh the PR ref and `REBASE_ONTO` in `node-test-commit-pre.sh` before
checking out `_jenkins_local_branch` and running `git rebase`.

When Jenkins has a shallow copy where `REBASE_ONTO` exists locally without
its parents, `git rebase` can treat nearly the entire Node.js history as
commits to replay. That caused failures like:

```console
Rebasing (1/46550)
Auto-merging Makefile
CONFLICT (add/add): Merge conflict in Makefile
```

---

The script now fetches the refs it is about to use and unshallows the repository when needed.

Validation
* `bash -n jenkins/scripts/node-test-commit-pre.sh`
* `git diff --check`
* Reproduced the bad shallow range locally: `before=46899`
* Confirmed the added fetch behavior reduces it to the expected range: `after=1`

---

Assisted-by: openai:gpt-5.5