### PR TITLE
ci(shellcheck): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/shellcheck.yml'
       - '.shellcheckrc'
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.