### PR TITLE
ansible: use gcc-14 to build h2load

### DIFF
--- a/ansible/roles/benchmarking/tasks/main.yml
+++ b/ansible/roles/benchmarking/tasks/main.yml
@@ -29,8 +29,8 @@
   args:
     chdir: "/home/{{ server_user }}/nghttp2"
   environment:
-    CC: gcc-12
-    CXX: g++-12
+    CC: gcc-14
+    CXX: g++-14
 
 - name: Download wrk git repo
   git:

--- a/ansible/roles/benchmarking/vars/main.yml
+++ b/ansible/roles/benchmarking/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 packages:
-  - g++-12
+  - g++-14
   - libc-ares-dev
   - libcunit1-dev
   - libev-dev


### PR DESCRIPTION
h2load now uses `print` which is a C++23 header that is not available in gcc 12.

---

Error is hard to spot in the Ansible output, but reformatted it is:
```
app_helper.cc:53:10: fatal error: print: No such file or directory
   53 | #include <print>
      |          ^~~~~~~
compilation terminated.
```

It is a result of https://github.com/nghttp2/nghttp2/pull/2747.

To run the playbook (the original goal was to update Java on the benchmark machines) to completion I've had to temporarily comment out running the `static-analysis` role from the playbook (not committed here) as we're currently affected by a [Coverity outage](https://redirect.github.com/nodejs/build/issues/4287#issuecomment-4623507695).