### PR TITLE
ansible: update Java for arm Dockerfiles

### DIFF
--- a/ansible/roles/docker/templates/debian13_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/debian13_armv7l.Dockerfile.j2
@@ -1,11 +1,11 @@
-FROM arm32v7/debian:11
+FROM arm32v7/debian:13
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
 ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
 ENV SHELL /bin/bash
 ENV HOME /home/{{ server_user }}
-ENV PATH /usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH /home/{{ server_user }}/venv/bin:/usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
 ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
 ENV OSTYPE linux-gnu
@@ -16,20 +16,22 @@ ENV ARCH {{ arch }}
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
       curl \
-      g++-10 \
-      gcc-10 \
+      g++ \
+      gcc \
       git \
       libfontconfig1 \
-      openjdk-17-jre-headless \
+      openjdk-25-jre-headless \
       pkg-config \
       procps \
       python3-pip \
+      python3-venv \
       xz-utils
 
 # Prevent Node.js picking up the OS's openssl.cnf, https://github.com/nodejs/node/issues/27862
 ENV OPENSSL_CONF /dev/null
 
-RUN pip3 install tap2junit=={{ tap2junit_version }}
+RUN python3 -m venv /home/{{ server_user }}/venv \
+  && /home/{{ server_user }}/venv/bin/pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/debian13_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/debian13_armv7l.Dockerfile.j2
@@ -5,7 +5,7 @@ ENV USER {{ server_user }}
 ENV JOBS {{ server_jobs | default(ansible_processor_vcpus) }}
 ENV SHELL /bin/bash
 ENV HOME /home/{{ server_user }}
-ENV PATH /home/{{ server_user }}/venv/bin:/usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH /usr/local/venv/bin:/usr/lib/ccache/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV NODE_COMMON_PIPE /home/{{ server_user }}/test.pipe
 ENV NODE_TEST_DIR /home/{{ server_user }}/tmp
 ENV OSTYPE linux-gnu
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
 # Prevent Node.js picking up the OS's openssl.cnf, https://github.com/nodejs/node/issues/27862
 ENV OPENSSL_CONF /dev/null
 
-RUN python3 -m venv /home/{{ server_user }}/venv \
-  && /home/{{ server_user }}/venv/bin/pip3 install tap2junit=={{ tap2junit_version }}
+RUN python3 -m venv /usr/local/venv \
+  && /usr/local/venv/bin/pip3 install tap2junit=={{ tap2junit_version }}
 
 RUN addgroup --gid {{ server_user_gid.stdout_lines[0] }} {{ server_user }}
 

--- a/ansible/roles/docker/templates/ubuntu2204.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204.Dockerfile.j2
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     g++-12 \
     gcc-12 \
     git \
-    openjdk-17-jre-headless \
+    openjdk-25-jre-headless \
     curl \
     python3-pip \
     python-is-python3 \

--- a/ansible/roles/docker/templates/ubuntu2204_armv7l.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_armv7l.Dockerfile.j2
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y ccache \
       g++-12 \
       gcc-12 \
       git \
-      openjdk-17-jre-headless \
+      openjdk-25-jre-headless \
       pkg-config \
       curl \
       python3-pip \

--- a/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2204_sharedlibs.Dockerfile.j2
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install apt-utils -y && \
       g++-12 \
       gcc-12 \
       git \
-      openjdk-17-jre-headless \
+      openjdk-25-jre-headless \
       pkg-config \
       curl \
       python3-pip \


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4304

---

Debian 11 armv7 containers are updated to Debian 13.
- No OS-provided Java packages for Java >17.
- [Temurin (Adoptium) doesn't provide 32-bit arm packages for Java >17](https://github.com/adoptium/adoptium-support/issues/962).
- Not keen on sourcing Java binaries from elsewhere.
- [Debian 11 reaches end of LTS support in August 2026](https://www.debian.org/releases/).

## Deployment

- [x] test-azure-ubuntu2404_docker-arm64-1
- [x] test-azure-ubuntu2404_docker-arm64-2
- [x] test-azure-ubuntu2404_docker-arm64-3
- [x] test-osuosl-ubuntu2404_docker-arm64-1