### PR TITLE
ibmi: update java path for Java 21

### DIFF
--- a/ansible/roles/jenkins-worker/vars/main.yml
+++ b/ansible/roles/jenkins-worker/vars/main.yml
@@ -61,7 +61,7 @@ jenkins: "{{ jenkins_init[init_type] }}"
 
 # some os'es needs different paths to java. add them here.
 java_path: {
-  'ibmi74': '/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit/bin/java',
+  'ibmi74': '/QOpenSys/QIBM/ProdData/JavaVM/jdk21/64bit/bin/java',
   'macos10.15': 'java',
   'macos11': 'java',
   'macos11.0': 'java',


### PR DESCRIPTION
We've installed Java 21 on the iinthecloud machines we now need to update the Java path.

Part of: https://github.com/nodejs/build/issues/4304