### PR TITLE
ansible: update Java on Debian 12 machines

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/repo/debian12.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian12.yml
@@ -1,0 +1,58 @@
+---
+
+# Debian 12
+
+- name: install prereqs for deb822_repository task
+  ansible.builtin.apt:
+    name: python3-debian
+    state: present
+
+# Signed-by key should match contents of:
+# curl -sL https://packages.adoptium.net/artifactory/api/gpg/key/public
+- name: enable Adoptium repository
+  ansible.builtin.deb822_repository:
+    architectures: amd64
+    components: main
+    enabled: true
+    name: adoptium
+    signed_by: |-
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      
+      mQENBGGTvTQBCAC6ey144n7CG8foafF6mwgIBN1fIm1ILZDuGS4tMr0/XI8pgJnT
+      QvsPxZWEvtSm7bEMObzEoZJcXwjBcJl1B0ui8k5kHMTI75gCmZPsoKLFWIEpuRBQ
+      PBocusw80apDmLnNDQLVQvDFtEua5gaNa/fRw9YsmBoXBqvgrjFUIdGyWoQvH5+a
+      9OYlWD9n5VV0gnVMb+aclwVzB/zJw3kHGSgzuMtlAHeQiah7Y8yomQn/UIX8yqDf
+      +11sP3+c87YcjkRqImRTtmKEDcEtGPAIXC6SYA+uEEkbYE0Fy0chkvtnVWJ597fa
+      Epai4rnICU8zoJ6X5z3v1aM2WerhX9oq9X8PABEBAAG0QEFkb3B0aXVtIEdQRyBL
+      ZXkgKERFQi9SUE0gU2lnbmluZyBLZXkpIDx0ZW11cmluLWRldkBlY2xpcHNlLm9y
+      Zz6JAVIEEwEIADwWIQQ7BNdTyQUNml00PzmEPEilZfjwSwUCYZO9NAIbAwULCQgH
+      AgMiAgEGFQoJCAsCBBYCAwECHgcCF4AACgkQhDxIpWX48Et4AggAjjJzYWuKV3nG
+      7ngInngl8G/m9JoHr7BmwgcQXYhdy5hVkMcUx5JLeXz2LMBUH/F2nD595hgjMabk
+      kVib20X8lq9RsNbdfc2hBcWU6qyHKxsIqT4boI2/XDyEzzMyyZWWNGo/27Ci7Xmj
+      pWu31nh0pDdPqdyWDIKojbVVnxlCRY8as8Sm+1ufi709KCi4MuwHNsUlCSwb/fju
+      NKeHkrHbLcHKUUIEcmTSKRWrpMYBzm1HYOGBz4xPuELwUfUp71ehfoyBZlp6RDRf
+      l5TYI1FmCyHuvjNhrJgWv7bOTcf8yObGY+TEUhzc4xQqCrF4ur9d3opvsuPBQsv+
+      Klqi5KSZgrkBDQRhk700AQgAq14okly8cFrpYVenEQPiB75AUZfKRpMduiR6IxAj
+      SKcH7aSoFZ9AubUEBVpZsyT5svxoEPe1i4TdbF+m9FGy42EcOlLa3ArLTj5H8FRl
+      UdGZB9I5mk4GptOzPM+aHMMu92vW/ZwjuS8DvOiQSp+cUmG1EqOMJSM7e/4BM71z
+      E+OKaVJCj79pEzhG3SK/IC/OlxxyETT66NSfYJd7Sw5R6Vr19am/uNU690W0CJ+q
+      VQeFpmDMr7LnfdFRIh+lJe05+PvWXeidkGjox5cbG52wf8aRIR/FgkfcFvqRMN1f
+      B+dVOWueloUeVAnzcUznOKmUEs7LP9ObJhYHHgup4IAU2wARAQABiQE2BBgBCAAg
+      FiEEOwTXU8kFDZpdND85hDxIpWX48EsFAmGTvTQCGwwACgkQhDxIpWX48EvXHQf/
+      Q0nZsGDXnZHiBoojeSdpkO7WBjMIP3w1GdLvRpPQrS8TfOPbZuoevzCNh38Y3gwF
+      yelJspvzDQrBXhgkzAGlucYg8Y7KHa5Ebm7iDgMzc37L1hYSZTYCqwd7aowfgy34
+      hOk3B67LffkJpIh738Oa9CtlwxQ9xcytmBmQ1fBBOwm/9IhAwHPQuydYIs4DxWbj
+      0MGSP4fDntU7e4UjsHNmhudDcYol0FaqdHHIIB9C/G4CzetRwHFOn3b4JwXMU7YU
+      6aJA3mXhi3hggMC3wkT2HHZ/TquuOdNc02fypWOCDOHz0alBBJNqoVUNFNqU3tfJ
+      wI4qF/KKq9BfyfucAs0ykA==
+      =szki
+      -----END PGP PUBLIC KEY BLOCK-----
+    suites: bookworm
+    types: deb
+    uris: https://packages.adoptium.net/artifactory/deb
+  register: adoptium_repo_install_result
+
+- name: update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+  when: adoptium_repo_install_result.changed

--- a/ansible/roles/java-base/vars/main.yml
+++ b/ansible/roles/java-base/vars/main.yml
@@ -7,7 +7,7 @@
 # When updating Java version, put the old version in the `previous_packages`
 # map below so it can be removed.
 packages: {
-  'debian12': 'openjdk-17-jre-headless',
+  'debian12': 'temurin-25-jre',
   'debian13': 'openjdk-25-jre-headless',
   'fedora42': 'java-21-openjdk-headless',
   'fedora43': 'java-25-openjdk-headless',
@@ -20,6 +20,7 @@ packages: {
   }
 
 previous_packages: {
+  'debian12': 'openjdk-17-jre-headless',
   'rhel8': 'java-17-openjdk-headless',
   'rhel9': 'java-17-openjdk-headless',
   'ubuntu': 'openjdk-17-jre-headless',


### PR DESCRIPTION
Update to Temurin 25 JRE from Adoptium as Jenkins LTS has dropped support for Java 17.

Refs: https://github.com/nodejs/build/issues/4304

---

## Deployment

- [x] [test-digitalocean-debian12-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Ddebian12%2Dx64%2D1/)
- [x] [test-ibm-debian12-x64-1](https://ci.nodejs.org/computer/test%2Dibm%2Ddebian12%2Dx64%2D1/)
- [x] [test-rackspace-debian12-x64-1](https://ci.nodejs.org/computer/test%2Drackspace%2Ddebian12%2Dx64%2D1/)