### PR TITLE
ansible: update Alpine to 3.23 and 3.24

### DIFF
--- a/ansible/roles/docker/templates/alpine323.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine323.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.23
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
@@ -22,7 +22,7 @@ RUN apk add --no-cache --virtual .build-deps \
         binutils-gold \
         cargo \
         curl \
-        clang \
+        clang21 \
         g++ \
         gcc \
         gnupg \
@@ -33,7 +33,7 @@ RUN apk add --no-cache --virtual .build-deps \
         rust \
         tar \
         ccache \
-        openjdk21 \
+        openjdk25 \
         git \
         procps-ng \
         openssh-client-default \

--- a/ansible/roles/docker/templates/alpine324.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine324.Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.24
 
 ENV LC_ALL C
 ENV USER {{ server_user }}
@@ -22,7 +22,7 @@ RUN apk add --no-cache --virtual .build-deps \
         binutils-gold \
         cargo \
         curl \
-        clang19 \
+        clang21 \
         g++ \
         gcc \
         gnupg \
@@ -33,7 +33,7 @@ RUN apk add --no-cache --virtual .build-deps \
         rust \
         tar \
         ccache \
-        openjdk21 \
+        openjdk25 \
         git \
         procps-ng \
         openssh-client-default \

--- a/ansible/roles/docker/templates/alpine324.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine324.Dockerfile.j2
@@ -22,7 +22,7 @@ RUN apk add --no-cache --virtual .build-deps \
         binutils-gold \
         cargo \
         curl \
-        clang21 \
+        clang22 \
         g++ \
         gcc \
         gnupg \


### PR DESCRIPTION
They are already the versions used by the official Docker images.
