### PR TITLE
ansible: remove ubuntu2204 hetzner machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -150,14 +150,6 @@ hosts:
         ubuntu2204_docker-x64-1: {ip: 52.117.26.9}
 
     - hetzner:
-        ubuntu2204-x64-1:
-            ip: 37.27.104.214
-            build_test_v8: yes
-            is_benchmark: true
-        ubuntu2204-x64-2:
-            ip: 37.27.104.215
-            build_test_v8: yes
-            is_benchmark: true
         ubuntu2404-x64-1:
             ip: 135.181.228.157
             build_test_v8: yes


### PR DESCRIPTION
## Summary

- Removes `test-hetzner-ubuntu2204-x64-1` (37.27.104.214) and `test-hetzner-ubuntu2204-x64-2` (37.27.104.215) from `ansible/inventory.yml`
- The two Hetzner ubuntu2404 machines in the same provider block are unaffected
- No `host_vars`, `group_vars`, or other references to these specific hosts exist in the repo

## Test plan

- [x] Confirm the diff removes only the two `ubuntu2204` hetzner entries from `ansible/inventory.yml`
- [x] Confirm ubuntu2404 hetzner machines and all other providers are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)