### PR TITLE
jenkins: adjust OpenSSL exclusions

### DIFF
--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -58,7 +58,8 @@ def buildExclusions = [
   [ /sharedlibs_debug_x64/,           anyType,     gte(22) ],
   [ /sharedlibs_openssl110/,          anyType,     gte(22) ],
   [ /sharedlibs_openssl102/,          anyType,     gte(22) ],
-  [ /sharedlibs_openssl35/,           anyType,     lt(24)  ], // Temporary until test fixes are backported
+  [ /sharedlibs_openssl35/,           anyType,     lt(22)  ],
+  [ /sharedlibs_openssl40/,           anyType,     lt(24)  ],
   [ /sharedlibs_fips20/,              anyType,     gte(22) ],
 
   // macOS -------------------------------------------------


### PR DESCRIPTION
Run `sharedlibs_openssl35` on Node.js 22 (test fixes were backported some time ago).
Add `sharedlibs_openssl40`, excluded for now on Node.js 22 (doesn't compile).

Refs: https://github.com/nodejs/build/pull/4364
Refs: https://github.com/nodejs/TSC/issues/1869