### PR TITLE
jenkins,win: remove buildpulse support

### DIFF
--- a/jenkins/scripts/windows/test.cmd
+++ b/jenkins/scripts/windows/test.cmd
@@ -22,16 +22,16 @@ if exist test.tap (
   tap2junit -i test.tap -o js-tests.junit.xml
   if errorlevel 1 exit /b
 )
-if exist js-tests.junit.xml (
-  call %~dp0buildpulse.cmd js-tests.junit.xml
-)
+@REM if exist js-tests.junit.xml (
+@REM   call %~dp0buildpulse.cmd js-tests.junit.xml
+@REM )
 if exist cctest.tap (
   tap2junit -i cctest.tap -o cctest.junit.xml
   if errorlevel 1 exit /b
 )
-if exist cctest.junit.xml (
-  call %~dp0buildpulse.cmd cctest.junit.xml
-)
+@REM if exist cctest.junit.xml (
+@REM   call %~dp0buildpulse.cmd cctest.junit.xml
+@REM )
 
 :: The JUnit Plugin only marks the job as Unstable when it finds any kind of failure, including flaky tests.
 :: We need to use the return code of vcbuild.bat to fail the job when there are real failures.


### PR DESCRIPTION
This is a housekeeping PR. I've just noticed that we're still sending data to BuildPulse, even though we don't use it. While only a few machines are sending data to it, it is still unnecessary, so this PR effectively reverts https://github.com/nodejs/build/pull/3653, but leaves the script for communicating with BuildPulse.

Fixes: https://github.com/nodejs/build/issues/3575