### PR TITLE
ansible: update cargo/rust on Debian 13

### DIFF
--- a/ansible/roles/baselayout/tasks/partials/postinstall/debian13.yml
+++ b/ansible/roles/baselayout/tasks/partials/postinstall/debian13.yml
@@ -1,0 +1,10 @@
+---
+
+# Debian 13
+
+- name: install packages from backports
+  ansible.builtin.apt:
+    autoremove: true
+    default_release: trixie-backports
+    name: cargo, rustc
+    state: latest

--- a/ansible/roles/baselayout/tasks/partials/repo/debian13.yml
+++ b/ansible/roles/baselayout/tasks/partials/repo/debian13.yml
@@ -1,0 +1,25 @@
+---
+
+# Debian 13
+
+- name: install prereqs for deb822_repository task
+  ansible.builtin.apt:
+    name: python3-debian
+    state: present
+
+- name: enable debian_backports repository
+  ansible.builtin.deb822_repository:
+    architectures: amd64
+    components: main
+    enabled: true
+    name: debian-backports
+    signed_by: /usr/share/keyrings/debian-archive-keyring.gpg
+    suites: trixie-backports
+    types: deb
+    uris: http://deb.debian.org/debian
+  register: debian_backports_repo_install_result
+
+- name: update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+  when: debian_backports_repo_install_result.changed

--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -61,8 +61,9 @@ packages: {
     'systemd-timesyncd,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,apt-transport-https,ca-certificates,sudo,python3-venv',
   ],
 
+  # cargo and rustc are installed from debian backports, see ansible/roles/baselayout/tasks/partials/postinstall/debian13.yml
   debian13: [
-    'apt-transport-https,ca-certificates,cargo,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,python3-packaging,python3-venv,rustc,sudo,systemd-timesyncd',
+    'apt-transport-https,ca-certificates,clang-19,gcc,g++,make,ccache,git,curl,libfontconfig1,python3-packaging,python3-venv,sudo,systemd-timesyncd',
   ],
 
   fedora: [


### PR DESCRIPTION
Use Debian backports to install newer versions of cargo and rustc on Debian 13.

Refs: https://github.com/nodejs/build/issues/4265

---

This is an attempt to port the instructions from https://backports.debian.org/Instructions/ to Ansible.

## Deployment

- [x] [test-digitalocean-debian13-x64-1](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Ddebian13%2Dx64%2D1/)
- [x] [test-digitalocean-debian13-x64-2](https://ci.nodejs.org/computer/test%2Ddigitalocean%2Ddebian13%2Dx64%2D2/)
