### PR TITLE
ansible: update cargo/rustc on Ubuntu 24.04

### DIFF
--- a/ansible/roles/baselayout/vars/main.yml
+++ b/ansible/roles/baselayout/vars/main.yml
@@ -141,6 +141,6 @@ packages: {
 
   # Default gcc/g++ package is 13.
   ubuntu2404: [
-    'cargo-1.82,clang-19,gcc,g++,python3,python3-pip,python-is-python3,python3-venv,rustc-1.82',
+    'cargo-1.89,clang-19,gcc,g++,python3,python3-pip,python-is-python3,python3-venv,rustc-1.89',
   ],
 }

--- a/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     clang-19 \
     cargo-1.82 \
     rustc-1.82 \
+    cargo-1.89 \
+    rustc-1.89 \
     git \
     openjdk-21-jre-headless \
     curl \

--- a/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install apt-utils -y && \
       clang-19 \
       cargo-1.82 \
       rustc-1.82 \
+      cargo-1.89 \
+      rustc-1.89 \
       git \
       openjdk-21-jre-headless \
       pkg-config \

--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -76,8 +76,8 @@ if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
       return
       ;;
     *ubuntu2404*)
-      export CARGO=cargo-1.82
-      export RUSTC=rustc-1.82
+      export CARGO=cargo-1.89
+      export RUSTC=rustc-1.89
       echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
       export CC="ccache clang-19"
       export CXX="ccache clang++-19"


### PR DESCRIPTION
Refs: https://github.com/nodejs/build/issues/4265

---

### Deployment

- [x] test-azure-ubuntu2404_docker-arm64-1
- [x] test-azure-ubuntu2404_docker-arm64-2
- [x] test-azure-ubuntu2404_docker-arm64-3
- [x] test-digitalocean-ubuntu2204_docker-x64-1
- [x] test-digitalocean-ubuntu2204_docker-x64-2
- [x] test-digitalocean-ubuntu2404-x64-1
- [x] test-hetzner-ubuntu2404-x64-1
- [x] test-hetzner-ubuntu2404-x64-2
- [x] test-ibm-ubuntu2204_docker-x64-1
- [x] test-ibm-ubuntu2404-x64-1
- [x] test-osuosl-ubuntu2404_docker-arm64-1
- [x] test-rackspace-ubuntu2404-x64-1
- [x] test-rackspace-ubuntu2404-x64-2