### PR TITLE
ansible: remove old cargo/rust version

### DIFF
--- a/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404.Dockerfile.j2
@@ -19,8 +19,6 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
     g++ \
     gcc \
     clang-19 \
-    cargo-1.82 \
-    rustc-1.82 \
     cargo-1.89 \
     rustc-1.89 \
     git \

--- a/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
+++ b/ansible/roles/docker/templates/ubuntu2404_sharedlibs.Dockerfile.j2
@@ -20,8 +20,6 @@ RUN apt-get update && apt-get install apt-utils -y && \
       g++ \
       gcc \
       clang-19 \
-      cargo-1.82 \
-      rustc-1.82 \
       cargo-1.89 \
       rustc-1.89 \
       git \


### PR DESCRIPTION
Remove now unused cargo/rust 1.82 from Ubuntu 24.04 containers.

Refs: https://github.com/nodejs/build/pull/4393#discussion_r3521073517

---

This is a tidy up PR. I may not even deploy this now and wait until the next time we update these containers.