### PR TITLE
ansible: update IP address for release MNX machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -55,7 +55,7 @@ hosts:
         zos24-s390x-1: {ip: 148.100.36.157, user: unix1}
 
     - mnx:
-        ubuntu2404_docker-x64-1: {ip: 8.225.232.80}
+        ubuntu2404_docker-x64-1: {ip: 192.207.255.99}
 
     - osuosl:
         aix72-ppc64_be-1:


### PR DESCRIPTION
MNX IP appears to have been updated as per https://github.com/nodejs/build/issues/4411.
This brings it into sync with the new correct value.