### PR TITLE
ansible: add ibm cloud docker host for alpine containers

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -47,6 +47,7 @@ hosts:
         rhel8-s390x-1: {ip: 148.100.84.45, swap_file_size_mb: 2048, user: linux1}
         rhel8-x64-1: {ip: 169.62.77.228}
         rhel8-x64-2: {ip: 52.117.26.5}
+        ubuntu2404_docker-x64-1: {ip: 169.62.77.227}
 
     - iinthecloud:
         ibmi73-ppc64_be-1: {ip: 65.183.160.62, user: nodejs}


### PR DESCRIPTION
Add release machine which will host Alpine 3.23 container as per decisions in https://github.com/nodejs/node/issues/62764
Secrets change with the container details is in https://github.com/nodejs-private/secrets/pull/409
