### PR TITLE
Add `xz` to alpine containers which is required by release machines

### DIFF
--- a/ansible/roles/docker/templates/alpine323.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine323.Dockerfile.j2
@@ -41,7 +41,8 @@ RUN apk add --no-cache --virtual .build-deps \
         bash \
         automake \
         libtool \
-        autoconf
+        autoconf \
+        xz
 
 RUN python3 -m venv /usr/local/venv
 RUN pip3 install tap2junit=={{ tap2junit_version }}

--- a/ansible/roles/docker/templates/alpine324.Dockerfile.j2
+++ b/ansible/roles/docker/templates/alpine324.Dockerfile.j2
@@ -41,7 +41,8 @@ RUN apk add --no-cache --virtual .build-deps \
         bash \
         automake \
         libtool \
-        autoconf
+        autoconf \
+        xz
 
 RUN python3 -m venv /usr/local/venv
 RUN pip3 install tap2junit=={{ tap2junit_version }}


### PR DESCRIPTION
There seems to be no particular ordering here so I'm putting it at the end. the other potential place would be next to `tar`.