### PR TITLE
ansible: add alpine/musl builds to expected assets

### DIFF
--- a/ansible/www-standalone/tools/promote/expected_assets/v22.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v22.x
@@ -18,8 +18,6 @@ node-{VERSION}-linux-s390x.tar.gz
 node-{VERSION}-linux-s390x.tar.xz
 node-{VERSION}-linux-x64.tar.gz
 node-{VERSION}-linux-x64.tar.xz
-node-{VERSION}-linux-x64-musl.tar.gz
-node-{VERSION}-linux-x64-musl.tar.xz
 node-{VERSION}.pkg
 node-{VERSION}.tar.gz
 node-{VERSION}.tar.xz

--- a/ansible/www-standalone/tools/promote/expected_assets/v22.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v22.x
@@ -18,6 +18,8 @@ node-{VERSION}-linux-s390x.tar.gz
 node-{VERSION}-linux-s390x.tar.xz
 node-{VERSION}-linux-x64.tar.gz
 node-{VERSION}-linux-x64.tar.xz
+node-{VERSION}-linux-x64-musl.tar.gz
+node-{VERSION}-linux-x64-musl.tar.xz
 node-{VERSION}.pkg
 node-{VERSION}.tar.gz
 node-{VERSION}.tar.xz

--- a/ansible/www-standalone/tools/promote/expected_assets/v24.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v24.x
@@ -17,6 +17,8 @@ node-{VERSION}-linux-s390x.tar.gz
 node-{VERSION}-linux-s390x.tar.xz
 node-{VERSION}-linux-x64.tar.gz
 node-{VERSION}-linux-x64.tar.xz
+node-{VERSION}-linux-x64-musl.tar.gz
+node-{VERSION}-linux-x64-musl.tar.xz
 node-{VERSION}.pkg
 node-{VERSION}.tar.gz
 node-{VERSION}.tar.xz

--- a/ansible/www-standalone/tools/promote/expected_assets/v26.x
+++ b/ansible/www-standalone/tools/promote/expected_assets/v26.x
@@ -18,6 +18,8 @@ node-{VERSION}-linux-s390x.tar.gz
 node-{VERSION}-linux-s390x.tar.xz
 node-{VERSION}-linux-x64.tar.gz
 node-{VERSION}-linux-x64.tar.xz
+node-{VERSION}-linux-x64-musl.tar.gz
+node-{VERSION}-linux-x64-musl.tar.xz
 node-{VERSION}.pkg
 node-{VERSION}.tar.gz
 node-{VERSION}.tar.xz

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -24,6 +24,9 @@ def buildExclusions = [
   [ /rhel8-ppc64le/,                  anyType,     gte(26) ], // Power 8 was dropped in v26
   [ /rhel8-power9le/,                 releaseType, lt(26)  ], // Power 8 was dropped in v26
 
+  // Alpine/musl -------------------------------------------
+  [ /alpine-x64/,                     releaseType, le(22)  ], // Only release on v24+ for now pending test changes
+
   // ARM  --------------------------------------------------
   [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, gte(22) ],
   [ /^cross-compiler-rhel8-armv7-gcc-10-glibc-2.28/, anyType, gte(24) ],

--- a/jenkins/scripts/VersionSelectorScript.groovy
+++ b/jenkins/scripts/VersionSelectorScript.groovy
@@ -25,7 +25,7 @@ def buildExclusions = [
   [ /rhel8-power9le/,                 releaseType, lt(26)  ], // Power 8 was dropped in v26
 
   // Alpine/musl -------------------------------------------
-  [ /alpine-x64/,                     releaseType, le(22)  ], // Only release on v24+ for now pending test changes
+  [ /alpine-x64/,                     releaseType, lt(24)  ], // Only release on v24+ for now pending test changes
 
   // ARM  --------------------------------------------------
   [ /^cross-compiler-rhel8-armv7-gcc-8-glibc-2.28/,  anyType, gte(22) ],


### PR DESCRIPTION
Part of the process for adding Alpine into the release builds.
Does the merging of this have to be explicitly co-ordinated with the addition to `iojs+release`?