### PR TITLE
Add RISC-V support to select-compiler.sh

### DIFF
--- a/jenkins/scripts/select-compiler.sh
+++ b/jenkins/scripts/select-compiler.sh
@@ -24,6 +24,7 @@ if [ "$DONTSELECT_COMPILER" != "DONT" ]; then
     *arm64* ) SELECT_ARCH=ARM64 ;;
     *armv7l* ) SELECT_ARCH=ARMV7L ;;
     *ibmi74* ) SELECT_ARCH=IBMI74 ;;
+    *riscv64* ) SELECT_ARCH=RISCV64 ;;
   esac
 fi
 
@@ -36,6 +37,13 @@ fi
 # Gradual transition to Clang from Node.js 25 (https://github.com/nodejs/build/issues/4091).
 if [ "$NODEJS_MAJOR_VERSION" -ge "25" ]; then
   case $NODE_NAME in
+    *riscv64*)
+        echo "Using Clang for Node.js $NODEJS_MAJOR_VERSION"
+        export CC="ccache clang-21"
+        export CXX="ccache clang++-21"
+        echo "Compiler set to Clang" `${CXX} -dumpversion`
+        return
+      ;;
     *aix*)
       # AIX does not support building v25 with clang so restrict to >25
       if [ "$NODEJS_MAJOR_VERSION" -ge "26" ]; then


### PR DESCRIPTION
I've put this new section at the top with an architecture-specific clause for now so it would override any of the defaults for Debian/Ubuntu in the future however since I've now removed most of of the RISC-V magic bits into https://github.com/nodejs/node/pull/65708 this could potentially be changed. We'll likely revisit when we're able to get some production machines into the CI anyway ... At the moment some of the systems have multiple versions of clang available so I'm locking this to 21 which is available on all of them (and not locking RUST as the version in each environment varies)

The systems I have for now are running `bianbu` or `armbian` distributions so I could make the switch statement `*armbian*|*bianbu*)` but I'd prefer to keep it like this for now to give me some flexibility while this is still in flux. If anyone strongly disagrees in the reviews I'll revisit.

Also noting that while we can build v24/v22 in RISC-V with gcc I'm only making changes for the v25+ clang sections for now.
